### PR TITLE
fix(security): harden web API auth and rate-limit layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Open **http://127.0.0.1:3377**
 
 By default the web server binds to loopback only. To expose it intentionally, set `CLAUDE_HUB_HOST`.
 
+If you put Claude Hub behind a reverse proxy (Caddy, nginx, cloudflared) and want the in-process rate limiter to identify real clients, also set `CLAUDE_HUB_TRUST_PROXY=true`. Without that flag, `X-Forwarded-For` is treated as untrusted input and the limiter keys on the actual TCP peer instead — this is intentional, so a malicious caller cannot bypass throttling by spoofing forwarded headers.
+
 ### macOS Security Note
 
 If you see an error like **"Claude Hub is damaged and can't be opened"** when running the desktop app, this is macOS Gatekeeper blocking unsigned apps — the app is not actually damaged.

--- a/src/__tests__/auth-login-rate-limit.test.ts
+++ b/src/__tests__/auth-login-rate-limit.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import auth from '../web/api/routes/auth.js';
+import { setupUser } from '../services/auth.service.js';
+import { resetDatabase } from '../db/migrations.js';
+import { closeDatabase } from '../infrastructure/database/sqlite.js';
+import { __resetRateLimitStoreForTests } from '../web/api/middleware/rateLimit.js';
+
+function loginRequest(password: string, forwardedFor: string): Request {
+  return new Request('http://localhost/login', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-forwarded-for': forwardedFor,
+    },
+    body: JSON.stringify({
+      username: 'alice',
+      password,
+    }),
+  });
+}
+
+describe('auth login rate limiting', () => {
+  beforeEach(async () => {
+    resetDatabase();
+    __resetRateLimitStoreForTests();
+    process.env.CLAUDE_HUB_TRUST_PROXY = 'true';
+    await setupUser('alice', 'password123');
+  });
+
+  afterEach(() => {
+    __resetRateLimitStoreForTests();
+    delete process.env.CLAUDE_HUB_TRUST_PROXY;
+    closeDatabase();
+  });
+
+  test('locks a username across rotating trusted proxy addresses', async () => {
+    for (let i = 0; i < 10; i++) {
+      const response = await auth.fetch(loginRequest('wrong-password', `10.0.0.${i}`));
+      expect(response.status).toBe(401);
+    }
+
+    const locked = await auth.fetch(loginRequest('wrong-password', '10.0.0.99'));
+    expect(locked.status).toBe(429);
+  });
+
+  test('successful login resets the per-username failure bucket', async () => {
+    for (let i = 0; i < 9; i++) {
+      const response = await auth.fetch(loginRequest('wrong-password', `10.0.1.${i}`));
+      expect(response.status).toBe(401);
+    }
+
+    const success = await auth.fetch(loginRequest('password123', '10.0.1.50'));
+    expect(success.status).toBe(200);
+
+    const afterReset = await auth.fetch(loginRequest('wrong-password', '10.0.1.51'));
+    expect(afterReset.status).toBe(401);
+  });
+});

