### PR TITLE
fix(recovery): quote resume session ids

### DIFF
--- a/src/__tests__/claude.scanner.test.ts
+++ b/src/__tests__/claude.scanner.test.ts
@@ -295,4 +295,63 @@ describe('Claude Scanner', () => {
     expect(result.stdout.includes('Skipped invalid session files during scan')).toBe(true);
     expect(result.stdout.includes('Failed to parse session file:')).toBe(false);
   });
+
+  test('skips session files whose filename does not contain a safe session ID', () => {
+    const homeDir = createTempHome();
+
+    writeSessionFile(homeDir, '-tmp-unsafe-filename', 'safe1234;touch-owned.jsonl', [
+      {
+        type: 'user',
+        uuid: 'user-1',
+        sessionId: 'safe1234;touch-owned',
+        cwd: '/tmp/unsafe-filename',
+        timestamp: '2026-04-13T12:20:00.000Z',
+        userType: 'external',
+        message: { role: 'user', content: 'malicious filename' },
+      },
+    ]);
+
+    const result = runScannerScriptDetailed(homeDir, `
+      const { clearSessionCache, getAllSessions, scanProjectsDirectory } = await import('./src/adapters/claude/scanner.ts');
+      clearSessionCache();
+      const files = scanProjectsDirectory();
+      const sessions = await getAllSessions();
+      console.log(JSON.stringify({
+        files: files.map((file) => file.sessionId),
+        sessions: sessions.map((session) => session.sessionId),
+      }));
+    `);
+
+    expect(result.data.files).toEqual([]);
+    expect(result.data.sessions).toEqual([]);
+    expect(result.stdout.includes('Skipped session files with invalid session IDs')).toBe(true);
+  });
+
+  test('skips parsed sessions whose JSONL payload contains an unsafe session ID', () => {
+    const homeDir = createTempHome();
+
+    writeSessionFile(homeDir, '-tmp-unsafe-payload', 'safe-session-123.jsonl', [
+      {
+        type: 'user',
+        uuid: 'user-1',
+        sessionId: 'safe1234;touch-owned',
+        cwd: '/tmp/unsafe-payload',
+        timestamp: '2026-04-13T12:30:00.000Z',
+        userType: 'external',
+        message: { role: 'user', content: 'malicious payload session id' },
+      },
+    ]);
+
+    const result = runScannerScriptDetailed(homeDir, `
+      const { clearSessionCache, getAllSessions } = await import('./src/adapters/claude/scanner.ts');
+      clearSessionCache();
+      const sessions = await getAllSessions();
+      console.log(JSON.stringify({
+        sessions: sessions.map((session) => session.sessionId),
+      }));
+    `);
+
+    expect(result.data.sessions).toEqual([]);
+    expect(result.stdout.includes('Skipped invalid session files during scan')).toBe(true);
+  });
 });

--- a/src/__tests__/pty-manager.test.ts
+++ b/src/__tests__/pty-manager.test.ts
@@ -68,6 +68,14 @@ describe('PTY session ownership', () => {
     expect(() => ptyManager.kill(session.id, 'owner-b')).toThrow('Forbidden');
   });
 
