### PR TITLE
Fix Host-spoofed local auth token minting

### DIFF
--- a/src/__tests__/auth-local-login.test.ts
+++ b/src/__tests__/auth-local-login.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import auth from '../web/api/routes/auth.js';
+import { resetDatabase } from '../db/migrations.js';
+import { closeDatabase } from '../infrastructure/database/sqlite.js';
+import { __resetRateLimitStoreForTests } from '../web/api/middleware/rateLimit.js';
+
+interface LocalLoginResponse {
+  success: boolean;
+  data?: {
+    token?: unknown;
+  };
+}
+
+async function parseJson(response: Response): Promise<LocalLoginResponse> {
+  return (await response.json()) as LocalLoginResponse;
+}
+
+async function postFromLoopback(): Promise<{ status: number; body: LocalLoginResponse }> {
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch(req, server) {
+      return auth.fetch(req, { server });
+    },
+  });
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${server.port}/local`, {
+      method: 'POST',
+    });
+    return { status: response.status, body: await parseJson(response) };
+  } finally {
+    server.stop(true);
+  }
+}
+
+describe('local auth route', () => {
+  beforeEach(() => {
+    resetDatabase();
+    __resetRateLimitStoreForTests();
+    delete process.env.CLAUDE_HUB_HOST;
+    delete process.env.CLAUDE_HUB_PUBLIC_ORIGIN;
+    delete process.env.CLAUDE_HUB_ALLOWED_ORIGINS;
+    delete process.env.CLAUDE_HUB_TRUST_PROXY;
+  });
+
+  afterEach(() => {
+    __resetRateLimitStoreForTests();
+    delete process.env.CLAUDE_HUB_HOST;
+    delete process.env.CLAUDE_HUB_PUBLIC_ORIGIN;
+    delete process.env.CLAUDE_HUB_ALLOWED_ORIGINS;
+    delete process.env.CLAUDE_HUB_TRUST_PROXY;
+    closeDatabase();
+  });
+
+  test('rejects a spoofed Host header when there is no loopback TCP peer', async () => {
+    const response = await auth.fetch(
+      new Request('http://public.example/local', {
+        method: 'POST',
+        headers: { host: 'localhost:3377' },
+      })
+    );
+
+    expect(response.status).toBe(403);
+    const body = await parseJson(response);
+    expect(body.success).toBe(false);
+    expect(body.data?.token).toBeUndefined();
+  });
+
+  test('does not treat trusted proxy forwarded headers as local login proof', async () => {
+    process.env.CLAUDE_HUB_TRUST_PROXY = 'true';
+
+    const response = await auth.fetch(
+      new Request('http://public.example/local', {
+        method: 'POST',
+        headers: {
+          host: 'public.example',
+          'x-forwarded-for': '127.0.0.1',
+          'x-real-ip': '127.0.0.1',
+        },
+      })
+    );
+
+    expect(response.status).toBe(403);
+    const body = await parseJson(response);
+    expect(body.success).toBe(false);
+    expect(body.data?.token).toBeUndefined();
+  });
+
+  test('rejects local login when the server is configured for public binding', async () => {
+    process.env.CLAUDE_HUB_HOST = '0.0.0.0';
+
+    const response = await postFromLoopback();
+
+    expect(response.status).toBe(403);
+    expect(response.body.success).toBe(false);
+    expect(response.body.data?.token).toBeUndefined();
+  });
+
+  test('rejects local login when public proxy origins are configured', async () => {
+    process.env.CLAUDE_HUB_PUBLIC_ORIGIN = 'https://hub.example.com';
+
+    const response = await postFromLoopback();
+
+    expect(response.status).toBe(403);
+    expect(response.body.success).toBe(false);
+    expect(response.body.data?.token).toBeUndefined();
+  });
+
+  test('allows local login from an actual loopback socket', async () => {
+    const response = await postFromLoopback();
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(typeof response.body.data?.token).toBe('string');
+  });
+});

--- a/src/web/api/routes/auth.ts
+++ b/src/web/api/routes/auth.ts
@@ -6,6 +6,7 @@
 
 import type { Context } from 'hono';
 import { Hono } from 'hono';
+import { getConnInfo } from 'hono/bun';
 import { getClientIp, rateLimit, resetRateLimitKey } from '../middleware/rateLimit.js';
 import { authMiddleware } from '../middleware/auth.js';
 import {
@@ -17,12 +18,48 @@ import {
   logAudit,
 } from '../../../services/auth.service.js';
 import type { JwtPayload } from '../../../services/auth.service.js';
+import { logger } from '../../../lib/logger.js';
 
 const auth = new Hono();
 const LOGIN_USERNAME_RATE_LIMIT_SCOPE = 'auth-login-username';
 
 function loginUsernameRateLimitKey(username: string): string {
   return `login:${username.slice(0, 64).toLowerCase()}`;
+}
+
+function getTcpPeerAddress(c: Context): string | undefined {
+  try {
+    return getConnInfo(c).remote?.address;
+  } catch (error) {
+    logger.warn('Unable to resolve TCP peer for local login', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}
+
+function isLoopbackPeer(address: string | undefined): boolean {
+  return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1';
+}
+
+function isLoopbackServerHost(hostname: string): boolean {
+  const host = hostname.trim().toLowerCase();
+  return host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === '[::1]';
+}
+
+function hasConfiguredPublicOrigin(): boolean {
+  const configuredOrigins = [
+    process.env.CLAUDE_HUB_PUBLIC_ORIGIN,
+    process.env.CLAUDE_HUB_ALLOWED_ORIGINS,
+  ];
+  return configuredOrigins
+    .flatMap((value) => (value ?? '').split(','))
+    .some((value) => value.trim().length > 0);
+}
+
+function isLoopbackOnlyServerMode(): boolean {
+  const hostname = process.env.CLAUDE_HUB_HOST || '127.0.0.1';
+  return isLoopbackServerHost(hostname) && !hasConfiguredPublicOrigin();
 }
 
 /**
@@ -132,16 +169,14 @@ auth.post(
 // POST /api/auth/logout - Revoke current token
 // POST /api/auth/local - Localhost passwordless login
 auth.post('/local', rateLimit(10, 60 * 1000), async (c) => {
-  const host = c.req.header('host') || '';
-  const isLocal = host.startsWith('localhost') || host.startsWith('127.0.0.1') || host.startsWith('[::1]');
-  if (!isLocal) {
+  const peerAddress = getTcpPeerAddress(c);
+  if (!isLoopbackOnlyServerMode() || !isLoopbackPeer(peerAddress)) {
     return c.json({ success: false, error: 'Local login only available from localhost' }, 403);
   }
 
   try {
     const result = await localLogin();
-    const ip = c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'local';
-    logAudit(null, 'local_login', ip);
+    logAudit(null, 'local_login', peerAddress);
     return c.json({ success: true, data: result });
   } catch (e) {
     const message = e instanceof Error ? e.message : 'Local login failed';

--- a/src/web/api/server.ts
+++ b/src/web/api/server.ts
@@ -189,7 +189,7 @@ export async function startWebServer(port: number = 3377) {
       }
 
       // Handle regular HTTP requests via Hono
-      return app.fetch(req);
+      return app.fetch(req, { server });
     },
     websocket: {
       idleTimeout: 0, // disable WS idle timeout for long-lived terminal sessions


### PR DESCRIPTION
## Summary
- Gate passwordless local auth on the actual Bun TCP peer address instead of the attacker-controlled Host header.
- Disable local passwordless auth when the server is configured for public binding or public proxy origins.
- Pass the Bun server object into Hono so getConnInfo can resolve connection metadata for normal HTTP routes.
- Add regression coverage for Host spoofing, trusted proxy header spoofing, public exposure config, and real loopback login.

Fixes #25

## Validation
- TMP_HOME=$(mktemp -d); CLAUDE_HUB_HOME="$TMP_HOME" bun test src/__tests__/auth-local-login.test.ts
- TMP_HOME=$(mktemp -d); CLAUDE_HUB_HOME="$TMP_HOME" bun run typecheck
- npx tsc --noEmit
- cd src/web/client && npx tsc --noEmit
- TMP_HOME=$(mktemp -d); CLAUDE_HUB_HOME="$TMP_HOME" bun test