### PR TITLE
fix(client): correct /sync endpoint path to /sessions/sync

### DIFF
--- a/src/web/client/src/services/api.ts
+++ b/src/web/client/src/services/api.ts
@@ -124,10 +124,10 @@ export async function fetchSessions(
 }
 
 /**
- * POST /api/sync - Sync sessions with filesystem
+ * POST /api/sessions/sync - Sync sessions with filesystem
  */
 export async function syncSessions(signal?: AbortSignal): Promise<ApiResponse<SyncResult>> {
-  return request<SyncResult>('/sync', { method: 'POST' }, signal)
+  return request<SyncResult>('/sessions/sync', { method: 'POST' }, signal)
 }
 
 /**


### PR DESCRIPTION
Fixes #12.

The web client was calling \`POST /api/sync\` but the route is registered inside the sessions router at \`/sessions/sync\` (mounted at \`/api/sessions\`). Result: 404, "Manual sync" button silently did nothing.

This switches the client to the correct path. One file, two-line change.

## Test plan
- [x] \`bunx tsc --noEmit\` passes
- [ ] In dashboard, click "Manual sync" — should now hit \`/api/sessions/sync\` and return a real response