+  test('rejects unsafe resume session IDs before spawning a PTY', async () => {
+    await expect(
+      ptyManager.create(ownerId, 80, 24, process.cwd(), 'safe1234;touch-owned')
+    ).rejects.toThrow('Invalid session ID format');
+
+    expect(ptyManager.listSessions(ownerId)).toHaveLength(0);
+  });
+
   test('removes exited sessions that have no attached clients', async () => {
     const exitScript = createExitScript('exit-no-clients.sh', 'printf "done\\n"\nsleep 0.05');
     config.set('webTerminal', {

--- a/src/__tests__/recovery-security.test.ts
+++ b/src/__tests__/recovery-security.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'bun:test';
+import type { Session } from '../domain/session/index.js';
+import type {
+  ISessionRepository,
+  ActiveSessionRecord,
+  ExistingSessionSummary,
+  SessionUpsertData,
+} from '../domain/session/repository.js';
+import type { SessionStatus } from '../domain/session/value-objects.js';
+import {
+  buildClaudeCommand,
+  buildClaudeCommandArgs,
+  RecoveryService,
+} from '../services/recovery.service.js';
+
+function recoverySession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: '1',
+    sessionId: 'safe-session-123',
+    directory: process.cwd(),
+    status: 'lost',
+    title: 'Recover me',
+    initialPrompt: 'Recover me',
+    lastActiveAt: new Date(),
+    toolCount: 0,
+    messageCount: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function createRepository(session: Session | null): ISessionRepository {
+  return {
+    findById: () => session,
+    findBySessionId: (sessionId: string) =>
+      session?.sessionId === sessionId ? session : null,
+    findBySessionIds: () => session ? [session] : [],
+    findBySessionIdsSummary: (): ExistingSessionSummary[] =>
+      session ? [{
+        sessionId: session.sessionId,
+        status: session.status,
+        title: session.title,
+      }] : [],
+    findAll: () => session ? [session] : [],
+    findAllLightweight: () => [],
+    findActive: () => session ? [session] : [],
+    findActiveLightweight: (): ActiveSessionRecord[] => [],
+    findByStatus: (status: SessionStatus) =>
+      session?.status === status ? [session] : [],
+    findByDirectory: (directory: string) =>
+      session?.directory === directory ? [session] : [],
+    upsert: (data: SessionUpsertData) => recoverySession({
+      ...session,
+      ...data,
+      sessionId: data.sessionId,
+    }),
+    deleteOldSessions: () => 0,
+    countByStatus: () => ({
+      running: 0,
+      waiting: 0,
+      idle: 0,
+      lost: session?.status === 'lost' ? 1 : 0,
+      completed: 0,
+    }),
+  };
+}
+
+describe('recovery command security', () => {
+  test('builds resume commands from structured argv', () => {
+    expect(buildClaudeCommandArgs('resume', 'safe-session-123')).toEqual([
+      'claude',
+      '--resume',
+      'safe-session-123',
+    ]);
+    expect(buildClaudeCommand('resume', 'safe-session-123')).toBe(
+      'claude --resume safe-session-123'
+    );
+  });
+
+  test('rejects unsafe session IDs before rendering resume commands', () => {
+    expect(() => buildClaudeCommand('resume', 'safe1234;touch-owned')).toThrow(
+      'Invalid session ID format'
+    );
+    expect(() => buildClaudeCommand('new', 'safe1234;touch-owned')).toThrow(
+      'Invalid session ID format'
+    );
+  });
+
+  test('shell-quotes prompts used in new-session recovery commands', () => {
+    expect(buildClaudeCommand('new', 'safe-session-123', "don't run; rm -rf /")).toBe(
+      "claude 'don'\\''t run; rm -rf /'"
+    );
+  });
+
+  test('marks persisted sessions with unsafe IDs as unrecoverable', () => {
+    const service = new RecoveryService(createRepository(recoverySession({
+      sessionId: 'safe1234;touch-owned',
+    })));
+
+    const result = service.canRecover(recoverySession({
+      sessionId: 'safe1234;touch-owned',
+    }));
+
+    expect(result).toEqual({
+      canRecover: false,
+      reason: 'Invalid session ID format',
+      availableMethods: [],
+    });
+  });
+
+  test('rejects invalid recovery requests before repository lookup', async () => {
+    const service = new RecoveryService(createRepository(null));
+
+    await expect(service.recoverSession({
+      method: 'resume',
+      sessionId: 'safe1234;touch-owned',
+      directory: process.cwd(),
+      openTerminal: false,
+    })).rejects.toThrow('Invalid session ID format');
+  });
+});

--- a/src/adapters/claude/scanner.ts
+++ b/src/adapters/claude/scanner.ts
@@ -20,6 +20,7 @@ import { parseSessionFile } from './parser/jsonl.js';
 import type { ClaudeSessionFile } from '../../domain/session/index.js';
 import type { ParsedSessionData } from './types.js';
 import { logger } from '../../lib/logger.js';
+import { isValidSessionId } from '../../lib/session-id.js';
 
 // Cache for parsed session data with modification times
 interface SessionCache {
@@ -121,6 +122,7 @@ export function scanProjectsDirectory(options: ScanOptions = {}): ClaudeSessionF
 
   // Map keyed by `${projectName}:${sessionId}` for O(1) cross-root dedup
   const byKey = new Map<string, ClaudeSessionFile>();
+  const invalidSessionFiles: string[] = [];
   const cutoffTime = maxAgeDays ? Date.now() - maxAgeDays * 24 * 60 * 60 * 1000 : 0;
   let scannedRoots = 0;
 
@@ -166,6 +168,11 @@ export function scanProjectsDirectory(options: ScanOptions = {}): ClaudeSessionF
           ? file.replace('.jsonl', '')
           : extractSessionId(file);
 
+        if (!isValidSessionId(sessionId)) {
+          invalidSessionFiles.push(filePath);
+          continue;
+        }
+
         // De-duplicate when the same sessionId exists in multiple roots
         // (e.g. .claude and .claude-work); prefer the newer file.
         const dedupeKey = `${projectName}:${sessionId}`;
@@ -190,7 +197,25 @@ export function scanProjectsDirectory(options: ScanOptions = {}): ClaudeSessionF
     });
   }
 
+  if (invalidSessionFiles.length > 0) {
+    logger.warn('Skipped session files with invalid session IDs', {
+      count: invalidSessionFiles.length,
+      sample: invalidSessionFiles.slice(0, 5),
+    });
+  }
+
   return Array.from(byKey.values());
+}
+
+function requireValidParsedSession(
+  parsed: ParsedSessionData | null,
+  filePath: string
+): ParsedSessionData | null {
+  if (parsed && !isValidSessionId(parsed.sessionId)) {
+    throw new Error(`Invalid session ID in session file: ${filePath}`);
+  }
+
+  return parsed;
 }
 
 /** Get all sessions with parsed data (optimized with caching) */
@@ -230,7 +255,10 @@ export async function getAllSessions(options: ScanOptions = {}): Promise<ParsedS
       }
 
       // Parse file and update cache
