### PR TITLE
fix: surface error states instead of silent zero-data fallbacks

### DIFF
--- a/menubar-tauri/src-tauri/src/codex.rs
+++ b/menubar-tauri/src-tauri/src/codex.rs
@@ -29,6 +29,9 @@ pub struct CodexStats {
     pub today_sessions: u32,
     #[serde(rename = "lastActivity")]
     pub last_activity: Option<String>,
+    /// Set when the stats could not be computed (e.g. file unreadable).
+    /// `None` and zero counts means "no history yet" — not an error.
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -244,26 +247,30 @@ pub async fn get_codex_stats() -> Result<CodexStats, String> {
                 total_sessions: 0,
                 today_sessions: 0,
                 last_activity: None,
+                error: Some("Could not find home directory".to_string()),
             });
         }
     };
 
     let history_file = codex_home.join("history.jsonl");
     if !history_file.exists() {
+        // Genuinely no history yet, not an error.
         return Ok(CodexStats {
             total_sessions: 0,
             today_sessions: 0,
             last_activity: None,
+            error: None,
         });
     }
 
     let file = match fs::File::open(&history_file) {
         Ok(f) => f,
-        Err(_) => {
+        Err(e) => {
             return Ok(CodexStats {
                 total_sessions: 0,
                 today_sessions: 0,
                 last_activity: None,
+                error: Some(format!("Failed to read history.jsonl: {}", e)),
             });
         }
     };
@@ -302,6 +309,7 @@ pub async fn get_codex_stats() -> Result<CodexStats, String> {
         total_sessions,
         today_sessions,
         last_activity,
+        error: None,
     })
 }
 

--- a/menubar-tauri/src/components/CodexPanel.tsx
+++ b/menubar-tauri/src/components/CodexPanel.tsx
@@ -14,6 +14,7 @@ interface CodexStats {
   totalSessions: number;
   todaySessions: number;
   lastActivity?: string;
+  error?: string;
 }
 
 interface CodexRateLimitWindow {
@@ -124,6 +125,8 @@ export default function CodexPanel({ onConnectionChange, onUsageChange }: CodexP
         setError(limits.error);
       } else if (info.error) {
         setError(info.error);
+      } else if (stats.error) {
+        setError(stats.error);
       }
 
       // Notify parent about connection status change

--- a/src/services/pty.manager.ts
+++ b/src/services/pty.manager.ts
@@ -122,7 +122,11 @@ class PtyManager {
       this.appendScrollback(session, data);
       const msg = JSON.stringify({ type: 'term:output', data: { sessionId, data } });
       for (const client of session.attachedClients) {
-        try { client.send(msg); } catch { /* client gone */ }
+        try {
+          client.send(msg);
+        } catch (e) {
+          logger.debug(`PTY ${sessionId}: client send failed (likely disconnected)`, e);
+        }
       }
     });
 
@@ -132,7 +136,11 @@ class PtyManager {
       session.exitCode = exitCode;
       const msg = JSON.stringify({ type: 'term:exited', data: { sessionId, exitCode } });
       for (const client of session.attachedClients) {
-        try { client.send(msg); } catch { /* client gone */ }
+        try {
+          client.send(msg);
+        } catch (e) {
+          logger.debug(`PTY ${sessionId}: client send (exit) failed`, e);
+        }
       }
       // Update DB
       runSql(

--- a/src/web/api/terminal-websocket.ts
+++ b/src/web/api/terminal-websocket.ts
@@ -21,7 +21,9 @@ const clientState = new WeakMap<ServerWebSocket<any>, TerminalWsState>();
 function send(ws: ServerWebSocket<any>, msg: object) {
   try {
     ws.send(JSON.stringify(msg));
-  } catch { /* client gone */ }
+  } catch (e) {
+    logger.debug('Terminal WS send failed (client likely disconnected)', e);
+  }
 }
 
 export const terminalWebsocketHandler = {


### PR DESCRIPTION
Refs #15. Addresses the two clearly real silent-degradation cases the audit flagged.

## Changes

**1. CodexStats now distinguishes \"no history yet\" from \"unreadable\"**
\`menubar-tauri/src-tauri/src/codex.rs\` — added \`error: Option<String>\` to the struct. Three branches now have distinct semantics:
- Missing home dir → \`error\` set, counts zero
- \`history.jsonl\` missing → \`error: None\`, counts zero (genuinely no history)
- File unreadable (permissions / corrupt) → \`error\` set with the io message

\`menubar-tauri/src/components/CodexPanel.tsx\` reads \`stats.error\` and routes it through the existing error banner.

**2. WS send swallow → debug log**
\`src/services/pty.manager.ts\` (term:output, term:exited broadcasts) and \`src/web/api/terminal-websocket.ts\` (helper send) — replace silent \`try { ... } catch { /* client gone */ }\` with \`logger.debug(...)\`. Routine disconnects stay quiet at info+ level; real send failures (backpressure) are now traceable.

## Scope I deliberately left out

The audit also flagged \`src/web/api/routes/sessions.ts:294-345\` zero-data fallbacks. Re-reading the code, those zeros only fire when \`usageStats\` is undefined — which is the genuine \"no API calls yet\" state, not a parse failure. The catch arms below already return HTTP 500. Not a bug as written.

The audit also flagged the audit-log swallow at \`auth.service.ts:203\`. That already calls \`logger.error\`, so it's not silent.

## Test plan
- [x] \`bunx tsc --noEmit\` (root + menubar-tauri) clean
- [x] \`cargo check\` (menubar-tauri/src-tauri) clean
- [x] All 174 existing tests pass