### PR TITLE
fix(menubar): position tray panel inside work area on Windows (#7)

### DIFF
--- a/menubar-tauri/src-tauri/src/codex.rs
+++ b/menubar-tauri/src-tauri/src/codex.rs
@@ -1,0 +1,462 @@
+//! Codex / ChatGPT integration: types, JWT decoding, and Tauri commands for
+//! account info, session stats, and rate limits.
+
+use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine as _};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CodexData {
+    pub connected: bool,
+    #[serde(rename = "planType")]
+    pub plan_type: Option<String>,
+    #[serde(rename = "accountId")]
+    pub account_id: Option<String>,
+    #[serde(rename = "subscriptionUntil")]
+    pub subscription_until: Option<String>,
+    pub email: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CodexStats {
+    #[serde(rename = "totalSessions")]
+    pub total_sessions: u32,
+    #[serde(rename = "todaySessions")]
+    pub today_sessions: u32,
+    #[serde(rename = "lastActivity")]
+    pub last_activity: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CodexRateLimitWindow {
+    #[serde(rename = "usedPercent")]
+    pub used_percent: f64,
+    #[serde(rename = "windowMinutes")]
+    pub window_minutes: Option<i64>,
+    #[serde(rename = "resetsAt")]
+    pub resets_at: Option<i64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CodexCredits {
+    #[serde(rename = "hasCredits")]
+    pub has_credits: bool,
+    pub unlimited: bool,
+    pub balance: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CodexRateLimits {
+    pub connected: bool,
+    #[serde(rename = "planType")]
+    pub plan_type: Option<String>,
+    pub primary: Option<CodexRateLimitWindow>,
+    pub secondary: Option<CodexRateLimitWindow>,
+    pub credits: Option<CodexCredits>,
+    pub error: Option<String>,
+}
+
+fn get_codex_home() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".codex"))
+}
+
+// Decode a JWT payload without verification (used to read ChatGPT account
+// metadata from a locally stored token).
+fn decode_jwt_payload(token: &str) -> Option<serde_json::Value> {
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+
+    let payload = parts[1];
+    let padded = match payload.len() % 4 {
+        2 => format!("{}==", payload),
+        3 => format!("{}=", payload),
+        _ => payload.to_string(),
+    };
+
+    let standard = padded.replace('-', "+").replace('_', "/");
+
+    STANDARD_NO_PAD
+        .decode(&standard)
+        .ok()
+        .or_else(|| base64::engine::general_purpose::STANDARD.decode(&standard).ok())
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .and_then(|json| serde_json::from_str(&json).ok())
+}
+
+#[tauri::command]
+pub async fn get_codex_info() -> Result<CodexData, String> {
+    let codex_home = match get_codex_home() {
+        Some(path) => path,
+        None => {
+            return Ok(CodexData {
+                connected: false,
+                plan_type: None,
+                account_id: None,
+                subscription_until: None,
+                email: None,
+                error: Some("Could not find home directory".to_string()),
+            });
+        }
+    };
+
+    let auth_file = codex_home.join("auth.json");
+    if !auth_file.exists() {
+        return Ok(CodexData {
+            connected: false,
+            plan_type: None,
+            account_id: None,
+            subscription_until: None,
+            email: None,
+            error: Some("Codex not configured. Please run 'codex' to login.".to_string()),
+        });
+    }
+
+    let auth_content = match fs::read_to_string(&auth_file) {
+        Ok(content) => content,
+        Err(e) => {
+            return Ok(CodexData {
+                connected: false,
+                plan_type: None,
+                account_id: None,
+                subscription_until: None,
+                email: None,
+                error: Some(format!("Failed to read auth.json: {}", e)),
+            });
+        }
+    };
+
+    let auth_json: serde_json::Value = match serde_json::from_str(&auth_content) {
+        Ok(json) => json,
+        Err(e) => {
+            return Ok(CodexData {
+                connected: false,
+                plan_type: None,
+                account_id: None,
+                subscription_until: None,
+                email: None,
+                error: Some(format!("Failed to parse auth.json: {}", e)),
+            });
+        }
+    };
+
+    let id_token = match auth_json["tokens"]["id_token"].as_str() {
+        Some(token) => token,
+        None => {
+            return Ok(CodexData {
+                connected: false,
+                plan_type: None,
+                account_id: None,
+                subscription_until: None,
+                email: None,
+                error: Some("No id_token found in auth.json".to_string()),
+            });
+        }
+    };
+
+    let payload = match decode_jwt_payload(id_token) {
+        Some(p) => p,
+        None => {
+            return Ok(CodexData {
+                connected: false,
+                plan_type: None,
+                account_id: None,
+                subscription_until: None,
+                email: None,
+                error: Some("Failed to decode JWT token".to_string()),
+            });
+        }
+    };
+
+    let auth_info = &payload["https://api.openai.com/auth"];
+    let plan_type = auth_info["chatgpt_plan_type"]
+        .as_str()
+        .map(|s| s.to_string());
+    let account_id = auth_info["chatgpt_account_id"]
+        .as_str()
+        .map(|s| s.to_string());
+    let subscription_until = auth_info["chatgpt_subscription_active_until"]
+        .as_str()
+        .map(|s| s.to_string());
+    let email = payload["email"].as_str().map(|s| s.to_string());
+
+    Ok(CodexData {
+        connected: true,
+        plan_type,
+        account_id,
+        subscription_until,
+        email,
+        error: None,
+    })
+}
+
+#[tauri::command]
+pub async fn get_codex_stats() -> Result<CodexStats, String> {
+    let codex_home = match get_codex_home() {
+        Some(path) => path,
+        None => {
+            return Ok(CodexStats {
+                total_sessions: 0,
+                today_sessions: 0,
+                last_activity: None,
+            });
+        }
+    };
+
+    let history_file = codex_home.join("history.jsonl");
+    if !history_file.exists() {
+        return Ok(CodexStats {
+            total_sessions: 0,
+            today_sessions: 0,
+            last_activity: None,
+        });
+    }
+
+    let file = match fs::File::open(&history_file) {
+        Ok(f) => f,
+        Err(_) => {
+            return Ok(CodexStats {
+                total_sessions: 0,
+                today_sessions: 0,
+                last_activity: None,
+            });
+        }
+    };
+
+    let reader = BufReader::new(file);
+    let today = Utc::now().date_naive();
+    let mut total_sessions = 0u32;
+    let mut today_sessions = 0u32;
+    let mut last_ts: Option<i64> = None;
+
+    for line in reader.lines() {
+        if let Ok(line_content) = line {
+            if let Ok(entry) = serde_json::from_str::<serde_json::Value>(&line_content) {
+                total_sessions += 1;
+
+                if let Some(ts) = entry["ts"].as_i64() {
+                    if let Some(dt) = DateTime::from_timestamp(ts, 0) {
+                        if dt.date_naive() == today {
+                            today_sessions += 1;
+                        }
+                    }
+
+                    if last_ts.map_or(true, |old| ts > old) {
+                        last_ts = Some(ts);
+                    }
+                }
+            }
+        }
+    }
+
+    let last_activity = last_ts
+        .and_then(|ts| DateTime::from_timestamp(ts, 0))
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string());
+
+    Ok(CodexStats {
+        total_sessions,
+        today_sessions,
+        last_activity,
+    })
+}
+
+#[tauri::command]
+pub async fn open_chatgpt_quota() -> Result<(), String> {
+    tauri_plugin_opener::open_url("https://chatgpt.com", None::<&str>)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn get_codex_rate_limits() -> Result<CodexRateLimits, String> {
+    let codex_home = match get_codex_home() {
+        Some(path) => path,
+        None => {
+            return Ok(CodexRateLimits {
+                connected: false,
+                plan_type: None,
+                primary: None,
+                secondary: None,
+                credits: None,
+                error: Some("Could not find home directory".to_string()),
+            });
+        }
+    };
+
+    let auth_file = codex_home.join("auth.json");
+    if !auth_file.exists() {
+        return Ok(CodexRateLimits {
+            connected: false,
+            plan_type: None,
+            primary: None,
+            secondary: None,
+            credits: None,
+            error: Some("Codex not configured. Please run 'codex' to login.".to_string()),
+        });
+    }
+
+    let auth_content = match fs::read_to_string(&auth_file) {
+        Ok(content) => content,
+        Err(e) => {
+            return Ok(CodexRateLimits {
+                connected: false,
+                plan_type: None,
+                primary: None,
+                secondary: None,
+                credits: None,
+                error: Some(format!("Failed to read auth.json: {}", e)),
+            });
+        }
+    };
+
+    let auth_json: serde_json::Value = match serde_json::from_str(&auth_content) {
+        Ok(json) => json,
+        Err(e) => {
+            return Ok(CodexRateLimits {
+                connected: false,
+                plan_type: None,
+                primary: None,
+                secondary: None,
+                credits: None,
+                error: Some(format!("Failed to parse auth.json: {}", e)),
+            });
+        }
+    };
+
+    let access_token = match auth_json["tokens"]["access_token"].as_str() {
+        Some(token) => token,
+        None => {
+            return Ok(CodexRateLimits {
+                connected: false,
+                plan_type: None,
+                primary: None,
+                secondary: None,
+                credits: None,
+                error: Some("No access_token found in auth.json".to_string()),
+            });
+        }
+    };
+
+    let account_id = auth_json["tokens"]["id_token"]
+        .as_str()
+        .and_then(|token| decode_jwt_payload(token))
+        .and_then(|payload| {
+            payload["https://api.openai.com/auth"]["chatgpt_account_id"]
+                .as_str()
+                .map(|s| s.to_string())
+        });
+
+    let client = reqwest::Client::new();
+    let mut request = client
+        .get("https://chatgpt.com/backend-api/wham/usage")
+        .header("Authorization", format!("Bearer {}", access_token))
+        .header("User-Agent", "codex-cli")
+        .timeout(std::time::Duration::from_secs(10));
+
+    if let Some(ref acc_id) = account_id {
+        request = request.header("ChatGPT-Account-Id", acc_id);
+    }
+
+    match request.send().await {
+        Ok(response) => {
+            if response.status().is_success() {
+                match response.json::<serde_json::Value>().await {
+                    Ok(data) => {
+                        let plan_type = data["plan_type"].as_str().map(|s| s.to_string());
+
+                        let primary = data["rate_limit"]
+                            .get("primary_window")
+                            .and_then(|w| {
+                                if w.is_null() {
+                                    None
+                                } else {
+                                    Some(CodexRateLimitWindow {
+                                        used_percent: w["used_percent"].as_i64().unwrap_or(0) as f64,
+                                        window_minutes: w["limit_window_seconds"]
+                                            .as_i64()
+                                            .map(|s| (s + 59) / 60),
+                                        resets_at: w["reset_at"].as_i64(),
+                                    })
+                                }
+                            });
+
+                        let secondary = data["rate_limit"]
+                            .get("secondary_window")
+                            .and_then(|w| {
+                                if w.is_null() {
+                                    None
+                                } else {
+                                    Some(CodexRateLimitWindow {
+                                        used_percent: w["used_percent"].as_i64().unwrap_or(0) as f64,
+                                        window_minutes: w["limit_window_seconds"]
+                                            .as_i64()
+                                            .map(|s| (s + 59) / 60),
+                                        resets_at: w["reset_at"].as_i64(),
+                                    })
+                                }
+                            });
+
+                        let credits = data["credits"].as_object().map(|c| CodexCredits {
+                            has_credits: c.get("has_credits")
+                                .and_then(|v| v.as_bool())
+                                .unwrap_or(false),
+                            unlimited: c.get("unlimited")
+                                .and_then(|v| v.as_bool())
+                                .unwrap_or(false),
+                            balance: c.get("balance")
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string()),
+                        });
+
+                        Ok(CodexRateLimits {
+                            connected: true,
+                            plan_type,
+                            primary,
+                            secondary,
+                            credits,
+                            error: None,
+                        })
+                    }
+                    Err(e) => Ok(CodexRateLimits {
+                        connected: false,
+                        plan_type: None,
+                        primary: None,
+                        secondary: None,
+                        credits: None,
+                        error: Some(format!("Failed to parse response: {}", e)),
+                    }),
+                }
+            } else if response.status().as_u16() == 401 || response.status().as_u16() == 403 {
+                Ok(CodexRateLimits {
+                    connected: false,
+                    plan_type: None,
+                    primary: None,
+                    secondary: None,
+                    credits: None,
+                    error: Some("Token expired. Please run 'codex' to re-login.".to_string()),
+                })
+            } else {
+                Ok(CodexRateLimits {
+                    connected: false,
+                    plan_type: None,
+                    primary: None,
+                    secondary: None,
+                    credits: None,
+                    error: Some(format!("API error: {}", response.status())),
+                })
+            }
+        }
+        Err(e) => Ok(CodexRateLimits {
+            connected: false,
+            plan_type: None,
+            primary: None,
+            secondary: None,
+            credits: None,
+            error: Some(format!("Network error: {}", e)),
+        }),
+    }
+}