-      const parsed = await parseSessionFile(file.filePath, { includeToolCalls: false });
+      const parsed = requireValidParsedSession(
+        await parseSessionFile(file.filePath, { includeToolCalls: false }),
+        file.filePath
+      );
       sessionSummaryCache.set(file.filePath, {
         data: parsed,
         modifiedAt: fileModTime,
@@ -298,7 +326,10 @@ async function getOrParseSession(file: ClaudeSessionFile): Promise<ParsedSession
   }
 
   try {
-    const parsed = await parseSessionFile(file.filePath, { includeToolCalls: true });
+    const parsed = requireValidParsedSession(
+      await parseSessionFile(file.filePath, { includeToolCalls: true }),
+      file.filePath
+    );
     sessionDetailCache.set(file.filePath, {
       data: parsed,
       modifiedAt: fileModTime,
@@ -334,7 +365,10 @@ async function getOrParseSessionSummary(file: ClaudeSessionFile): Promise<Parsed
   }
 
   try {
-    const parsed = await parseSessionFile(file.filePath, { includeToolCalls: false });
+    const parsed = requireValidParsedSession(
+      await parseSessionFile(file.filePath, { includeToolCalls: false }),
+      file.filePath
+    );
     sessionSummaryCache.set(file.filePath, {
       data: parsed,
       modifiedAt: fileModTime,

--- a/src/adapters/hook/server.ts
+++ b/src/adapters/hook/server.ts
@@ -8,6 +8,7 @@ import Fastify, { FastifyInstance } from 'fastify';
 import { logger } from '../../lib/logger.js';
 import { config } from '../../lib/config.js';
 import { emit } from '../../lib/events.js';
+import { isValidSessionId } from '../../lib/session-id.js';
 import { updateSession } from '../../services/session.service.js';
 import {
   getCompressionQueue,
@@ -45,7 +46,7 @@ function isValidHookEvent(event: unknown): event is HookEvent {
   const e = event as Record<string, unknown>;
 
   // Required fields
-  if (typeof e.session_id !== 'string' || e.session_id.length === 0) {
+  if (!isValidSessionId(e.session_id)) {
     return false;
   }
   if (typeof e.cwd !== 'string') {

--- a/src/lib/session-id.ts
+++ b/src/lib/session-id.ts
@@ -1,0 +1,17 @@
+/**
+ * Session ID validation shared by scanners, persistence, and recovery sinks.
+ */
+
+const SESSION_ID_PATTERN = /^[a-zA-Z0-9-_]{8,64}$/;
+
+/** Validate session ID format used by Claude Hub recovery APIs. */
+export function isValidSessionId(id: unknown): id is string {
+  return typeof id === 'string' && SESSION_ID_PATTERN.test(id);
+}
+
+/** Throw when a value cannot safely be used as a Claude session ID. */
+export function assertValidSessionId(id: unknown): asserts id is string {
+  if (!isValidSessionId(id)) {
+    throw new Error('Invalid session ID format');
+  }
+}

--- a/src/lib/shell-quote.ts
+++ b/src/lib/shell-quote.ts
@@ -1,0 +1,27 @@
+/**
+ * Shell argument rendering for terminal display/automation.
+ */
+
+const SAFE_SHELL_WORD = /^[A-Za-z0-9_@%+=:,./-]+$/;
+
+/** Quote exactly one shell argument. */
+export function shellQuote(value: string): string {
+  if (value.length === 0) {
+    return "''";
+  }
+
+  if (SAFE_SHELL_WORD.test(value)) {
+    return value;
+  }
+
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/** Render argv as a shell command string for terminal apps. */
+export function renderShellCommand(args: readonly string[]): string {
+  if (args.length === 0) {
+    throw new Error('Cannot render empty shell command');
+  }
+
+  return args.map(shellQuote).join(' ');
+}

--- a/src/services/pty.manager.ts
+++ b/src/services/pty.manager.ts
@@ -14,6 +14,7 @@ import { spawn as spawnPty } from 'bun-pty';
 import { runSql } from '../infrastructure/database/sqlite.js';
 import { config } from '../lib/config.js';
 import { logger } from '../lib/logger.js';
+import { assertValidSessionId } from '../lib/session-id.js';
 
 interface IPty {
   pid: number;
@@ -108,6 +109,7 @@ class PtyManager {
     let file: string;
     let args: string[];
     if (resumeSessionId) {
+      assertValidSessionId(resumeSessionId);
       file = 'claude';
       args = ['--resume', resumeSessionId];
     } else {

--- a/src/services/recovery.service.ts
+++ b/src/services/recovery.service.ts
@@ -10,31 +10,46 @@ import { RecoveryError } from '../lib/errors.js';
 import { emit } from '../lib/events.js';
 import { getProjectFolder } from '../lib/paths.js';
 import { logger } from '../lib/logger.js';
+import { isValidSessionId, assertValidSessionId } from '../lib/session-id.js';
+import { renderShellCommand } from '../lib/shell-quote.js';
 import { openTerminalWithCommand, printRecoveryCommand } from './terminal.js';
 import type { RecoveryMethod, RecoveryOptions, RecoveryResult } from './recovery.types.js';
 
-/** Build claude command for recovery */
-function buildClaudeCommand(
+/** Build claude argv for recovery. */
+export function buildClaudeCommandArgs(
+  method: RecoveryMethod,
+  sessionId: string,
+  initialPrompt?: string,
+  skipPermissions = false
+): string[] {
+  assertValidSessionId(sessionId);
+
+  const args = ['claude'];
+  if (skipPermissions) {
+    args.push('--dangerously-skip-permissions');
+  }
+
+  switch (method) {
+    case 'resume':
+      return [...args, '--resume', sessionId];
+    case 'continue':
+      return [...args, '--continue'];
+    case 'new':
+      if (initialPrompt) {
+        return [...args, initialPrompt];
+      }
+      return args;
+  }
+}
+
+/** Build shell-safe claude command for recovery terminal apps. */
+export function buildClaudeCommand(
   method: RecoveryMethod,
   sessionId: string,
   initialPrompt?: string,
   skipPermissions = false
 ): string {
-  const baseCmd = skipPermissions ? 'claude --dangerously-skip-permissions' : 'claude';
-
-  switch (method) {
-    case 'resume':
-      return `${baseCmd} --resume ${sessionId}`;
-    case 'continue':
-      return `${baseCmd} --continue`;
-    case 'new':
-      if (initialPrompt) {
-        // Escape the prompt for shell
-        const escapedPrompt = initialPrompt.replace(/'/g, "'\\''");
-        return `${baseCmd} '${escapedPrompt}'`;
-      }
-      return baseCmd;
-  }
+  return renderShellCommand(buildClaudeCommandArgs(method, sessionId, initialPrompt, skipPermissions));
 }
 
 export class RecoveryService {
@@ -47,6 +62,14 @@ export class RecoveryService {
     availableMethods: RecoveryMethod[];
   } {
     const availableMethods: RecoveryMethod[] = [];
+
+    if (!isValidSessionId(session.sessionId)) {
+      return {
+        canRecover: false,
+        reason: 'Invalid session ID format',
+        availableMethods: [],
+      };
+    }
 
     // Check if session file exists
     const projectFolder = getProjectFolder(session.directory);
@@ -78,7 +101,11 @@ export class RecoveryService {
 
   /** Get recommended recovery method */
   getRecommendedMethod(session: Session): RecoveryMethod {
-    const { availableMethods } = this.canRecover(session);
+    const { canRecover: canRecoverSession, reason, availableMethods } = this.canRecover(session);
+
+    if (!canRecoverSession) {
+      throw new RecoveryError(session.sessionId, reason || 'Cannot recover session');
+    }
 
     // Prefer resume if available
     if (availableMethods.includes('resume')) {
@@ -96,6 +123,10 @@ export class RecoveryService {
 
   /** Recover a lost session */
   async recoverSession(options: RecoveryOptions): Promise<RecoveryResult> {
+    if (!isValidSessionId(options.sessionId)) {
+      throw new RecoveryError(options.sessionId, 'Invalid session ID format');
+    }
+
     const session = this.repository.findBySessionId(options.sessionId);
 
     if (!session) {
@@ -174,6 +205,15 @@ export class RecoveryService {
     recommendedMethod?: RecoveryMethod;
     command?: string;
   } {
+    if (!isValidSessionId(sessionId)) {
+      return {
+        session: null,
+        canRecover: false,
+        reason: 'Invalid session ID format',
+        availableMethods: [],
+      };
+    }
+
     const session = this.repository.findBySessionId(sessionId);
 
     if (!session) {

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -14,6 +14,7 @@ import { getCachedProcesses, clearProcessCache } from '../adapters/process/scann
 import { detectSessionStatus } from '../adapters/process/detector.js';
 import { getAllSessions as getClaudeSessions } from '../adapters/claude/scanner.js';
 import { logger } from '../lib/logger.js';
+import { isValidSessionId } from '../lib/session-id.js';
 import type { CreateSessionInput, UpdateSessionInput, AggregatedSession } from './session.types.js';
 import { matchProcessesToSessions } from './session.process-matcher.js';
 
@@ -119,7 +120,22 @@ export class SessionService {
       const runningClaudePids = new Set(processes.map((process) => process.pid));
 
       // Get Claude sessions from file system (with optional age filter for performance)
-      const claudeSessions = await getClaudeSessions({ maxAgeDays });
+      const scannedClaudeSessions = await getClaudeSessions({ maxAgeDays });
+      const invalidClaudeSessions = scannedClaudeSessions.filter(
+        (session) => !isValidSessionId(session.sessionId)
+      );
+      if (invalidClaudeSessions.length > 0) {
+        logger.warn('Skipped scanned sessions with invalid session IDs before persistence', {
+          count: invalidClaudeSessions.length,
+          sample: invalidClaudeSessions.slice(0, 5).map((session) => ({
+            sessionId: session.sessionId,
+            directory: session.directory,
+          })),
+        });
+      }
+      const claudeSessions = scannedClaudeSessions.filter((session) =>
+        isValidSessionId(session.sessionId)
+      );
       const processMatches = matchProcessesToSessions(claudeSessions, processes);
       const existingSessions = this.repository.findBySessionIdsSummary(
         claudeSessions.map((session) => session.sessionId)

--- a/src/services/terminal.ts
+++ b/src/services/terminal.ts
@@ -6,6 +6,7 @@ import { execSync, spawn } from 'child_process';
 import path from 'path';
 import { existsSync } from 'fs';
 import { logger } from '../lib/logger.js';
+import { shellQuote } from '../lib/shell-quote.js';
 import type { TerminalApp } from './recovery.types.js';
 
 // Allowed commands whitelist for recovery
@@ -94,10 +95,11 @@ export function openTerminalWithCommand(
 
 /** Open Terminal.app with command */
 function openTerminalApp(command: string, directory: string): void {
+  const terminalCommand = `cd ${shellQuote(directory)} && ${command}`;
   const script = `
     tell application "Terminal"
       activate
-      do script "cd ${escapeForAppleScript(directory)} && ${escapeForAppleScript(command)}"
+      do script "${escapeForAppleScript(terminalCommand)}"
     end tell
   `;
 
@@ -112,12 +114,13 @@ function openTerminalApp(command: string, directory: string): void {
 
 /** Open iTerm with command */
 function openITerm(command: string, directory: string): void {
+  const terminalCommand = `cd ${shellQuote(directory)} && ${command}`;
   const script = `
     tell application "iTerm"
       activate
       create window with default profile
       tell current session of current window
-        write text "cd ${escapeForAppleScript(directory)} && ${escapeForAppleScript(command)}"
+        write text "${escapeForAppleScript(terminalCommand)}"
       end tell
     end tell
   `;
@@ -133,6 +136,7 @@ function openITerm(command: string, directory: string): void {
 
 /** Open Warp with command */
 function openWarp(command: string, directory: string): void {
+  const terminalCommand = `cd ${shellQuote(directory)} && ${command}`;
   const script = `
     tell application "Warp"
       activate
@@ -141,7 +145,7 @@ function openWarp(command: string, directory: string): void {
         tell process "Warp"
           keystroke "t" using command down
           delay 0.3
-          keystroke "cd ${escapeForAppleScript(directory)} && ${escapeForAppleScript(command)}"
+          keystroke "${escapeForAppleScript(terminalCommand)}"
           key code 36
         end tell
       end tell
@@ -202,7 +206,7 @@ export function executeCommand(command: string, cwd: string): number | null {
 /** Print command for user to copy */
 export function printRecoveryCommand(command: string, directory: string): void {
   console.log('\nTo recover this session, run:\n');
-  console.log(`  cd ${directory}`);
+  console.log(`  cd ${shellQuote(directory)}`);
   console.log(`  ${command}`);
   console.log('');
 }

--- a/src/web/api/middleware/validation.ts
+++ b/src/web/api/middleware/validation.ts
@@ -13,11 +13,7 @@ export type RecoveryMethod = (typeof VALID_RECOVERY_METHODS)[number];
 export const VALID_TERMINAL_APPS = ['Terminal', 'iTerm', 'Warp', 'auto'] as const;
 export type TerminalAppOption = (typeof VALID_TERMINAL_APPS)[number];
 
-/** Validate session ID format (UUID-like) */
-export function isValidSessionId(id: string): boolean {
-  // Session IDs are UUIDs or similar alphanumeric strings
-  return typeof id === 'string' && /^[a-zA-Z0-9-_]{8,64}$/.test(id);
-}
+export { isValidSessionId } from '../../../lib/session-id.js';
 
 /** Recovery request body */
 export interface RecoverRequestBody {


### PR DESCRIPTION
## Summary
- centralize safe session ID validation for scanner, hook, sync, PTY, and recovery paths
- build recovery commands from argv and shell-quote rendered terminal strings
- skip unsafe JSONL filename/payload session IDs and cover malicious recovery inputs

Fixes #28

## Validation
- bun test src/__tests__/recovery-security.test.ts src/__tests__/claude.scanner.test.ts
- bun run typecheck
- bun test
- bun run build