### PR TITLE
fix(web): harden terminal websocket launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ Open **http://127.0.0.1:3377**
 
 By default the web server binds to loopback only. To expose it intentionally, set `CLAUDE_HUB_HOST`.
 
-If you put Claude Hub behind a reverse proxy (Caddy, nginx, cloudflared) and want the in-process rate limiter to identify real clients, also set `CLAUDE_HUB_TRUST_PROXY=true`. Without that flag, `X-Forwarded-For` is treated as untrusted input and the limiter keys on the actual TCP peer instead — this is intentional, so a malicious caller cannot bypass throttling by spoofing forwarded headers.
+If you put Claude Hub behind a reverse proxy (Caddy, nginx, cloudflared), set `CLAUDE_HUB_PUBLIC_ORIGIN=https://your-public-host.example` so the terminal WebSocket accepts the browser's public `Origin`. For multiple public origins, use comma-separated `CLAUDE_HUB_ALLOWED_ORIGINS`.
+
+If you also want the in-process rate limiter to identify real clients behind that proxy, set `CLAUDE_HUB_TRUST_PROXY=true`. Without that flag, `X-Forwarded-For` is treated as untrusted input and the limiter keys on the actual TCP peer instead — this is intentional, so a malicious caller cannot bypass throttling by spoofing forwarded headers.
 
 ### macOS Security Note
 

--- a/src/__tests__/terminal-security.test.ts
+++ b/src/__tests__/terminal-security.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { resolveAllowedTerminalCwd } from '../services/pty.manager.js';
+import { isAllowedTerminalOrigin } from '../web/api/terminal-security.js';
+
+describe('terminal WebSocket Origin guard', () => {
+  test('rejects missing Origin headers', () => {
+    const req = new Request('http://127.0.0.1:3377/ws/terminal');
+    expect(isAllowedTerminalOrigin(req, '127.0.0.1', 3377, false)).toBe(false);
+  });
+
+  test('rejects cross-site browser origins', () => {
+    const req = new Request('http://127.0.0.1:3377/ws/terminal', {
+      headers: { Origin: 'https://attacker.example' },
+    });
+    expect(isAllowedTerminalOrigin(req, '127.0.0.1', 3377, false)).toBe(false);
+  });
+
+  test('accepts same-origin browser connections', () => {
+    const req = new Request('http://127.0.0.1:3377/ws/terminal', {
+      headers: { Origin: 'http://127.0.0.1:3377' },
+    });
+    expect(isAllowedTerminalOrigin(req, '127.0.0.1', 3377, false)).toBe(true);
+  });
+
+  test('accepts localhost alias for a loopback-bound server', () => {
+    const req = new Request('http://localhost:3377/ws/terminal', {
+      headers: { Origin: 'http://localhost:3377' },
+    });
+    expect(isAllowedTerminalOrigin(req, '127.0.0.1', 3377, false)).toBe(true);
+  });
+
+  test('does not trust an attacker-controlled Host origin', () => {
+    const req = new Request('http://attacker.example:3377/ws/terminal', {
+      headers: { Origin: 'http://attacker.example:3377' },
+    });
+    expect(isAllowedTerminalOrigin(req, '127.0.0.1', 3377, false)).toBe(false);
+  });
+
+  test('accepts a configured HTTPS public origin for reverse proxies', () => {
+    const req = new Request('http://127.0.0.1:3377/ws/terminal', {
+      headers: { Origin: 'https://hub.example.com' },
+    });
+    expect(isAllowedTerminalOrigin(
+      req,
+      '127.0.0.1',
+      3377,
+      false,
+      ['https://hub.example.com'],
+    )).toBe(true);
+  });
+});
+
+describe('terminal cwd allowlist', () => {
+  const tempDirs: string[] = [];
+
+  function tempDir(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      rmSync(tempDirs.pop()!, { recursive: true, force: true });
+    }
+  });
+
+  test('allows directories under an allowed root', () => {
+    const root = tempDir('claude-hub-root-');
+    const project = join(root, 'project');
+    mkdirSync(project);
+
+    expect(resolveAllowedTerminalCwd(project, [root])).toBe(realpathSync(project));
+  });
+
+  test('rejects directories outside allowed roots', () => {
+    const root = tempDir('claude-hub-root-');
+    const outside = tempDir('claude-hub-outside-');
+
+    expect(() => resolveAllowedTerminalCwd(outside, [root])).toThrow('outside allowed roots');
+  });
+
+  test('rejects symlinks that resolve outside allowed roots', () => {
+    const root = tempDir('claude-hub-root-');
+    const outside = tempDir('claude-hub-outside-');
+    const link = join(root, 'outside-link');
+    symlinkSync(outside, link, 'dir');
+
+    expect(() => resolveAllowedTerminalCwd(link, [root])).toThrow('outside allowed roots');
+  });
+});