--- a/menubar-tauri/src-tauri/src/lib.rs
+++ b/menubar-tauri/src-tauri/src/lib.rs
@@ -1,737 +1,20 @@
+mod codex;
+mod quota;
+mod tray_commands;
 mod tray_icon;
 
-use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine as _};
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-use std::fs;
-use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
-use std::process::Command;
 use std::sync::Mutex;
 use tauri::{
     image::Image,
     menu::{MenuBuilder, MenuItemBuilder},
-    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent, TrayIconId},
-    AppHandle, LogicalSize, Manager, State,
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+    Manager,
 };
 use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
 
-// Global state to store tray icon ID
-struct TrayState {
-    tray_id: Mutex<Option<TrayIconId>>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct UsageInfo {
-    pub used: f64,
-    pub limit: f64,
-    pub percentage: f64,
-    #[serde(rename = "resetTime")]
-    pub reset_time: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct QuotaData {
-    pub connected: bool,
-    pub session: Option<UsageInfo>,
-    #[serde(rename = "weeklyTotal")]
-    pub weekly_total: Option<UsageInfo>,
-    #[serde(rename = "weeklyOpus")]
-    pub weekly_opus: Option<UsageInfo>,
-    #[serde(rename = "weeklySonnet")]
-    pub weekly_sonnet: Option<UsageInfo>,
-    pub error: Option<String>,
-}
-
-// Codex data structures
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct CodexData {
-    pub connected: bool,
-    #[serde(rename = "planType")]
-    pub plan_type: Option<String>,
-    #[serde(rename = "accountId")]
-    pub account_id: Option<String>,
-    #[serde(rename = "subscriptionUntil")]
-    pub subscription_until: Option<String>,
-    pub email: Option<String>,
-    pub error: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct CodexStats {
-    #[serde(rename = "totalSessions")]
-    pub total_sessions: u32,
-    #[serde(rename = "todaySessions")]
-    pub today_sessions: u32,
-    #[serde(rename = "lastActivity")]
-    pub last_activity: Option<String>,
-}
-
-// Codex rate limit data (from ChatGPT backend API)
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct CodexRateLimitWindow {
-    #[serde(rename = "usedPercent")]
-    pub used_percent: f64,
-    #[serde(rename = "windowMinutes")]
-    pub window_minutes: Option<i64>,
-    #[serde(rename = "resetsAt")]
-    pub resets_at: Option<i64>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct CodexCredits {
-    #[serde(rename = "hasCredits")]
-    pub has_credits: bool,
-    pub unlimited: bool,
-    pub balance: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct CodexRateLimits {
-    pub connected: bool,
-    #[serde(rename = "planType")]
-    pub plan_type: Option<String>,
-    pub primary: Option<CodexRateLimitWindow>,
-    pub secondary: Option<CodexRateLimitWindow>,
-    pub credits: Option<CodexCredits>,
-    pub error: Option<String>,
-}
-
-// Read OAuth token from macOS Keychain
-fn get_oauth_token() -> Result<String, String> {
-    // Try multiple possible credential names in macOS Keychain
-    let credential_names = [
-        "Claude Code-credentials",
-        "claude-credentials",
-        "Claude-credentials",
-        "claudecode-credentials",
-    ];
-
-    for cred_name in credential_names {
-        let output = Command::new("security")
-            .args(["find-generic-password", "-s", cred_name, "-w"])
-            .output();
-
-        if let Ok(result) = output {
-            if result.status.success() {
-                let creds_json = String::from_utf8_lossy(&result.stdout).trim().to_string();
-                if !creds_json.is_empty() {
-                    // Parse credentials JSON to extract access token
-                    if let Ok(creds) = serde_json::from_str::<serde_json::Value>(&creds_json) {
-                        if let Some(token) = creds["claudeAiOauth"]["accessToken"].as_str() {
-                            return Ok(token.to_string());
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    Err("OAuth token not found. Please ensure you are logged into Claude Code.".to_string())
-}
-
-#[tauri::command]
-async fn get_quota() -> Result<QuotaData, String> {
-    // Step 1: Get OAuth token from Keychain
-    let access_token = match get_oauth_token() {
-        Ok(token) => token,
-        Err(e) => {
-            return Ok(QuotaData {
-                connected: false,
-                session: None,
-                weekly_total: None,
-                weekly_opus: None,
-                weekly_sonnet: None,
-                error: Some(e),
-            });
-        }
-    };
-
-    // Step 2: Call Anthropic API directly
-    let client = reqwest::Client::new();
-
-    match client
-        .get("https://api.anthropic.com/api/oauth/usage")
-        .header("Accept", "application/json")
-        .header("Authorization", format!("Bearer {}", access_token))
-        .header("anthropic-beta", "oauth-2025-04-20")
-        .timeout(std::time::Duration::from_secs(10))
-        .send()
-        .await
-    {
-        Ok(response) => {
-            if response.status().is_success() {
-                match response.json::<serde_json::Value>().await {
-                    Ok(data) => {
-                        // Check for API error
-                        if data["error"].is_object() {
-                            let error_msg = data["error"]["message"]
-                                .as_str()
-                                .unwrap_or("API error");
-                            return Ok(QuotaData {
-                                connected: false,
-                                session: None,
-                                weekly_total: None,
-                                weekly_opus: None,
-                                weekly_sonnet: None,
-                                error: Some(format!("{} (Token may be expired)", error_msg)),
-                            });
-                        }
-
-                        // Parse Anthropic API structure
-                        let session = parse_quota_window(&data["five_hour"]);
-                        let weekly_total = parse_quota_window(&data["seven_day"]);
-                        let weekly_opus = parse_quota_window(&data["seven_day_opus"]);
-                        let weekly_sonnet = parse_quota_window(&data["seven_day_sonnet"]);
-
-                        Ok(QuotaData {
-                            connected: true,
-                            session,
-                            weekly_total,
-                            weekly_opus,
-                            weekly_sonnet,
-                            error: None,
-                        })
-                    }
-                    Err(e) => Ok(QuotaData {
-                        connected: false,
-                        session: None,
-                        weekly_total: None,
-                        weekly_opus: None,
-                        weekly_sonnet: None,
-                        error: Some(format!("Failed to parse response: {}", e)),
-                    }),
-                }
-            } else if response.status().as_u16() == 401 || response.status().as_u16() == 403 {
-                Ok(QuotaData {
-                    connected: false,
-                    session: None,
-                    weekly_total: None,
-                    weekly_opus: None,
-                    weekly_sonnet: None,
-                    error: Some("Token expired. Please re-login to Claude Code.".to_string()),
-                })
-            } else {
-                Ok(QuotaData {
-                    connected: false,
-                    session: None,
-                    weekly_total: None,
-                    weekly_opus: None,
-                    weekly_sonnet: None,
-                    error: Some(format!("API error: {}", response.status())),
-                })
-            }
-        }
-        Err(e) => Ok(QuotaData {
-            connected: false,
-            session: None,
-            weekly_total: None,
-            weekly_opus: None,
-            weekly_sonnet: None,
-            error: Some(format!("Network error: {}", e)),
-        }),
-    }
-}
-
-// Resize window to fit content
-#[tauri::command]
-async fn resize_window(app: AppHandle, height: f64) -> Result<(), String> {
-    if let Some(window) = app.get_webview_window("main") {
-        let size = LogicalSize::new(320.0, height);
-        window.set_size(size).map_err(|e| e.to_string())?;
-    }
-    Ok(())
-}
-
-// Hide or show dock icon (macOS only)
-#[tauri::command]
-async fn set_dock_visibility(app: AppHandle, visible: bool) -> Result<(), String> {
-    #[cfg(target_os = "macos")]
-    {
-        // Use Tauri's activation policy API
-        use tauri::ActivationPolicy;
-        if visible {
-            let _ = app.set_activation_policy(ActivationPolicy::Regular);
-        } else {
-            let _ = app.set_activation_policy(ActivationPolicy::Accessory);
-        }
-    }
-    Ok(())
-}
-
-// Update tray icon with percentage
-#[tauri::command]
-async fn update_tray_icon(
-    app: AppHandle,
-    tray_state: State<'_, TrayState>,
-    percentage: u8,
-) -> Result<(), String> {
-    println!("[Tray] Updating icon with percentage: {}", percentage);
-
-    let tray_id = {
-        let guard = tray_state.tray_id.lock().map_err(|e| e.to_string())?;
-        guard.clone()
-    };
-
-    if let Some(id) = tray_id {
-        if let Some(tray) = app.tray_by_id(&id) {
-            let icon_bytes = tray_icon::generate_tray_icon_with_ring(percentage, 44);
-            let icon = Image::from_bytes(&icon_bytes).map_err(|e| e.to_string())?;
-            tray.set_icon(Some(icon)).map_err(|e| e.to_string())?;
-            tray.set_icon_as_template(false).map_err(|e| e.to_string())?;
-
-            let tooltip = format!("Claude Quota Monitor ({percentage}%)");
-            tray.set_tooltip(Some(tooltip)).map_err(|e| e.to_string())?;
-            tray.set_visible(true).map_err(|e| e.to_string())?;
-            println!("[Tray] Icon + tooltip updated: {}%", percentage);
-        } else {
-            println!("[Tray] Tray not found by ID");
-        }
-    } else {
-        println!("[Tray] No tray ID stored");
-    }
-
-    Ok(())
-}
-
-// Parse a QuotaWindow from Anthropic API (has utilization and resets_at)
-fn parse_quota_window(value: &serde_json::Value) -> Option<UsageInfo> {
-    if value.is_null() || !value.is_object() {
-        return None;
-    }
-
-    let utilization = value["utilization"].as_f64().unwrap_or(0.0);
-    let resets_at = value["resets_at"].as_str().map(|s| s.to_string());
-
-    Some(UsageInfo {
-        used: utilization,
-        limit: 100.0,
-        percentage: utilization,
-        reset_time: resets_at,
-    })
-}
-
-// Get Codex config directory path
-fn get_codex_home() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".codex"))
-}
-
-// Decode JWT payload (without verification)
-fn decode_jwt_payload(token: &str) -> Option<serde_json::Value> {
-    let parts: Vec<&str> = token.split('.').collect();
-    if parts.len() != 3 {
-        return None;
-    }
-
-    // Decode base64 payload (second part)
-    let payload = parts[1];
-    // Add padding if needed
-    let padded = match payload.len() % 4 {
-        2 => format!("{}==", payload),
-        3 => format!("{}=", payload),
-        _ => payload.to_string(),
-    };
-
-    // Replace URL-safe chars
-    let standard = padded.replace('-', "+").replace('_', "/");
-
-    STANDARD_NO_PAD
-        .decode(&standard)
-        .ok()
-        .or_else(|| base64::engine::general_purpose::STANDARD.decode(&standard).ok())
-        .and_then(|bytes| String::from_utf8(bytes).ok())
-        .and_then(|json| serde_json::from_str(&json).ok())
-}
-
-// Get Codex subscription info from auth.json
-#[tauri::command]
-async fn get_codex_info() -> Result<CodexData, String> {
-    let codex_home = match get_codex_home() {
-        Some(path) => path,
-        None => {
-            return Ok(CodexData {
-                connected: false,
-                plan_type: None,
-                account_id: None,
-                subscription_until: None,
-                email: None,
-                error: Some("Could not find home directory".to_string()),
-            });
-        }
-    };
-
-    let auth_file = codex_home.join("auth.json");
-    if !auth_file.exists() {
-        return Ok(CodexData {
-            connected: false,
-            plan_type: None,
-            account_id: None,
-            subscription_until: None,
-            email: None,
-            error: Some("Codex not configured. Please run 'codex' to login.".to_string()),
-        });
-    }
-
-    // Read and parse auth.json
-    let auth_content = match fs::read_to_string(&auth_file) {
-        Ok(content) => content,
-        Err(e) => {
-            return Ok(CodexData {
-                connected: false,
-                plan_type: None,
-                account_id: None,
-                subscription_until: None,
-                email: None,
-                error: Some(format!("Failed to read auth.json: {}", e)),
-            });
-        }
-    };
-
-    let auth_json: serde_json::Value = match serde_json::from_str(&auth_content) {
-        Ok(json) => json,
-        Err(e) => {
-            return Ok(CodexData {
-                connected: false,
-                plan_type: None,
-                account_id: None,
-                subscription_until: None,
-                email: None,
-                error: Some(format!("Failed to parse auth.json: {}", e)),
-            });
-        }
-    };
-
-    // Get id_token from tokens object
-    let id_token = match auth_json["tokens"]["id_token"].as_str() {
-        Some(token) => token,
-        None => {
-            return Ok(CodexData {
-                connected: false,
-                plan_type: None,
-                account_id: None,
-                subscription_until: None,
-                email: None,
-                error: Some("No id_token found in auth.json".to_string()),
-            });
-        }
-    };
-
-    // Decode JWT to extract subscription info
-    let payload = match decode_jwt_payload(id_token) {
-        Some(p) => p,
-        None => {
-            return Ok(CodexData {
-                connected: false,
-                plan_type: None,
-                account_id: None,
-                subscription_until: None,
-                email: None,
-                error: Some("Failed to decode JWT token".to_string()),
-            });
-        }
-    };
-
-    // Extract info from JWT payload
-    let auth_info = &payload["https://api.openai.com/auth"];
-    let plan_type = auth_info["chatgpt_plan_type"]
-        .as_str()
-        .map(|s| s.to_string());
-    let account_id = auth_info["chatgpt_account_id"]
-        .as_str()
-        .map(|s| s.to_string());
-    let subscription_until = auth_info["chatgpt_subscription_active_until"]
-        .as_str()
-        .map(|s| s.to_string());
-    let email = payload["email"].as_str().map(|s| s.to_string());
-
-    Ok(CodexData {
-        connected: true,
-        plan_type,
-        account_id,
-        subscription_until,
-        email,
-        error: None,
-    })
-}
-
-// Get Codex usage statistics from history.jsonl
-#[tauri::command]
-async fn get_codex_stats() -> Result<CodexStats, String> {
-    let codex_home = match get_codex_home() {
-        Some(path) => path,
-        None => {
-            return Ok(CodexStats {
-                total_sessions: 0,
-                today_sessions: 0,
-                last_activity: None,
-            });
-        }
-    };
-
-    let history_file = codex_home.join("history.jsonl");
-    if !history_file.exists() {
-        return Ok(CodexStats {
-            total_sessions: 0,
-            today_sessions: 0,
-            last_activity: None,
-        });
-    }
-
-    let file = match fs::File::open(&history_file) {
-        Ok(f) => f,
-        Err(_) => {
-            return Ok(CodexStats {
-                total_sessions: 0,
-                today_sessions: 0,
-                last_activity: None,
-            });
-        }
-    };
-
-    let reader = BufReader::new(file);
-    let today = Utc::now().date_naive();
-    let mut total_sessions = 0u32;
-    let mut today_sessions = 0u32;
-    let mut last_ts: Option<i64> = None;
-
-    for line in reader.lines() {
-        if let Ok(line_content) = line {
-            if let Ok(entry) = serde_json::from_str::<serde_json::Value>(&line_content) {
-                total_sessions += 1;
-
-                if let Some(ts) = entry["ts"].as_i64() {
-                    // Check if this is today
-                    if let Some(dt) = DateTime::from_timestamp(ts, 0) {
-                        if dt.date_naive() == today {
-                            today_sessions += 1;
-                        }
-                    }
-
-                    // Track latest timestamp
-                    if last_ts.is_none() || ts > last_ts.unwrap() {
-                        last_ts = Some(ts);
-                    }
-                }
-            }
-        }
-    }
-
-    let last_activity = last_ts
-        .and_then(|ts| DateTime::from_timestamp(ts, 0))
-        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string());
-
-    Ok(CodexStats {
-        total_sessions,
-        today_sessions,
-        last_activity,
-    })
-}
-
-// Open ChatGPT in browser to view quota
-#[tauri::command]
-async fn open_chatgpt_quota() -> Result<(), String> {
-    tauri_plugin_opener::open_url("https://chatgpt.com", None::<&str>)
-        .map_err(|e| e.to_string())
-}
-
-// Get Codex rate limits from ChatGPT backend API
-#[tauri::command]
-async fn get_codex_rate_limits() -> Result<CodexRateLimits, String> {
-    let codex_home = match get_codex_home() {
-        Some(path) => path,
-        None => {
-            return Ok(CodexRateLimits {
-                connected: false,
-                plan_type: None,
-                primary: None,
-                secondary: None,
-                credits: None,
-                error: Some("Could not find home directory".to_string()),
-            });
-        }
-    };
-
-    let auth_file = codex_home.join("auth.json");
-    if !auth_file.exists() {
-        return Ok(CodexRateLimits {
-            connected: false,
-            plan_type: None,
-            primary: None,
-            secondary: None,
-            credits: None,
-            error: Some("Codex not configured. Please run 'codex' to login.".to_string()),
-        });
-    }
-
-    // Read auth.json
-    let auth_content = match fs::read_to_string(&auth_file) {
-        Ok(content) => content,
-        Err(e) => {
-            return Ok(CodexRateLimits {
-                connected: false,
-                plan_type: None,
-                primary: None,
-                secondary: None,
-                credits: None,
-                error: Some(format!("Failed to read auth.json: {}", e)),
-            });
-        }
-    };
-
-    let auth_json: serde_json::Value = match serde_json::from_str(&auth_content) {
-        Ok(json) => json,
-        Err(e) => {
-            return Ok(CodexRateLimits {
-                connected: false,
-                plan_type: None,
-                primary: None,
-                secondary: None,
-                credits: None,
-                error: Some(format!("Failed to parse auth.json: {}", e)),
-            });
-        }
-    };
-
-    // Get access_token from tokens object
-    let access_token = match auth_json["tokens"]["access_token"].as_str() {
-        Some(token) => token,
-        None => {
-            return Ok(CodexRateLimits {
-                connected: false,
-                plan_type: None,
-                primary: None,
-                secondary: None,
-                credits: None,
-                error: Some("No access_token found in auth.json".to_string()),
-            });
-        }
-    };
-
-    // Try to get account_id from id_token JWT
-    let account_id = auth_json["tokens"]["id_token"]
-        .as_str()
-        .and_then(|token| decode_jwt_payload(token))
-        .and_then(|payload| {
-            payload["https://api.openai.com/auth"]["chatgpt_account_id"]
-                .as_str()
-                .map(|s| s.to_string())
-        });
-
-    // Call ChatGPT backend API
-    let client = reqwest::Client::new();
-    let mut request = client
-        .get("https://chatgpt.com/backend-api/wham/usage")
-        .header("Authorization", format!("Bearer {}", access_token))
-        .header("User-Agent", "codex-cli")
-        .timeout(std::time::Duration::from_secs(10));
-
-    if let Some(ref acc_id) = account_id {
-        request = request.header("ChatGPT-Account-Id", acc_id);
-    }
-
-    match request.send().await {
-        Ok(response) => {
-            if response.status().is_success() {
-                match response.json::<serde_json::Value>().await {
-                    Ok(data) => {
-                        // Parse the response
-                        let plan_type = data["plan_type"].as_str().map(|s| s.to_string());
-
-                        // Parse primary window
-                        let primary = data["rate_limit"]
-                            .get("primary_window")
-                            .and_then(|w| {
-                                if w.is_null() {
-                                    None
-                                } else {
-                                    Some(CodexRateLimitWindow {
-                                        used_percent: w["used_percent"].as_i64().unwrap_or(0) as f64,
-                                        window_minutes: w["limit_window_seconds"]
-                                            .as_i64()
-                                            .map(|s| (s + 59) / 60),
-                                        resets_at: w["reset_at"].as_i64(),
-                                    })
-                                }
-                            });
-
-                        // Parse secondary window
-                        let secondary = data["rate_limit"]
-                            .get("secondary_window")
-                            .and_then(|w| {
-                                if w.is_null() {
-                                    None
-                                } else {
-                                    Some(CodexRateLimitWindow {
-                                        used_percent: w["used_percent"].as_i64().unwrap_or(0) as f64,
-                                        window_minutes: w["limit_window_seconds"]
-                                            .as_i64()
-                                            .map(|s| (s + 59) / 60),
-                                        resets_at: w["reset_at"].as_i64(),
-                                    })
-                                }
-                            });
-
-                        // Parse credits
-                        let credits = data["credits"].as_object().map(|c| CodexCredits {
-                            has_credits: c.get("has_credits")
-                                .and_then(|v| v.as_bool())
-                                .unwrap_or(false),
-                            unlimited: c.get("unlimited")
-                                .and_then(|v| v.as_bool())
-                                .unwrap_or(false),
-                            balance: c.get("balance")
-                                .and_then(|v| v.as_str())
-                                .map(|s| s.to_string()),
-                        });
-
-                        Ok(CodexRateLimits {
-                            connected: true,
-                            plan_type,
-                            primary,
-                            secondary,
-                            credits,
-                            error: None,
-                        })
-                    }
-                    Err(e) => Ok(CodexRateLimits {
-                        connected: false,
-                        plan_type: None,
-                        primary: None,
-                        secondary: None,
-                        credits: None,
-                        error: Some(format!("Failed to parse response: {}", e)),
-                    }),
-                }
-            } else if response.status().as_u16() == 401 || response.status().as_u16() == 403 {
-                Ok(CodexRateLimits {
-                    connected: false,
-                    plan_type: None,
-                    primary: None,
-                    secondary: None,
-                    credits: None,
-                    error: Some("Token expired. Please run 'codex' to re-login.".to_string()),
-                })
-            } else {
-                Ok(CodexRateLimits {
-                    connected: false,
-                    plan_type: None,
-                    primary: None,
-                    secondary: None,
-                    credits: None,
-                    error: Some(format!("API error: {}", response.status())),
-                })
-            }
-        }
-        Err(e) => Ok(CodexRateLimits {
-            connected: false,
-            plan_type: None,
-            primary: None,
-            secondary: None,
-            credits: None,
-            error: Some(format!("Network error: {}", e)),
-        }),
-    }
-}
+use codex::{get_codex_info, get_codex_rate_limits, get_codex_stats, open_chatgpt_quota};
+use quota::get_quota;
+use tray_commands::{resize_window, set_dock_visibility, update_tray_icon, TrayState};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -741,7 +24,16 @@ pub fn run() {
         .manage(TrayState {
             tray_id: Mutex::new(None),
         })
-        .invoke_handler(tauri::generate_handler![get_quota, update_tray_icon, resize_window, set_dock_visibility, get_codex_info, get_codex_stats, open_chatgpt_quota, get_codex_rate_limits])
+        .invoke_handler(tauri::generate_handler![
+            get_quota,
+            update_tray_icon,
+            resize_window,
+            set_dock_visibility,
+            get_codex_info,
+            get_codex_stats,
+            open_chatgpt_quota,
+            get_codex_rate_limits,
+        ])
         .setup(|app| {
             // Start in accessory mode for menubar behavior consistency on macOS.
             #[cfg(target_os = "macos")]
@@ -750,15 +42,12 @@ pub fn run() {
                 let _ = app.set_activation_policy(ActivationPolicy::Accessory);
             }
 
-            // Use dynamic ring icon showing 0% at startup
             let icon_bytes = tray_icon::generate_tray_icon_with_ring(0, 44);
             let initial_icon = Image::from_bytes(&icon_bytes)?;
 
-            // Create right-click menu
             let quit_item = MenuItemBuilder::with_id("quit", "Quit").build(app)?;
             let menu = MenuBuilder::new(app).items(&[&quit_item]).build()?;
 
-            // Setup system tray
             let tray = match TrayIconBuilder::with_id("quota-tray")
                 .icon(initial_icon)
                 .icon_as_template(false)
@@ -782,10 +71,8 @@ pub fn run() {
                             if window.is_visible().unwrap_or(false) {
                                 let _ = window.hide();
                             } else {
-                                // Position window near tray icon
                                 if let Ok(Some(rect)) = tray.rect() {
                                     let window_size = window.outer_size().unwrap_or_default();
-                                    // Convert Position and Size to physical values
                                     let pos = match rect.position {
                                         tauri::Position::Physical(p) => (p.x, p.y),
                                         tauri::Position::Logical(l) => (l.x as i32, l.y as i32),
@@ -810,7 +97,10 @@ pub fn run() {
             {
                 Ok(tray) => Some(tray),
                 Err(err) => {
-                    eprintln!("[Tray] Failed to create tray icon, falling back to window mode: {}", err);
+                    eprintln!(
+                        "[Tray] Failed to create tray icon, falling back to window mode: {}",
+                        err
+                    );
                     #[cfg(target_os = "macos")]
                     {
                         use tauri::ActivationPolicy;
@@ -826,7 +116,6 @@ pub fn run() {
 
             let tray_available = tray.is_some();
 
-            // Store tray ID for later updates
             if let (Some(tray), Some(state)) = (tray.as_ref(), app.try_state::<TrayState>()) {
                 let _ = tray.set_visible(true);
                 if let Ok(mut guard) = state.tray_id.lock() {
@@ -834,17 +123,17 @@ pub fn run() {
                 }
             }
 
-            // Apply vibrancy and rounded corners on macOS
             if let Some(window) = app.get_webview_window("main") {
                 #[cfg(target_os = "macos")]
                 {
-                    if let Err(err) = apply_vibrancy(&window, NSVisualEffectMaterial::Popover, None, Some(8.0)) {
+                    if let Err(err) =
+                        apply_vibrancy(&window, NSVisualEffectMaterial::Popover, None, Some(8.0))
+                    {
                         eprintln!("[Window] Failed to apply vibrancy: {}", err);
                     }
                 }
 
                 if tray_available {
-                    // Hide window when it loses focus only in tray mode.
                     let window_clone = window.clone();
                     window.on_window_event(move |event| {
                         if let tauri::WindowEvent::Focused(false) = event {

--- a/menubar-tauri/src-tauri/src/lib.rs
+++ b/menubar-tauri/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod codex;
+mod panel_position;
 mod quota;
 mod tray_commands;
 mod tray_icon;
@@ -72,17 +73,62 @@ pub fn run() {
                                 let _ = window.hide();
                             } else {
                                 if let Ok(Some(rect)) = tray.rect() {
-                                    let window_size = window.outer_size().unwrap_or_default();
-                                    let pos = match rect.position {
+                                    let panel = window.outer_size().unwrap_or_default();
+                                    let (tray_x, tray_y) = match rect.position {
                                         tauri::Position::Physical(p) => (p.x, p.y),
                                         tauri::Position::Logical(l) => (l.x as i32, l.y as i32),
                                     };
-                                    let tray_size = match rect.size {
-                                        tauri::Size::Physical(s) => s.height,
-                                        tauri::Size::Logical(l) => l.height as u32,
+                                    let (tray_w, tray_h) = match rect.size {
+                                        tauri::Size::Physical(s) => (s.width, s.height),
+                                        tauri::Size::Logical(l) => {
+                                            (l.width as u32, l.height as u32)
+                                        }
                                     };
-                                    let x = pos.0 - (window_size.width as i32 / 2);
-                                    let y = pos.1 + tray_size as i32 + 4;
+
+                                    // Pick the monitor whose area contains the tray center;
+                                    // fall back to the first monitor if none matches.
+                                    let tray_cx = tray_x + tray_w as i32 / 2;
+                                    let tray_cy = tray_y + tray_h as i32 / 2;
+                                    let monitors =
+                                        app.available_monitors().unwrap_or_default();
+                                    let monitor = monitors
+                                        .iter()
+                                        .find(|m| {
+                                            let p = m.position();
+                                            let s = m.size();
+                                            tray_cx >= p.x
+                                                && tray_cx < p.x + s.width as i32
+                                                && tray_cy >= p.y
+                                                && tray_cy < p.y + s.height as i32
+                                        })
+                                        .or_else(|| monitors.first());
+
+                                    let (work_x, work_y, work_w, work_h) = monitor
+                                        .map(|m| {
+                                            let wa = m.work_area();
+                                            (
+                                                wa.position.x,
+                                                wa.position.y,
+                                                wa.size.width,
+                                                wa.size.height,
+                                            )
+                                        })
+                                        .unwrap_or((0, 0, u32::MAX / 2, u32::MAX / 2));
+
+                                    let (x, y) = panel_position::compute_panel_position(
+                                        panel_position::LayoutInput {
+                                            tray_x,
+                                            tray_y,
+                                            tray_w,
+                                            tray_h,
+                                            panel_w: panel.width,
+                                            panel_h: panel.height,
+                                            work_x,
+                                            work_y,
+                                            work_w,
+                                            work_h,
+                                        },
+                                    );
                                     let _ = window.set_position(tauri::Position::Physical(
                                         tauri::PhysicalPosition { x, y },
                                     ));

--- a/menubar-tauri/src-tauri/src/panel_position.rs
+++ b/menubar-tauri/src-tauri/src/panel_position.rs
@@ -1,0 +1,266 @@
+//! Panel positioning relative to the tray icon, in physical pixels.
+//!
+//! Pure function so positioning behavior can be unit-tested on any host OS
+//! without a live tray or monitor. Inputs and outputs are plain integers; the
+//! caller (`lib.rs`) is responsible for converting between Tauri's
+//! Logical/Physical units before and after.
+
+#[derive(Debug, Clone, Copy)]
+pub struct LayoutInput {
+    pub tray_x: i32,
+    pub tray_y: i32,
+    pub tray_w: u32,
+    pub tray_h: u32,
+    pub panel_w: u32,
+    pub panel_h: u32,
+    pub work_x: i32,
+    pub work_y: i32,
+    pub work_w: u32,
+    pub work_h: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Edge {
+    Top,
+    Bottom,
+    Left,
+    Right,
+}
+
+const GAP: i32 = 4;
+
+fn detect_edge(i: &LayoutInput) -> Edge {
+    let cx = i.tray_x + i.tray_w as i32 / 2;
+    let cy = i.tray_y + i.tray_h as i32 / 2;
+    let d_top = (cy - i.work_y).abs();
+    let d_bottom = (i.work_y + i.work_h as i32 - cy).abs();
+    let d_left = (cx - i.work_x).abs();
+    let d_right = (i.work_x + i.work_w as i32 - cx).abs();
+    let min = d_top.min(d_bottom).min(d_left).min(d_right);
+    if min == d_top {
+        Edge::Top
+    } else if min == d_bottom {
+        Edge::Bottom
+    } else if min == d_left {
+        Edge::Left
+    } else {
+        Edge::Right
+    }
+}
+
+pub fn compute_panel_position(i: LayoutInput) -> (i32, i32) {
+    let (x, y) = match detect_edge(&i) {
+        // macOS menubar — panel drops below tray icon. Preserves the legacy
+        // formula `tray_x - panel_w/2` so existing Mac placement is unchanged.
+        Edge::Top => (
+            i.tray_x - i.panel_w as i32 / 2,
+            i.tray_y + i.tray_h as i32 + GAP,
+        ),
+        // Windows default — taskbar at bottom, panel rises above tray icon.
+        Edge::Bottom => (
+            i.tray_x - i.panel_w as i32 / 2,
+            i.tray_y - i.panel_h as i32 - GAP,
+        ),
+        // Vertical taskbar pinned to the left edge.
+        Edge::Left => (
+            i.tray_x + i.tray_w as i32 + GAP,
+            i.tray_y - i.panel_h as i32 / 2,
+        ),
+        // Vertical taskbar pinned to the right edge.
+        Edge::Right => (
+            i.tray_x - i.panel_w as i32 - GAP,
+            i.tray_y - i.panel_h as i32 / 2,
+        ),
+    };
+
+    let max_x = (i.work_x + i.work_w as i32 - i.panel_w as i32).max(i.work_x);
+    let max_y = (i.work_y + i.work_h as i32 - i.panel_h as i32).max(i.work_y);
+    (x.clamp(i.work_x, max_x), y.clamp(i.work_y, max_y))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(case: LayoutInput) -> (i32, i32) {
+        compute_panel_position(case)
+    }
+
+    fn assert_inside_work_area(case: &LayoutInput, x: i32, y: i32) {
+        assert!(
+            x >= case.work_x && x + case.panel_w as i32 <= case.work_x + case.work_w as i32,
+            "x={} out of work area x=[{}, {})",
+            x,
+            case.work_x,
+            case.work_x + case.work_w as i32,
+        );
+        assert!(
+            y >= case.work_y && y + case.panel_h as i32 <= case.work_y + case.work_h as i32,
+            "y={} out of work area y=[{}, {})",
+            y,
+            case.work_y,
+            case.work_y + case.work_h as i32,
+        );
+    }
+
+    /// Regression: macOS top menubar must keep the legacy formula
+    /// `x = tray_x - panel_w/2`, `y = tray_y + tray_h + 4`.
+    #[test]
+    fn macos_top_menubar_matches_legacy_formula() {
+        let case = LayoutInput {
+            tray_x: 1200,
+            tray_y: 0,
+            tray_w: 22,
+            tray_h: 22,
+            panel_w: 360,
+            panel_h: 480,
+            work_x: 0,
+            work_y: 25, // mac menubar takes ~25px
+            work_w: 1920,
+            work_h: 1055,
+        };
+        let (x, y) = run(case);
+        // legacy: x = 1200 - 180 = 1020; y = 0 + 22 + 4 = 26 -> clamped up to 25
+        assert_eq!(x, 1020);
+        assert_eq!(y, 26);
+        assert_inside_work_area(&case, x, y);
+    }
+
+    /// Issue #7: Windows 11, 2560x1440, taskbar at bottom-right.
+    /// Old formula put y below tray (off-screen) and right edge clipped.
+    /// New behavior must place panel above tray and inside work area.
+    #[test]
+    fn windows_bottom_right_taskbar_clamps_into_work_area() {
+        let case = LayoutInput {
+            tray_x: 2500,
+            tray_y: 1410,
+            tray_w: 24,
+            tray_h: 24,
+            panel_w: 380,
+            panel_h: 520,
+            work_x: 0,
+            work_y: 0,
+            work_w: 2560,
+            work_h: 1400, // taskbar height 40px
+        };
+        let (x, y) = run(case);
+        assert_inside_work_area(&case, x, y);
+        // Panel must be above the tray icon, not below it.
+        assert!(
+            y + case.panel_h as i32 <= case.tray_y,
+            "panel bottom {} must not overlap tray top {}",
+            y + case.panel_h as i32,
+            case.tray_y,
+        );
+        // Right edge flush against work area (clamped).
+        assert_eq!(x, case.work_w as i32 - case.panel_w as i32);
+    }
+
+    /// Windows with vertical taskbar pinned to the left.
+    #[test]
+    fn windows_left_taskbar_panel_on_right_side() {
+        let case = LayoutInput {
+            tray_x: 0,
+            tray_y: 700,
+            tray_w: 48,
+            tray_h: 32,
+            panel_w: 380,
+            panel_h: 520,
+            work_x: 48,
+            work_y: 0,
+            work_w: 1872,
+            work_h: 1080,
+        };
+        let (x, y) = run(case);
+        assert_inside_work_area(&case, x, y);
+        assert!(x >= case.tray_x + case.tray_w as i32, "panel must be to the right of tray");
+    }
+
+    /// Windows with vertical taskbar pinned to the right.
+    #[test]
+    fn windows_right_taskbar_panel_on_left_side() {
+        let case = LayoutInput {
+            tray_x: 2512,
+            tray_y: 700,
+            tray_w: 48,
+            tray_h: 32,
+            panel_w: 380,
+            panel_h: 520,
+            work_x: 0,
+            work_y: 0,
+            work_w: 2512,
+            work_h: 1440,
+        };
+        let (x, y) = run(case);
+        assert_inside_work_area(&case, x, y);
+        assert!(
+            x + case.panel_w as i32 <= case.tray_x,
+            "panel right {} must not overlap tray left {}",
+            x + case.panel_w as i32,
+            case.tray_x,
+        );
+    }
+
+    /// Multi-monitor: tray sits on a secondary monitor offset to the right.
+    /// Work area origin is non-zero. Panel must stay inside that monitor.
+    #[test]
+    fn multi_monitor_secondary_display() {
+        let case = LayoutInput {
+            tray_x: 4400,
+            tray_y: 1410,
+            tray_w: 24,
+            tray_h: 24,
+            panel_w: 380,
+            panel_h: 520,
+            work_x: 2560,
+            work_y: 0,
+            work_w: 1920,
+            work_h: 1400,
+        };
+        let (x, y) = run(case);
+        assert_inside_work_area(&case, x, y);
+        assert!(x >= 2560, "panel must stay on secondary monitor");
+    }
+
+    /// 200% DPI scaling: same shape as Windows bottom-right but doubled.
+    /// Confirms the math has no scale-dependent assumptions.
+    #[test]
+    fn high_dpi_scales_proportionally() {
+        let case = LayoutInput {
+            tray_x: 5000,
+            tray_y: 2820,
+            tray_w: 48,
+            tray_h: 48,
+            panel_w: 760,
+            panel_h: 1040,
+            work_x: 0,
+            work_y: 0,
+            work_w: 5120,
+            work_h: 2800,
+        };
+        let (x, y) = run(case);
+        assert_inside_work_area(&case, x, y);
+        assert!(y + case.panel_h as i32 <= case.tray_y);
+    }
+
+    /// Pathological: panel taller than work area. Clamp must still produce
+    /// a coordinate inside the work area origin (no panic, no negative).
+    #[test]
+    fn panel_larger_than_work_area_does_not_overflow() {
+        let case = LayoutInput {
+            tray_x: 100,
+            tray_y: 100,
+            tray_w: 24,
+            tray_h: 24,
+            panel_w: 400,
+            panel_h: 400,
+            work_x: 0,
+            work_y: 0,
+            work_w: 200,
+            work_h: 200,
+        };
+        let (x, y) = run(case);
+        assert_eq!(x, 0);
+        assert_eq!(y, 0);
+    }
+}

--- a/menubar-tauri/src-tauri/src/panel_position.rs
+++ b/menubar-tauri/src-tauri/src/panel_position.rs
@@ -49,28 +49,15 @@ fn detect_edge(i: &LayoutInput) -> Edge {
 }
 
 pub fn compute_panel_position(i: LayoutInput) -> (i32, i32) {
+    // Place the panel adjacent to the tray on the side opposite the screen
+    // edge, then align it on the tray's center along the perpendicular axis.
+    let center_x = i.tray_x + i.tray_w as i32 / 2 - i.panel_w as i32 / 2;
+    let center_y = i.tray_y + i.tray_h as i32 / 2 - i.panel_h as i32 / 2;
     let (x, y) = match detect_edge(&i) {
-        // macOS menubar — panel drops below tray icon. Preserves the legacy
-        // formula `tray_x - panel_w/2` so existing Mac placement is unchanged.
-        Edge::Top => (
-            i.tray_x - i.panel_w as i32 / 2,
-            i.tray_y + i.tray_h as i32 + GAP,
-        ),
-        // Windows default — taskbar at bottom, panel rises above tray icon.
-        Edge::Bottom => (
-            i.tray_x - i.panel_w as i32 / 2,
-            i.tray_y - i.panel_h as i32 - GAP,
-        ),
-        // Vertical taskbar pinned to the left edge.
-        Edge::Left => (
-            i.tray_x + i.tray_w as i32 + GAP,
-            i.tray_y - i.panel_h as i32 / 2,
-        ),
-        // Vertical taskbar pinned to the right edge.
-        Edge::Right => (
-            i.tray_x - i.panel_w as i32 - GAP,
-            i.tray_y - i.panel_h as i32 / 2,
-        ),
+        Edge::Top => (center_x, i.tray_y + i.tray_h as i32 + GAP),
+        Edge::Bottom => (center_x, i.tray_y - i.panel_h as i32 - GAP),
+        Edge::Left => (i.tray_x + i.tray_w as i32 + GAP, center_y),
+        Edge::Right => (i.tray_x - i.panel_w as i32 - GAP, center_y),
     };
 
     let max_x = (i.work_x + i.work_w as i32 - i.panel_w as i32).max(i.work_x);
@@ -103,10 +90,10 @@ mod tests {
         );
     }
 
-    /// Regression: macOS top menubar must keep the legacy formula
-    /// `x = tray_x - panel_w/2`, `y = tray_y + tray_h + 4`.
+    /// macOS top menubar — panel drops below the tray icon, centered on the
+    /// tray's horizontal midpoint.
     #[test]
-    fn macos_top_menubar_matches_legacy_formula() {
+    fn macos_top_menubar_centers_panel_below_tray() {
         let case = LayoutInput {
             tray_x: 1200,
             tray_y: 0,
@@ -120,8 +107,9 @@ mod tests {
             work_h: 1055,
         };
         let (x, y) = run(case);
-        // legacy: x = 1200 - 180 = 1020; y = 0 + 22 + 4 = 26 -> clamped up to 25
-        assert_eq!(x, 1020);
+        // tray center x = 1200 + 11 = 1211; panel x = 1211 - 180 = 1031
+        // panel y = tray_y + tray_h + GAP = 0 + 22 + 4 = 26
+        assert_eq!(x, 1031);
         assert_eq!(y, 26);
         assert_inside_work_area(&case, x, y);
     }

--- a/menubar-tauri/src-tauri/src/quota.rs
+++ b/menubar-tauri/src-tauri/src/quota.rs
@@ -1,0 +1,173 @@
+//! Claude quota: types, OAuth token retrieval, and the `get_quota` command.
+
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UsageInfo {
+    pub used: f64,
+    pub limit: f64,
+    pub percentage: f64,
+    #[serde(rename = "resetTime")]
+    pub reset_time: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct QuotaData {
+    pub connected: bool,
+    pub session: Option<UsageInfo>,
+    #[serde(rename = "weeklyTotal")]
+    pub weekly_total: Option<UsageInfo>,
+    #[serde(rename = "weeklyOpus")]
+    pub weekly_opus: Option<UsageInfo>,
+    #[serde(rename = "weeklySonnet")]
+    pub weekly_sonnet: Option<UsageInfo>,
+    pub error: Option<String>,
+}
+
+// Read OAuth token from macOS Keychain.
+fn get_oauth_token() -> Result<String, String> {
+    let credential_names = [
+        "Claude Code-credentials",
+        "claude-credentials",
+        "Claude-credentials",
+        "claudecode-credentials",
+    ];
+
+    for cred_name in credential_names {
+        let output = Command::new("security")
+            .args(["find-generic-password", "-s", cred_name, "-w"])
+            .output();
+
+        if let Ok(result) = output {
+            if result.status.success() {
+                let creds_json = String::from_utf8_lossy(&result.stdout).trim().to_string();
+                if !creds_json.is_empty() {
+                    if let Ok(creds) = serde_json::from_str::<serde_json::Value>(&creds_json) {
+                        if let Some(token) = creds["claudeAiOauth"]["accessToken"].as_str() {
+                            return Ok(token.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Err("OAuth token not found. Please ensure you are logged into Claude Code.".to_string())
+}
+
+// Parse a QuotaWindow from the Anthropic API (utilization + resets_at).
+fn parse_quota_window(value: &serde_json::Value) -> Option<UsageInfo> {
+    if value.is_null() || !value.is_object() {
+        return None;
+    }
+
+    let utilization = value["utilization"].as_f64().unwrap_or(0.0);
+    let resets_at = value["resets_at"].as_str().map(|s| s.to_string());
+
+    Some(UsageInfo {
+        used: utilization,
+        limit: 100.0,
+        percentage: utilization,
+        reset_time: resets_at,
+    })
+}
+
+#[tauri::command]
+pub async fn get_quota() -> Result<QuotaData, String> {
+    let access_token = match get_oauth_token() {
+        Ok(token) => token,
+        Err(e) => {
+            return Ok(QuotaData {
+                connected: false,
+                session: None,
+                weekly_total: None,
+                weekly_opus: None,
+                weekly_sonnet: None,
+                error: Some(e),
+            });
+        }
+    };
+
+    let client = reqwest::Client::new();
+
+    match client
+        .get("https://api.anthropic.com/api/oauth/usage")
+        .header("Accept", "application/json")
+        .header("Authorization", format!("Bearer {}", access_token))
+        .header("anthropic-beta", "oauth-2025-04-20")
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+    {
+        Ok(response) => {
+            if response.status().is_success() {
+                match response.json::<serde_json::Value>().await {
+                    Ok(data) => {
+                        if data["error"].is_object() {
+                            let error_msg = data["error"]["message"]
+                                .as_str()
+                                .unwrap_or("API error");
+                            return Ok(QuotaData {
+                                connected: false,
+                                session: None,
+                                weekly_total: None,
+                                weekly_opus: None,
+                                weekly_sonnet: None,
+                                error: Some(format!("{} (Token may be expired)", error_msg)),
+                            });
+                        }
+
+                        let session = parse_quota_window(&data["five_hour"]);
+                        let weekly_total = parse_quota_window(&data["seven_day"]);
+                        let weekly_opus = parse_quota_window(&data["seven_day_opus"]);
+                        let weekly_sonnet = parse_quota_window(&data["seven_day_sonnet"]);
+
+                        Ok(QuotaData {
+                            connected: true,
+                            session,
+                            weekly_total,
+                            weekly_opus,
+                            weekly_sonnet,
+                            error: None,
+                        })
+                    }
+                    Err(e) => Ok(QuotaData {
+                        connected: false,
+                        session: None,
+                        weekly_total: None,
+                        weekly_opus: None,
+                        weekly_sonnet: None,
+                        error: Some(format!("Failed to parse response: {}", e)),
+                    }),
+                }
+            } else if response.status().as_u16() == 401 || response.status().as_u16() == 403 {
+                Ok(QuotaData {
+                    connected: false,
+                    session: None,
+                    weekly_total: None,
+                    weekly_opus: None,
+                    weekly_sonnet: None,
+                    error: Some("Token expired. Please re-login to Claude Code.".to_string()),
+                })
+            } else {
+                Ok(QuotaData {
+                    connected: false,
+                    session: None,
+                    weekly_total: None,
+                    weekly_opus: None,
+                    weekly_sonnet: None,
+                    error: Some(format!("API error: {}", response.status())),
+                })
+            }
+        }
+        Err(e) => Ok(QuotaData {
+            connected: false,
+            session: None,
+            weekly_total: None,
+            weekly_opus: None,
+            weekly_sonnet: None,
+            error: Some(format!("Network error: {}", e)),
+        }),
+    }
+}

--- a/menubar-tauri/src-tauri/src/tray_commands.rs
+++ b/menubar-tauri/src-tauri/src/tray_commands.rs
@@ -1,0 +1,73 @@
+//! Window/tray Tauri commands and the shared `TrayState` handle.
+
+use std::sync::Mutex;
+use tauri::{image::Image, tray::TrayIconId, AppHandle, LogicalSize, Manager, State};
+
+use crate::tray_icon;
+
+pub struct TrayState {
+    pub tray_id: Mutex<Option<TrayIconId>>,
+}
+
+#[tauri::command]
+pub async fn resize_window(app: AppHandle, height: f64) -> Result<(), String> {
+    if let Some(window) = app.get_webview_window("main") {
+        let size = LogicalSize::new(320.0, height);
+        window.set_size(size).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn set_dock_visibility(app: AppHandle, visible: bool) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        use tauri::ActivationPolicy;
+        if visible {
+            let _ = app.set_activation_policy(ActivationPolicy::Regular);
+        } else {
+            let _ = app.set_activation_policy(ActivationPolicy::Accessory);
+        }
+    }
+    // Reference `app` and `visible` on non-macOS to keep the signature unified
+    // without dead-code warnings.
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, visible);
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn update_tray_icon(
+    app: AppHandle,
+    tray_state: State<'_, TrayState>,
+    percentage: u8,
+) -> Result<(), String> {
+    println!("[Tray] Updating icon with percentage: {}", percentage);
+
+    let tray_id = {
+        let guard = tray_state.tray_id.lock().map_err(|e| e.to_string())?;
+        guard.clone()
+    };
+
+    if let Some(id) = tray_id {
+        if let Some(tray) = app.tray_by_id(&id) {
+            let icon_bytes = tray_icon::generate_tray_icon_with_ring(percentage, 44);
+            let icon = Image::from_bytes(&icon_bytes).map_err(|e| e.to_string())?;
+            tray.set_icon(Some(icon)).map_err(|e| e.to_string())?;
+            tray.set_icon_as_template(false).map_err(|e| e.to_string())?;
+
+            let tooltip = format!("Claude Quota Monitor ({percentage}%)");
+            tray.set_tooltip(Some(tooltip)).map_err(|e| e.to_string())?;
+            tray.set_visible(true).map_err(|e| e.to_string())?;
+            println!("[Tray] Icon + tooltip updated: {}%", percentage);
+        } else {
+            println!("[Tray] Tray not found by ID");
+        }
+    } else {
+        println!("[Tray] No tray ID stored");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Fixes #7: on Windows the tray panel rendered partly off-screen because the
  positioning code assumed a macOS-style top-edge tray. Replaced the inline math
  with a pure `panel_position` module that detects which edge the tray sits on,
  picks the correct adjacent side, and clamps the result into the active
  monitor's work area. Multi-monitor and high-DPI cases handled.
- Refactor: split `lib.rs` (was 861 lines, over the 800-line ceiling) into
  focused modules: `quota.rs`, `codex.rs`, `tray_commands.rs`, plus the new
  `panel_position.rs`. Pure code motion — public command names, JSON shapes,
  and (post-#8) tray icon behavior are unchanged.
- Centering cleanup: dropped the legacy `tray_x - panel_w/2` offset; all four
  edges now center the panel on the tray's perpendicular midpoint. Net effect
  on macOS: panel shifts ~half a tray icon width to the right (~11 px for a
  22 px icon).

> Stacked on #8 because the refactor moves post-#8 versions of `update_tray_icon`
> and `run()`. Base will retarget to `main` automatically once #8 merges.

## Verification
- `cargo check` — clean
- `cargo test panel_position` — 7/7 pass (legacy macOS top, Windows
  bottom/left/right taskbars, multi-monitor secondary display, 200% DPI,
  pathological panel-larger-than-screen)

## Test plan
- [ ] macOS regression: launch, click tray, panel drops below the icon (now
  ~11 px right of previous position; centered on tray)
- [ ] Windows 11 (issue reporter or CI build): launch, click tray, panel rises
  above bottom taskbar and stays inside the screen
- [ ] Multi-monitor: tray on a secondary display → panel appears on the same
  display