### PR TITLE
fix(auth): timing-safe JWT compare, trusted-proxy IP, per-username login cap

### DIFF
--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -4,7 +4,7 @@
  * Handles user management, JWT tokens, and TOTP 2FA.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID, timingSafeEqual } from 'crypto';
 import { queryOne, runSql } from '../infrastructure/database/sqlite.js';
 import { logger } from '../lib/logger.js';
 
@@ -87,7 +87,10 @@ export function verifyToken(token: string): JwtPayload | null {
 
     const [header, body, signature] = parts;
     const expectedSig = hmacSign(`${header}.${body}`);
-    if (signature !== expectedSig) return null;
+    const sigBuf = Buffer.from(signature, 'utf8');
+    const expBuf = Buffer.from(expectedSig, 'utf8');
+    if (sigBuf.length !== expBuf.length) return null;
+    if (!timingSafeEqual(sigBuf, expBuf)) return null;
 
     const payload = JSON.parse(Buffer.from(body, 'base64url').toString()) as JwtPayload;
     if (payload.exp < Math.floor(Date.now() / 1000)) return null;

--- a/src/web/api/middleware/rateLimit.ts
+++ b/src/web/api/middleware/rateLimit.ts
@@ -4,14 +4,38 @@
  * Simple in-memory rate limiter for API endpoints
  */
 
+import { getConnInfo } from 'hono/bun';
 import { logger } from '../../../lib/logger.js';
 
 // Simple in-memory rate limiter
 const rateLimitStore = new Map<string, { count: number; resetTime: number }>();
 
+/**
+ * Resolve the client IP for rate-limiting and audit logging.
+ *
+ * `x-forwarded-for` / `x-real-ip` are client-controlled when no proxy
+ * fronts the server, so an attacker on the same loopback can rotate the
+ * header to bypass per-IP limits. Only honor those headers when
+ * `TRUSTED_PROXY=true` is explicitly set; otherwise fall back to the
+ * actual socket peer reported by Bun.
+ */
+export function getClientIp(c: any): string {
+  if (process.env.TRUSTED_PROXY === 'true') {
+    const xff = c.req.header('x-forwarded-for');
+    if (xff) return xff.split(',')[0]!.trim();
+    const xri = c.req.header('x-real-ip');
+    if (xri) return xri;
+  }
+  try {
+    return getConnInfo(c).remote.address ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
 export function rateLimit(maxRequests: number, windowMs: number) {
   return async (c: any, next: () => Promise<void>) => {
-    const ip = c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown';
+    const ip = getClientIp(c);
     const now = Date.now();
 
     let record = rateLimitStore.get(ip);

--- a/src/web/api/routes/auth.ts
+++ b/src/web/api/routes/auth.ts
@@ -5,7 +5,7 @@
  */
 
 import { Hono } from 'hono';
-import { rateLimit } from '../middleware/rateLimit.js';
+import { rateLimit, getClientIp } from '../middleware/rateLimit.js';
 import { authMiddleware } from '../middleware/auth.js';
 import {
   isSetupComplete,
@@ -17,6 +17,20 @@ import {
 import type { JwtPayload } from '../../../services/auth.service.js';
 
 const auth = new Hono();
+
+// Per-username login attempt counter, in addition to the per-IP rateLimit
+// middleware. Bounds brute-force against a single account even when an
+// attacker rotates IPs.
+const usernameLoginAttempts = new Map<string, { count: number; resetTime: number }>();
+const LOGIN_ATTEMPTS_PER_USERNAME = 5;
+const LOGIN_USERNAME_WINDOW_MS = 15 * 60 * 1000;
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [k, v] of usernameLoginAttempts.entries()) {
+    if (now > v.resetTime) usernameLoginAttempts.delete(k);
+  }
+}, LOGIN_USERNAME_WINDOW_MS);
 
 // GET /api/auth/status - Check if setup is complete and if user is authenticated
 auth.get('/status', async (c) => {
@@ -55,7 +69,7 @@ auth.post('/setup', rateLimit(5, 60 * 1000), async (c) => {
     }
 
     const result = await setupUser(username, password, enableTotp);
-    const ip = c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown';
+    const ip = getClientIp(c);
     logAudit(null, 'setup_complete', ip);
 
     return c.json({ success: true, data: result });
@@ -67,6 +81,7 @@ auth.post('/setup', rateLimit(5, 60 * 1000), async (c) => {
 
 // POST /api/auth/login - Authenticate
 auth.post('/login', rateLimit(10, 60 * 1000), async (c) => {
+  const ip = getClientIp(c);
   try {
     const body = await c.req.json();
     const { username, password, totpCode } = body;
@@ -75,13 +90,26 @@ auth.post('/login', rateLimit(10, 60 * 1000), async (c) => {
       return c.json({ success: false, error: 'Username and password required' }, 400);
     }
 
+    // Per-username attempt cap (in addition to per-IP middleware above).
+    const now = Date.now();
+    let record = usernameLoginAttempts.get(username);
+    if (!record || now > record.resetTime) {
+      record = { count: 0, resetTime: now + LOGIN_USERNAME_WINDOW_MS };
+      usernameLoginAttempts.set(username, record);
+    }
+    if (record.count >= LOGIN_ATTEMPTS_PER_USERNAME) {
+      logAudit(null, 'login_locked', ip, `User: ${username}`);
+      return c.json({ success: false, error: 'Too many attempts for this account' }, 429);
+    }
+    record.count++;
+
     const result = await login(username, password, totpCode);
-    const ip = c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown';
+    // Reset on success so legitimate users are not locked out by retries.
+    usernameLoginAttempts.delete(username);
     logAudit(null, 'login_success', ip, `User: ${username}`);
 
     return c.json({ success: true, data: result });
   } catch (e) {
-    const ip = c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown';
     logAudit(null, 'login_failed', ip);
     const message = e instanceof Error ? e.message : 'Login failed';
     return c.json({ success: false, error: message }, 401);


### PR DESCRIPTION
Fixes #16.

Three small security hardening changes, all in the auth path.

## Changes

**1. Timing-safe JWT compare** — \`src/services/auth.service.ts:90\`
Replace \`!==\` on the HMAC signature with \`crypto.timingSafeEqual\`. Lengths are checked first (both are equal-length base64url) to avoid throw on mismatch.

**2. Trusted-proxy XFF gate** — \`src/web/api/middleware/rateLimit.ts\`
Extracted \`getClientIp(c)\` helper. \`x-forwarded-for\` / \`x-real-ip\` are only honored when \`TRUSTED_PROXY=true\` env var is explicitly set; otherwise fall back to the actual socket peer via Hono's \`getConnInfo\`. Closes the per-IP rate-limit bypass via spoofed XFF on loopback.

**3. Per-username login cap** — \`src/web/api/routes/auth.ts:69\`
Layered on top of the per-IP middleware: 5 attempts per username per 15 min. Bounds account-targeted brute-force even when the attacker rotates IPs. Counter resets on successful login so legitimate retries don't lock accounts.

## Test plan
- [x] \`bunx tsc --noEmit\` passes
- [x] All 174 existing tests pass (\`bun test src/__tests__/\`)
- [ ] Verify behind a real proxy: \`TRUSTED_PROXY=true\` honors XFF; without it, the peer address is used
- [ ] Verify per-username lock triggers after 5 wrong passwords from different IPs