### PR TITLE
fix(config): honor runtime CLAUDE_HUB_HOME override; drop dead TASKER aliases

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,7 +4,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { CLAUDE_HUB_HOME, ensureClaudeHubDataHome } from './paths.js';
+import { ensureClaudeHubDataHome, getClaudeHubHome } from './paths.js';
 import { ConfigError } from './errors.js';
 
 export interface ClaudeHubConfig {
@@ -79,7 +79,13 @@ const defaultConfig: ClaudeHubConfig = {
   },
 };
 
-const CONFIG_FILE = join(CLAUDE_HUB_HOME, 'config.json');
+/**
+ * Resolve the config file path lazily so a runtime CLAUDE_HUB_HOME override
+ * (set after this module imports) still routes reads/writes correctly.
+ */
+function getConfigFile(): string {
+  return join(getClaudeHubHome(), 'config.json');
+}
 
 /** Validate config values are within acceptable ranges */
 function validateConfig(cfg: ClaudeHubConfig): void {
@@ -123,10 +129,11 @@ class ConfigManager {
     if (this.loaded) return this.config;
 
     ensureClaudeHubDataHome();
+    const configFile = getConfigFile();
 
-    if (existsSync(CONFIG_FILE)) {
+    if (existsSync(configFile)) {
       try {
-        const content = readFileSync(CONFIG_FILE, 'utf-8');
+        const content = readFileSync(configFile, 'utf-8');
         const parsed = JSON.parse(content) as Partial<ClaudeHubConfig>;
         this.config = { ...defaultConfig, ...parsed };
 
@@ -147,10 +154,11 @@ class ConfigManager {
   }
 
   save(): void {
-    if (!existsSync(CLAUDE_HUB_HOME)) {
-      mkdirSync(CLAUDE_HUB_HOME, { recursive: true });
+    const home = getClaudeHubHome();
+    if (!existsSync(home)) {
+      mkdirSync(home, { recursive: true });
     }
-    writeFileSync(CONFIG_FILE, JSON.stringify(this.config, null, 2));
+    writeFileSync(getConfigFile(), JSON.stringify(this.config, null, 2));
   }
 
   get(): ClaudeHubConfig {

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -21,29 +21,51 @@ export const CLAUDE_SETTINGS = join(CLAUDE_HOME, 'settings.json');
 /** Legacy Tasker data directory */
 export const LEGACY_TASKER_HOME = join(homedir(), '.tasker');
 
-/** Claude Hub data directory */
-export const CLAUDE_HUB_HOME = process.env.CLAUDE_HUB_HOME || join(homedir(), '.claude-hub');
+/**
+ * Resolve the Claude Hub data directory from the current environment.
+ *
+ * Re-reads `process.env.CLAUDE_HUB_HOME` every call so a CLI flag that
+ * sets the env var after this module is imported still takes effect.
+ */
+export function getClaudeHubHome(): string {
+  return process.env.CLAUDE_HUB_HOME || join(homedir(), '.claude-hub');
+}
 
-/** Claude Hub database file */
-export const CLAUDE_HUB_DB = join(CLAUDE_HUB_HOME, 'claude-hub.db');
+/** Claude Hub database file (re-resolved each call). */
+export function getClaudeHubDb(): string {
+  return join(getClaudeHubHome(), 'claude-hub.db');
+}
 
-/** Claude Hub log file */
-export const CLAUDE_HUB_LOG = join(CLAUDE_HUB_HOME, 'claude-hub.log');
+/** Claude Hub log file (re-resolved each call). */
+export function getClaudeHubLog(): string {
+  return join(getClaudeHubHome(), 'claude-hub.log');
+}
 
-/** Claude Hub PID file for daemon */
-export const CLAUDE_HUB_PID = join(CLAUDE_HUB_HOME, 'claude-hub.pid');
+/** Claude Hub PID file for daemon (re-resolved each call). */
+export function getClaudeHubPid(): string {
+  return join(getClaudeHubHome(), 'claude-hub.pid');
+}
 
 /**
- * Backward-compatible aliases. New code should prefer CLAUDE_HUB_* names.
+ * Module-load-time snapshot of the data directory.
+ *
+ * Kept for back-compat with consumers that read it as a constant. New code
+ * should prefer `getClaudeHubHome()` so a runtime env override is honored.
  */
-export const TASKER_HOME = CLAUDE_HUB_HOME;
-export const TASKER_DB = CLAUDE_HUB_DB;
-export const TASKER_LOG = CLAUDE_HUB_LOG;
-export const TASKER_PID = CLAUDE_HUB_PID;
+export const CLAUDE_HUB_HOME = getClaudeHubHome();
+
+/** Claude Hub database file (load-time snapshot). */
+export const CLAUDE_HUB_DB = getClaudeHubDb();
+
+/** Claude Hub log file (load-time snapshot). */
+export const CLAUDE_HUB_LOG = getClaudeHubLog();
+
+/** Claude Hub PID file (load-time snapshot). */
+export const CLAUDE_HUB_PID = getClaudeHubPid();
 
 export function migrateClaudeHubDataHome(
   legacyHome: string = LEGACY_TASKER_HOME,
-  nextHome: string = CLAUDE_HUB_HOME
+  nextHome: string = getClaudeHubHome()
 ): void {
   if (nextHome === legacyHome) return;
   if (existsSync(nextHome) || !existsSync(legacyHome)) return;
@@ -59,11 +81,12 @@ export function migrateClaudeHubDataHome(
 
 /** Ensure the Claude Hub data directory exists, migrating legacy Tasker data if needed. */
 export function ensureClaudeHubDataHome(): string {
-  migrateClaudeHubDataHome();
-  if (!existsSync(CLAUDE_HUB_HOME)) {
-    mkdirSync(CLAUDE_HUB_HOME, { recursive: true });
+  const home = getClaudeHubHome();
+  migrateClaudeHubDataHome(LEGACY_TASKER_HOME, home);
+  if (!existsSync(home)) {
+    mkdirSync(home, { recursive: true });
   }
-  return CLAUDE_HUB_HOME;
+  return home;
 }
 
 /** Ensure the parent directory for a Claude Hub file path exists. */


### PR DESCRIPTION
Closes #17.

## Changes

**\`src/lib/paths.ts\`**
- Add \`getClaudeHubHome()\`, \`getClaudeHubDb()\`, \`getClaudeHubLog()\`, \`getClaudeHubPid()\` functions that re-read \`process.env.CLAUDE_HUB_HOME\` on every call. Code paths that need a runtime override should use these.
- Keep the \`CLAUDE_HUB_HOME\` / \`_DB\` / \`_LOG\` / \`_PID\` consts as load-time snapshots for back-compat with existing importers (no churn).
- \`migrateClaudeHubDataHome\` and \`ensureClaudeHubDataHome\` now route through the getter, so a CLI flag that sets \`CLAUDE_HUB_HOME\` after this module imports still takes effect.
- Delete \`TASKER_HOME\` / \`TASKER_DB\` / \`TASKER_LOG\` / \`TASKER_PID\` aliases. \`grep -rn TASKER_ src/\` confirms zero callers outside \`paths.ts\` itself — pure dead code (per U-24, no aliases). \`LEGACY_TASKER_HOME\` stays since it's still used to detect the old data tree in \`cli/status.ts\` and the migration default.

**\`src/lib/config.ts\`**
- Replace top-level \`const CONFIG_FILE = join(CLAUDE_HUB_HOME, ...)\` with a \`getConfigFile()\` helper that calls \`getClaudeHubHome()\`. Same in \`save()\` for the mkdir target. Fixes the bug where setting \`CLAUDE_HUB_HOME\` post-import silently wrote to the original path.

## Scope I left out

The issue mentioned \`src/db/migrations.ts:14-25\` resetDatabase DROP-list drift as a P2 bonus. Skipping in this PR to keep it atomic — happy to file a follow-up.

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] All 174 existing tests pass (\`bun test src/__tests__/\`)
- [x] \`grep -rn TASKER_ src/\` returns only \`LEGACY_TASKER_HOME\` references
- [ ] Verify: \`CLAUDE_HUB_HOME=/tmp/test-hub claude-hub list\` writes to \`/tmp/test-hub/\` even when env is set after node startup