--- a/src/__tests__/auth-token-safety.test.ts
+++ b/src/__tests__/auth-token-safety.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for JWT token verification edge cases.
+ *
+ * Focus on the timing-attack hardening of `verifyToken`:
+ * - Forged signatures of *correct length* but wrong content are rejected.
+ * - Forged signatures of *wrong length* are rejected without throwing.
+ * - Tampered payloads (re-encoded body) are rejected because the signature
+ *   no longer matches the recomputed HMAC.
+ * - Valid tokens still verify.
+ *
+ * We do not measure wall-clock timing here (flaky in CI). The point of
+ * `timingSafeEqual` is correctness *and* uniform timing; correctness is the
+ * directly testable guarantee.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { setupUser, verifyToken } from '../services/auth.service.js';
+import { resetDatabase } from '../db/migrations.js';
+import { closeDatabase } from '../infrastructure/database/sqlite.js';
+
+describe('verifyToken hardening', () => {
+  beforeEach(() => {
+    resetDatabase();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test('accepts a freshly-issued token', async () => {
+    const { token } = await setupUser('alice', 'password123');
+    const payload = verifyToken(token);
+    expect(payload).not.toBeNull();
+    expect(payload?.username).toBe('alice');
+  });
+
+  test('rejects a token with the same length but wrong signature', async () => {
+    const { token } = await setupUser('alice', 'password123');
+    const [header, body, signature] = token.split('.');
+    expect(signature).toBeDefined();
+
+    // Flip every character of the signature — preserves length, breaks content.
+    const forged = signature
+      .split('')
+      .map((ch) => (ch === 'A' ? 'B' : 'A'))
+      .join('');
+    expect(forged.length).toBe(signature.length);
+
+    const tampered = `${header}.${body}.${forged}`;
+    expect(verifyToken(tampered)).toBeNull();
+  });
+
+  test('rejects a token whose signature is the wrong length without throwing', async () => {
+    const { token } = await setupUser('alice', 'password123');
+    const [header, body] = token.split('.');
+
+    // Empty signature.
+    expect(() => verifyToken(`${header}.${body}.`)).not.toThrow();
+    expect(verifyToken(`${header}.${body}.`)).toBeNull();
+
+    // Truncated signature (one byte short).
+    const truncated = `${header}.${body}.shortsig`;
+    expect(verifyToken(truncated)).toBeNull();
+
+    // Over-long garbage signature.
+    const overlong = `${header}.${body}.${'a'.repeat(1024)}`;
+    expect(verifyToken(overlong)).toBeNull();
+  });
+
+  test('rejects a token with a re-encoded payload that drops exp', async () => {
+    const { token } = await setupUser('alice', 'password123');
+    const [header, , signature] = token.split('.');
+
+    // Try to forge a body claiming admin without re-signing.
+    const evilBody = Buffer.from(
+      JSON.stringify({
+        sub: 'attacker',
+        username: 'attacker',
+        iat: 0,
+        exp: 9_999_999_999,
+        jti: 'attacker',
+      })
+    ).toString('base64url');
+
+    const forged = `${header}.${evilBody}.${signature}`;
+    expect(verifyToken(forged)).toBeNull();
+  });
+
+  test('rejects garbage input shapes gracefully', () => {
+    expect(verifyToken('')).toBeNull();
+    expect(verifyToken('not-a-token')).toBeNull();
+    expect(verifyToken('a.b')).toBeNull();
+    expect(verifyToken('a.b.c.d')).toBeNull();
+  });
+});

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { Hono } from 'hono';
 import {
   rateLimit,
+  resetRateLimitKey,
   __resetRateLimitStoreForTests,
   __getRateLimitStoreSizeForTests,
 } from '../web/api/middleware/rateLimit.js';
@@ -166,6 +167,20 @@ describe('rateLimit middleware', () => {
     expect(a2.status).toBe(429);
   });
 
+  test('separate middleware instances do not double-count the same address', async () => {
+    const app = new Hono();
+    app.use('*', rateLimit(100, 60_000));
+    app.get('/login', rateLimit(2, 60_000), (c) => c.json({ ok: true }));
+
+    const first = await app.fetch(new Request('http://localhost/login'));
+    const second = await app.fetch(new Request('http://localhost/login'));
+    const third = await app.fetch(new Request('http://localhost/login'));
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(third.status).toBe(429);
+  });
+
   test('async keyExtractor (e.g. body-derived) is awaited', async () => {
     const app = new Hono();
     app.use(
@@ -219,5 +234,33 @@ describe('rateLimit middleware', () => {
     }
 
     expect(__getRateLimitStoreSizeForTests()).toBeLessThanOrEqual(5);
+  });
+
+  test('resetRateLimitKey clears one scoped bucket', async () => {
+    const scope = 'test-login';
+    const app = new Hono();
+    app.use(
+      '*',
+      rateLimit(1, 60_000, {
+        scope,
+        keyExtractor: (c) => `u:${c.req.header('x-user')}`,
+      })
+    );
+    app.get('/login', (c) => c.json({ ok: true }));
+
+    const a = await app.fetch(
+      new Request('http://localhost/login', { headers: { 'x-user': 'alice' } })
+    );
+    const b = await app.fetch(
+      new Request('http://localhost/login', { headers: { 'x-user': 'alice' } })
+    );
+    resetRateLimitKey(scope, 'u:alice');
+    const c = await app.fetch(
+      new Request('http://localhost/login', { headers: { 'x-user': 'alice' } })
+    );
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(429);
+    expect(c.status).toBe(200);
   });
 });

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Integration tests for the hardened rate limiter.
+ *
+ * Covers:
+ * - Authoritative IP cannot be spoofed via x-forwarded-for in default
+ *   (TRUST_PROXY=false) mode.
+ * - Standard IETF rate-limit headers are emitted on every request.
+ * - 429 responses carry Retry-After.
+ * - Custom keyExtractor (sync + async) buckets independently.
+ * - Store size stays bounded under unique-key flooding.
+ *
+ * No mocks: each test wires a fresh Hono app to the real middleware.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { Hono } from 'hono';
+import {
+  rateLimit,
+  __resetRateLimitStoreForTests,
+  __getRateLimitStoreSizeForTests,
+} from '../web/api/middleware/rateLimit.js';
+
+function buildApp(maxRequests: number, windowMs: number) {
+  const app = new Hono();
+  app.use('*', rateLimit(maxRequests, windowMs));
+  app.get('/ping', (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe('rateLimit middleware', () => {
+  beforeEach(() => {
+    __resetRateLimitStoreForTests();
+    delete process.env.CLAUDE_HUB_TRUST_PROXY;
+  });
+
+  afterEach(() => {
+    __resetRateLimitStoreForTests();
+    delete process.env.CLAUDE_HUB_TRUST_PROXY;
+  });
+
+  test('emits IETF rate-limit headers on a normal response', async () => {
+    const app = buildApp(3, 60_000);
+    const res = await app.fetch(new Request('http://localhost/ping'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('3');
+    // First request burns 1, so 2 remain.
+    expect(res.headers.get('X-RateLimit-Remaining')).toBe('2');
+    expect(res.headers.get('X-RateLimit-Reset')).toMatch(/^\d+$/);
+    expect(res.headers.get('Retry-After')).toBeNull();
+  });
+
+  test('returns 429 with Retry-After once the limit is exceeded', async () => {
+    const app = buildApp(2, 60_000);
+
+    const a = await app.fetch(new Request('http://localhost/ping'));
+    const b = await app.fetch(new Request('http://localhost/ping'));
+    const c = await app.fetch(new Request('http://localhost/ping'));
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(c.status).toBe(429);
+    expect(c.headers.get('Retry-After')).toMatch(/^\d+$/);
+    const body = (await c.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Too many requests');
+  });
+
+  test('does NOT trust x-forwarded-for by default — spoofing cannot bypass limit', async () => {
+    // TRUST_PROXY is false (default). All requests should land in the same
+    // anonymous bucket regardless of forwarded values, because synthesised
+    // Request objects in tests have no socket peer.
+    const app = buildApp(2, 60_000);
+
+    const r1 = await app.fetch(
+      new Request('http://localhost/ping', {
+        headers: { 'x-forwarded-for': '1.1.1.1' },
+      })
+    );
+    const r2 = await app.fetch(
+      new Request('http://localhost/ping', {
+        headers: { 'x-forwarded-for': '2.2.2.2' },
+      })
+    );
+    const r3 = await app.fetch(
+      new Request('http://localhost/ping', {
+        headers: { 'x-forwarded-for': '3.3.3.3' },
+      })
+    );
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r3.status).toBe(429);
+  });
+
+  test('honours x-forwarded-for ONLY when CLAUDE_HUB_TRUST_PROXY=true', async () => {
+    process.env.CLAUDE_HUB_TRUST_PROXY = 'true';
+    const app = buildApp(1, 60_000);
+
+    const a = await app.fetch(
+      new Request('http://localhost/ping', {
+        headers: { 'x-forwarded-for': '1.1.1.1' },
+      })
+    );
+    const b = await app.fetch(
+      new Request('http://localhost/ping', {
+        headers: { 'x-forwarded-for': '2.2.2.2' },
+      })
+    );
+
+    // Different forwarded clients, so each has its own bucket.
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+
+    // Same forwarded client second time: blocked.
+    const c = await app.fetch(
+      new Request('http://localhost/ping', {
+        headers: { 'x-forwarded-for': '1.1.1.1' },
+      })
+    );
+    expect(c.status).toBe(429);
+  });
+
+  test('uses left-most address from a comma-separated x-forwarded-for', async () => {
+    process.env.CLAUDE_HUB_TRUST_PROXY = 'true';
+    const app = buildApp(1, 60_000);
+
+    // Both requests claim originating client 9.9.9.9, with different proxy
+    // chains appended. The left-most address must be the bucket key.
+    const a = await app.fetch(
+      new Request('http://localhost/ping', {
+        headers: { 'x-forwarded-for': '9.9.9.9, 10.0.0.1' },
+      })
+    );
+    const b = await app.fetch(
+      new Request('http://localhost/ping', {
+        headers: { 'x-forwarded-for': '9.9.9.9, 10.0.0.2' },
+      })
+    );
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(429);
+  });
+
+  test('custom synchronous keyExtractor buckets independently', async () => {
+    const app = new Hono();
+    app.use(
+      '*',
+      rateLimit(1, 60_000, {
+        keyExtractor: (c) => `tag:${c.req.header('x-tag') ?? 'none'}`,
+      })
+    );
+    app.get('/ping', (c) => c.json({ ok: true }));
+
+    const a = await app.fetch(
+      new Request('http://localhost/ping', { headers: { 'x-tag': 'alice' } })
+    );
+    const b = await app.fetch(
+      new Request('http://localhost/ping', { headers: { 'x-tag': 'bob' } })
+    );
+    const a2 = await app.fetch(
+      new Request('http://localhost/ping', { headers: { 'x-tag': 'alice' } })
+    );
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(a2.status).toBe(429);
+  });
+
+  test('async keyExtractor (e.g. body-derived) is awaited', async () => {
+    const app = new Hono();
+    app.use(
+      '*',
+      rateLimit(1, 60_000, {
+        keyExtractor: async (c) => {
+          const body = (await c.req.raw.clone().json()) as { user?: string };
+          return `u:${body.user ?? 'anon'}`;
+        },
+      })
+    );
+    app.post('/login', (c) => c.json({ ok: true }));
+
+    const post = (user: string) =>
+      app.fetch(
+        new Request('http://localhost/login', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ user }),
+        })
+      );
+
+    const a = await post('alice');
+    const b = await post('bob');
+    const a2 = await post('alice');
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(a2.status).toBe(429);
+  });
+
+  test('store size is bounded by maxKeys', async () => {
+    __resetRateLimitStoreForTests();
+
+    const app = new Hono();
+    app.use(
+      '*',
+      rateLimit(100, 60_000, {
+        keyExtractor: (c) => `k:${c.req.header('x-k')}`,
+        maxKeys: 5,
+      })
+    );
+    app.get('/ping', (c) => c.json({ ok: true }));
+
+    for (let i = 0; i < 50; i++) {
+      await app.fetch(
+        new Request('http://localhost/ping', {
+          headers: { 'x-k': String(i) },
+        })
+      );
+    }
+
+    expect(__getRateLimitStoreSizeForTests()).toBeLessThanOrEqual(5);
+  });
+});

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -4,7 +4,7 @@
  * Handles user management, JWT tokens, and TOTP 2FA.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID, timingSafeEqual } from 'crypto';
 import { queryOne, runSql } from '../infrastructure/database/sqlite.js';
 import { logger } from '../lib/logger.js';
 
@@ -41,6 +41,27 @@ function hmacSign(payload: string): string {
   const hmac = new Bun.CryptoHasher('sha256', getJwtSecret());
   hmac.update(payload);
   return hmac.digest('base64url') as unknown as string;
+}
+
+/**
+ * Constant-time string comparison.
+ *
+ * `!==` short-circuits at the first mismatched byte and leaks the position of
+ * the first differing character through wall-clock time. For HMAC signatures
+ * this lets an attacker recover bytes one at a time. `timingSafeEqual` always
+ * compares both buffers in full and only fails fast on a length mismatch
+ * (which is fine because length is not secret here — both sides are
+ * deterministic SHA-256/base64url encodings of fixed length).
+ */
+function safeEqual(a: string, b: string): boolean {
+  // Length-mismatch shortcut is intentional: HMAC outputs are fixed-length,
+  // so a length difference is guaranteed to be a forgery.
+  if (a.length !== b.length) return false;
+  const bufA = Buffer.from(a, 'utf8');
+  const bufB = Buffer.from(b, 'utf8');
+  // Defensive guard: timingSafeEqual throws on differing lengths.
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
 }
 
 // ── JWT ──
@@ -87,7 +108,7 @@ export function verifyToken(token: string): JwtPayload | null {
 
     const [header, body, signature] = parts;
     const expectedSig = hmacSign(`${header}.${body}`);
-    if (signature !== expectedSig) return null;
+    if (!safeEqual(signature, expectedSig)) return null;
 
     const payload = JSON.parse(Buffer.from(body, 'base64url').toString()) as JwtPayload;
     if (payload.exp < Math.floor(Date.now() / 1000)) return null;

--- a/src/web/api/middleware/rateLimit.ts
+++ b/src/web/api/middleware/rateLimit.ts
@@ -1,38 +1,181 @@
 /**
  * Rate Limiting Middleware
  *
- * Simple in-memory rate limiter for API endpoints
+ * Hardened in-memory rate limiter for API endpoints.
+ *
+ * Design notes:
+ * - Default key is the authoritative connection address from Hono's
+ *   `getConnInfo` (Bun adapter), so callers cannot bypass the limiter by
+ *   spoofing `x-forwarded-for`. Forwarded headers are only honored when
+ *   `CLAUDE_HUB_TRUST_PROXY=true`, in which case the *left-most* address of
+ *   `x-forwarded-for` is used (RFC 7239 / Express convention).
+ * - When neither a connection address nor a trusted forwarded header is
+ *   available, the request is bucketed under a stable per-process anonymous
+ *   key (`__noaddr__`) so missing metadata cannot silently merge every
+ *   client into a single shared bucket.
+ * - Each response carries the IETF rate-limit headers
+ *   (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`).
+ *   On a 429 we additionally set `Retry-After` per RFC 6585.
+ * - The internal store is bounded by `maxKeys` and uses simple insertion-
+ *   order eviction so a flood of unique keys cannot exhaust memory.
+ * - The cleanup timer is `unref()`-ed so it does not pin the runtime open
+ *   during shutdown.
+ * - A custom `keyExtractor` lets callers (e.g. login routes) rate-limit per
+ *   username instead of per IP, which materially raises the cost of
+ *   credential-stuffing across rotating proxies.
  */
 
+import type { Context, Next } from 'hono';
+import { getConnInfo } from 'hono/bun';
 import { logger } from '../../../lib/logger.js';
 
-// Simple in-memory rate limiter
-const rateLimitStore = new Map<string, { count: number; resetTime: number }>();
+/**
+ * Trust forwarded headers? Read on every request so operators can flip it
+ * without restarting (and so tests can exercise both modes without splitting
+ * across processes). The check is a single env-var read; the cost is
+ * negligible relative to the rest of the request path.
+ *
+ * Off by default — Claude Hub binds to loopback only by default.
+ */
+function trustProxy(): boolean {
+  return process.env.CLAUDE_HUB_TRUST_PROXY === 'true';
+}
 
-export function rateLimit(maxRequests: number, windowMs: number) {
-  return async (c: any, next: () => Promise<void>) => {
-    const ip = c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown';
+/** Hard cap on distinct keys before recency eviction kicks in. */
+const DEFAULT_MAX_KEYS = 10_000;
+
+/** Stable bucket name for callers we cannot identify by address. */
+export const ANON_RATE_LIMIT_KEY = '__noaddr__';
+
+interface RateLimitRecord {
+  count: number;
+  resetTime: number;
+}
+
+/** Map insertion order is preserved; we exploit that for FIFO eviction. */
+const rateLimitStore = new Map<string, RateLimitRecord>();
+
+export interface RateLimitOptions {
+  /**
+   * Custom key extractor (e.g. for per-username login lockout).
+   * May return a string or a `Promise<string>`; for async extractors that
+   * need to peek at the request body, use `c.req.raw.clone().json()` so that
+   * downstream handlers can still read the original body.
+   */
+  keyExtractor?: (c: Context) => string | Promise<string>;
+  /** Hard cap for the in-memory store. Defaults to 10k keys. */
+  maxKeys?: number;
+}
+
+/**
+ * Read the *first* (left-most) address from a forwarded header value.
+ * Per RFC 7239 / X-Forwarded-For convention, the originating client is the
+ * left-most entry; intermediate proxies append on the right. Only consulted
+ * when `TRUST_PROXY` is enabled.
+ */
+function firstForwardedAddress(headerValue: string | undefined): string | undefined {
+  if (!headerValue) return undefined;
+  const first = headerValue.split(',')[0]?.trim();
+  return first ? first : undefined;
+}
+
+/** Resolve the authoritative remote address for a request. */
+function resolveAddress(c: Context): string {
+  if (trustProxy()) {
+    const fwd =
+      firstForwardedAddress(c.req.header('x-forwarded-for')) ||
+      c.req.header('x-real-ip');
+    if (fwd) return fwd;
+  }
+
+  // Fall back to the actual TCP peer that opened the socket.
+  try {
+    const info = getConnInfo(c);
+    const addr = info.remote?.address;
+    if (addr) return addr;
+  } catch {
+    // getConnInfo may throw if the request is synthesised in tests.
+  }
+
+  return ANON_RATE_LIMIT_KEY;
+}
+
+/** Bound the store size via simple insertion-order (FIFO) eviction. */
+function evictIfNeeded(maxKeys: number): void {
+  if (rateLimitStore.size <= maxKeys) return;
+  const overflow = rateLimitStore.size - maxKeys;
+  let removed = 0;
+  for (const key of rateLimitStore.keys()) {
+    if (removed >= overflow) break;
+    rateLimitStore.delete(key);
+    removed++;
+  }
+}
+
+export function rateLimit(
+  maxRequests: number,
+  windowMs: number,
+  options: RateLimitOptions = {}
+) {
+  const { keyExtractor, maxKeys = DEFAULT_MAX_KEYS } = options;
+
+  return async (c: Context, next: Next) => {
+    const key = keyExtractor
+      ? await keyExtractor(c)
+      : `ip:${resolveAddress(c)}`;
     const now = Date.now();
 
-    let record = rateLimitStore.get(ip);
+    let record = rateLimitStore.get(key);
     if (!record || now > record.resetTime) {
       record = { count: 0, resetTime: now + windowMs };
-      rateLimitStore.set(ip, record);
+      // Re-insert to refresh recency for FIFO eviction.
+      rateLimitStore.delete(key);
+      rateLimitStore.set(key, record);
+      evictIfNeeded(maxKeys);
     }
 
     record.count++;
 
+    const remaining = Math.max(0, maxRequests - record.count);
+    const resetSeconds = Math.ceil(record.resetTime / 1000);
+
+    // IETF rate-limit headers, present on every response.
+    c.header('X-RateLimit-Limit', String(maxRequests));
+    c.header('X-RateLimit-Remaining', String(remaining));
+    c.header('X-RateLimit-Reset', String(resetSeconds));
+
     if (record.count > maxRequests) {
-      logger.warn('Rate limit exceeded', { ip, count: record.count });
-      return c.json({ success: false, error: 'Too many requests' }, 429);
+      const retryAfter = Math.max(1, Math.ceil((record.resetTime - now) / 1000));
+      c.header('Retry-After', String(retryAfter));
+      // Don't log the raw key (may be PII); log scope only.
+      logger.warn('Rate limit exceeded', {
+        scope: keyExtractor ? 'custom' : 'address',
+        count: record.count,
+        limit: maxRequests,
+      });
+      return c.json(
+        { success: false, error: 'Too many requests' },
+        429
+      );
     }
 
     await next();
   };
 }
 
-// Clean up rate limit store periodically (every 5 minutes)
-setInterval(() => {
+/** Reset the in-memory store. Test-only helper. */
+export function __resetRateLimitStoreForTests(): void {
+  rateLimitStore.clear();
+}
+
+/** Inspect the current store size. Test-only helper. */
+export function __getRateLimitStoreSizeForTests(): number {
+  return rateLimitStore.size;
+}
+
+// Periodic GC: drop expired records every 5 minutes. `unref()` so we don't
+// keep the Bun event loop alive on shutdown.
+const cleanupTimer = setInterval(() => {
   const now = Date.now();
   for (const [key, value] of rateLimitStore.entries()) {
     if (now > value.resetTime) {
@@ -40,3 +183,8 @@ setInterval(() => {
     }
   }
 }, 5 * 60 * 1000);
+
+// Bun's setInterval handle exposes `unref` but the global `Timer` typing
+// does not always include it — guard at runtime.
+type MaybeUnref = { unref?: () => void };
+(cleanupTimer as unknown as MaybeUnref).unref?.();

--- a/src/web/api/middleware/rateLimit.ts
+++ b/src/web/api/middleware/rateLimit.ts
@@ -54,6 +54,7 @@ interface RateLimitRecord {
 
 /** Map insertion order is preserved; we exploit that for FIFO eviction. */
 const rateLimitStore = new Map<string, RateLimitRecord>();
+let nextScopeId = 0;
 
 export interface RateLimitOptions {
   /**
@@ -63,6 +64,11 @@ export interface RateLimitOptions {
    * downstream handlers can still read the original body.
    */
   keyExtractor?: (c: Context) => string | Promise<string>;
+  /**
+   * Namespace this limiter instance. Defaults to a unique per-middleware
+   * scope so global and route-local limiters do not double-count each other.
+   */
+  scope?: string;
   /** Hard cap for the in-memory store. Defaults to 10k keys. */
   maxKeys?: number;
 }
@@ -80,7 +86,7 @@ function firstForwardedAddress(headerValue: string | undefined): string | undefi
 }
 
 /** Resolve the authoritative remote address for a request. */
-function resolveAddress(c: Context): string {
+export function getClientIp(c: Context): string {
   if (trustProxy()) {
     const fwd =
       firstForwardedAddress(c.req.header('x-forwarded-for')) ||
@@ -118,11 +124,13 @@ export function rateLimit(
   options: RateLimitOptions = {}
 ) {
   const { keyExtractor, maxKeys = DEFAULT_MAX_KEYS } = options;
+  const scope = options.scope ?? `limit:${++nextScopeId}`;
 
   return async (c: Context, next: Next) => {
-    const key = keyExtractor
+    const rawKey = keyExtractor
       ? await keyExtractor(c)
-      : `ip:${resolveAddress(c)}`;
+      : `ip:${getClientIp(c)}`;
+    const key = `${scope}:${rawKey}`;
     const now = Date.now();
 
     let record = rateLimitStore.get(key);
@@ -149,7 +157,8 @@ export function rateLimit(
       c.header('Retry-After', String(retryAfter));
       // Don't log the raw key (may be PII); log scope only.
       logger.warn('Rate limit exceeded', {
-        scope: keyExtractor ? 'custom' : 'address',
+        scope,
+        keyType: keyExtractor ? 'custom' : 'address',
         count: record.count,
         limit: maxRequests,
       });
@@ -161,6 +170,11 @@ export function rateLimit(
 
     await next();
   };
+}
+
+/** Clear one bucket, used after successful auth to count failures only. */
+export function resetRateLimitKey(scope: string, key: string): void {
+  rateLimitStore.delete(`${scope}:${key}`);
 }
 
 /** Reset the in-memory store. Test-only helper. */

--- a/src/web/api/routes/auth.ts
+++ b/src/web/api/routes/auth.ts
@@ -6,7 +6,7 @@
 
 import type { Context } from 'hono';
 import { Hono } from 'hono';
-import { rateLimit } from '../middleware/rateLimit.js';
+import { getClientIp, rateLimit, resetRateLimitKey } from '../middleware/rateLimit.js';
 import { authMiddleware } from '../middleware/auth.js';
 import {
   isSetupComplete,
@@ -18,6 +18,11 @@ import {
 import type { JwtPayload } from '../../../services/auth.service.js';
 
 const auth = new Hono();
+const LOGIN_USERNAME_RATE_LIMIT_SCOPE = 'auth-login-username';
+
+function loginUsernameRateLimitKey(username: string): string {
+  return `login:${username.slice(0, 64).toLowerCase()}`;
+}
 
 /**
  * Defence-in-depth limit: lock out the *username* after too many failed
@@ -34,8 +39,7 @@ async function loginUsernameKey(c: Context): Promise<string> {
     const cloned = c.req.raw.clone();
     const body = (await cloned.json()) as { username?: unknown };
     if (typeof body.username === 'string' && body.username.length > 0) {
-      // Length-cap to avoid pathological keys exhausting memory.
-      return `login:${body.username.slice(0, 64).toLowerCase()}`;
+      return loginUsernameRateLimitKey(body.username);
     }
   } catch {
     // fall through
@@ -80,7 +84,7 @@ auth.post('/setup', rateLimit(5, 60 * 1000), async (c) => {
     }
 
     const result = await setupUser(username, password, enableTotp);
-    const ip = c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown';
+    const ip = getClientIp(c);
     logAudit(null, 'setup_complete', ip);
 
     return c.json({ success: true, data: result });
@@ -97,7 +101,10 @@ auth.post('/setup', rateLimit(5, 60 * 1000), async (c) => {
 auth.post(
   '/login',
   rateLimit(10, 60 * 1000),
-  rateLimit(10, 5 * 60 * 1000, { keyExtractor: loginUsernameKey }),
+  rateLimit(10, 5 * 60 * 1000, {
+    keyExtractor: loginUsernameKey,
+    scope: LOGIN_USERNAME_RATE_LIMIT_SCOPE,
+  }),
   async (c) => {
   try {
     const body = await c.req.json();
@@ -108,12 +115,13 @@ auth.post(
     }
 
     const result = await login(username, password, totpCode);
-    const ip = c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown';
+    resetRateLimitKey(LOGIN_USERNAME_RATE_LIMIT_SCOPE, loginUsernameRateLimitKey(username));
+    const ip = getClientIp(c);
     logAudit(null, 'login_success', ip, `User: ${username}`);
 
     return c.json({ success: true, data: result });
   } catch (e) {
-    const ip = c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown';
+    const ip = getClientIp(c);
     logAudit(null, 'login_failed', ip);
     const message = e instanceof Error ? e.message : 'Login failed';
     return c.json({ success: false, error: message }, 401);

--- a/src/web/api/routes/auth.ts
+++ b/src/web/api/routes/auth.ts
@@ -4,6 +4,7 @@
  * Handles setup, login, logout, and status checks.
  */
 
+import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { rateLimit } from '../middleware/rateLimit.js';
 import { authMiddleware } from '../middleware/auth.js';
@@ -17,6 +18,30 @@ import {
 import type { JwtPayload } from '../../../services/auth.service.js';
 
 const auth = new Hono();
+
+/**
+ * Defence-in-depth limit: lock out the *username* after too many failed
+ * attempts inside the window, regardless of source IP. This is what
+ * blocks credential-stuffing through rotating proxies — the per-IP limit
+ * alone is bypassed once the attacker has more IPs than the limit.
+ *
+ * We extract the username out-of-band by peeking at the request body. The
+ * extractor must not throw; on any failure we fall back to the constant
+ * `unknown` bucket which still applies a small global cap.
+ */
+async function loginUsernameKey(c: Context): Promise<string> {
+  try {
+    const cloned = c.req.raw.clone();
+    const body = (await cloned.json()) as { username?: unknown };
+    if (typeof body.username === 'string' && body.username.length > 0) {
+      // Length-cap to avoid pathological keys exhausting memory.
+      return `login:${body.username.slice(0, 64).toLowerCase()}`;
+    }
+  } catch {
+    // fall through
+  }
+  return 'login:__unknown__';
+}
 
 // GET /api/auth/status - Check if setup is complete and if user is authenticated
 auth.get('/status', async (c) => {
@@ -65,8 +90,15 @@ auth.post('/setup', rateLimit(5, 60 * 1000), async (c) => {
   }
 });
 
-// POST /api/auth/login - Authenticate
-auth.post('/login', rateLimit(10, 60 * 1000), async (c) => {
+// POST /api/auth/login - Authenticate.
+// Two-layer rate limit: per-IP (default) AND per-username. The per-username
+// layer makes credential-stuffing across rotating proxies expensive: 10
+// attempts per username per 5 minutes regardless of source IP.
+auth.post(
+  '/login',
+  rateLimit(10, 60 * 1000),
+  rateLimit(10, 5 * 60 * 1000, { keyExtractor: loginUsernameKey }),
+  async (c) => {
   try {
     const body = await c.req.json();
     const { username, password, totpCode } = body;


### PR DESCRIPTION
## Summary

Tightens the web-terminal auth and rate-limit code:

1. **JWT verification is constant-time.** Replaces short-circuit HMAC signature comparison with `crypto.timingSafeEqual` while still rejecting wrong-length signatures safely.

2. **Rate limiter no longer trusts forwarded headers by default.** It keys on the authoritative Bun/Hono connection address, and only honors `X-Forwarded-For` / `X-Real-IP` when `CLAUDE_HUB_TRUST_PROXY=true`.

3. **Rate-limit responses expose backoff metadata.** Normal responses include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset`; 429s also include `Retry-After`.

4. **The in-memory limiter is bounded and shutdown-friendly.** It caps keys with FIFO eviction and `unref()`s its cleanup timer.

5. **Login has a per-username throttle in addition to per-IP throttling.** The username bucket is scoped separately from global/route IP buckets, so layered middleware does not double-count. Successful login clears the username failure bucket.

6. **Audit IP capture now uses the same trusted-proxy logic** instead of directly trusting forwarded headers.

Also documents `CLAUDE_HUB_TRUST_PROXY` in README.

## Test plan

- [x] `bun test` — 191 passing, 0 failing
- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean; Vite reports the existing >500k chunk-size warning
- [x] Added regression coverage:
  - JWT forged/wrong-length/tampered token rejection
  - XFF ignored by default and honored only with `CLAUDE_HUB_TRUST_PROXY=true`
  - IETF rate-limit headers and `Retry-After`
  - bounded rate-limit store
  - separate middleware scopes so global + route limiters do not double-count
  - per-username login lockout across rotating trusted proxy addresses
  - successful login resets the per-username failure bucket