--- a/src/services/pty.manager.ts
+++ b/src/services/pty.manager.ts
@@ -7,6 +7,9 @@
  */
 
 import { randomUUID } from 'crypto';
+import { existsSync, realpathSync, statSync } from 'fs';
+import { homedir } from 'os';
+import path from 'path';
 import { spawn as spawnPty } from 'bun-pty';
 import { runSql } from '../infrastructure/database/sqlite.js';
 import { config } from '../lib/config.js';
@@ -25,6 +28,33 @@ interface IPty {
 
 interface ServerWebSocket {
   send: (data: string | Buffer) => void;
+}
+
+export function resolveAllowedTerminalCwd(
+  requestedCwd: unknown,
+  allowedRoots: string[] = getAllowedTerminalCwdRoots(),
+): string {
+  if (requestedCwd !== undefined && typeof requestedCwd !== 'string') {
+    throw new Error('Terminal cwd must be a string');
+  }
+
+  const fallbackCwd = process.env.HOME || homedir();
+  const candidate = requestedCwd && requestedCwd.trim().length > 0 ? requestedCwd : fallbackCwd;
+  const realCandidate = realDirectory(candidate, 'Terminal cwd');
+  const realAllowedRoots = allowedRoots
+    .map((root) => root.trim())
+    .filter(Boolean)
+    .map((root) => realDirectory(root, 'Terminal cwd allowlist root'));
+
+  if (realAllowedRoots.length === 0) {
+    throw new Error('Terminal cwd allowlist is empty');
+  }
+
+  if (!realAllowedRoots.some((root) => isPathWithin(realCandidate, root))) {
+    throw new Error('Terminal cwd is outside allowed roots');
+  }
+
+  return realCandidate;
 }
 
 export interface PtySession {
@@ -72,7 +102,7 @@ class PtyManager {
     }
 
     const sessionId = randomUUID();
-    const spawnCwd = cwd || process.env.HOME || '/';
+    const spawnCwd = resolveAllowedTerminalCwd(cwd);
 
     // Build command: if resumeSessionId provided, use `claude --resume <id>`
     let file: string;
@@ -295,3 +325,30 @@ class PtyManager {
 }
 
 export const ptyManager = new PtyManager();
+
+function getAllowedTerminalCwdRoots(): string[] {
+  const configuredRoots = process.env.CLAUDE_HUB_TERMINAL_CWD_ROOTS;
+  if (configuredRoots) {
+    return configuredRoots.split(path.delimiter);
+  }
+  return [process.env.HOME || homedir()];
+}
+
+function realDirectory(directory: string, label: string): string {
+  const resolved = path.resolve(directory);
+  if (!existsSync(resolved)) {
+    throw new Error(`${label} does not exist`);
+  }
+
+  const realPath = realpathSync(resolved);
+  if (!statSync(realPath).isDirectory()) {
+    throw new Error(`${label} is not a directory`);
+  }
+
+  return realPath;
+}
+
+function isPathWithin(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}

--- a/src/web/api/server.ts
+++ b/src/web/api/server.ts
@@ -29,6 +29,7 @@ import {
   REALTIME_POLL_INTERVAL_MS,
   shouldRunRealtimeFullSync,
 } from './realtime-updates.js';
+import { isAllowedTerminalOrigin } from './terminal-security.js';
 
 const app = new Hono();
 
@@ -173,6 +174,15 @@ export async function startWebServer(port: number = 3377) {
 
       // Handle WebSocket upgrade - terminal
       if (url.pathname === '/ws/terminal') {
+        const tlsEnabled = Boolean(terminalConfig.tlsCert && terminalConfig.tlsKey);
+        if (!isAllowedTerminalOrigin(req, hostname, port, tlsEnabled)) {
+          logger.warn('Rejected terminal WebSocket with invalid Origin', {
+            origin: req.headers.get('origin') ?? '<missing>',
+            host: url.host,
+          });
+          return new Response('Forbidden', { status: 403 });
+        }
+
         const upgraded = server.upgrade(req, { data: { type: 'terminal' } });
         if (upgraded) return undefined;
         return new Response('WebSocket upgrade failed', { status: 400 });

--- a/src/web/api/terminal-security.ts
+++ b/src/web/api/terminal-security.ts
@@ -1,0 +1,74 @@
+/**
+ * Security helpers for the browser-backed terminal endpoint.
+ */
+
+export function getAllowedTerminalOrigins(
+  hostname: string,
+  port: number,
+  tlsEnabled: boolean,
+  configuredOrigins: string[] = getConfiguredAllowedOrigins(),
+): Set<string> {
+  const allowed = new Set<string>();
+  const protocol = tlsEnabled ? 'https' : 'http';
+  addOrigin(allowed, protocol, hostname, port);
+
+  if (isLoopbackHost(hostname) || hostname === '0.0.0.0' || hostname === '::') {
+    addOrigin(allowed, protocol, '127.0.0.1', port);
+    addOrigin(allowed, protocol, 'localhost', port);
+    addOrigin(allowed, protocol, '[::1]', port);
+  }
+
+  for (const origin of configuredOrigins) {
+    addConfiguredOrigin(allowed, origin);
+  }
+
+  return allowed;
+}
+
+export function isAllowedTerminalOrigin(
+  req: Request,
+  hostname: string,
+  port: number,
+  tlsEnabled: boolean,
+  configuredOrigins?: string[],
+): boolean {
+  const origin = req.headers.get('origin');
+  if (!origin) return false;
+
+  let normalizedOrigin: string;
+  try {
+    normalizedOrigin = new URL(origin).origin;
+  } catch {
+    return false;
+  }
+
+  return getAllowedTerminalOrigins(hostname, port, tlsEnabled, configuredOrigins).has(normalizedOrigin);
+}
+
+function addOrigin(allowed: Set<string>, protocol: string, hostname: string, port: number) {
+  const host = hostname.includes(':') && !hostname.startsWith('[') ? `[${hostname}]` : hostname;
+  allowed.add(new URL(`${protocol}://${host}:${port}`).origin);
+}
+
+function addConfiguredOrigin(allowed: Set<string>, origin: string) {
+  try {
+    allowed.add(new URL(origin).origin);
+  } catch {
+    // Ignore malformed opt-in origins rather than widening the allowlist.
+  }
+}
+
+function getConfiguredAllowedOrigins(): string[] {
+  const values = [
+    process.env.CLAUDE_HUB_PUBLIC_ORIGIN,
+    process.env.CLAUDE_HUB_ALLOWED_ORIGINS,
+  ];
+  return values
+    .flatMap((value) => (value ?? '').split(','))
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === '127.0.0.1' || hostname === 'localhost' || hostname === '::1' || hostname === '[::1]';
+}


### PR DESCRIPTION
## Summary\n- reject terminal WebSocket upgrades when the browser Origin is missing or not same-origin/configured-origin\n- resolve PTY cwd through realpath before spawning and restrict it to configured terminal roots, defaulting to the user home\n- add regression tests for CSWSH Origin rejection and cwd/symlink escape rejection\n\nCloses #10\n\n## Verification\n- bun test src/__tests__/terminal-security.test.ts src/__tests__/pty-manager.test.ts\n- bun run typecheck\n- bun test\n- bun run build