### PR TITLE
fix(persistence): persist sub-agent metadata, usage stats, and tool calls (#13)

### DIFF
--- a/src/__tests__/claude.scanner.test.ts
+++ b/src/__tests__/claude.scanner.test.ts
@@ -232,6 +232,115 @@ describe('Claude Scanner', () => {
     });
   });
 
+  test('rich bulk scans include sub-agent files and tool calls for persistence sync', () => {
+    const homeDir = createTempHome();
+
+    writeSessionFile(homeDir, '-tmp-agent-project', 'parent-session.jsonl', [
+      {
+        type: 'user',
+        uuid: 'user-parent',
+        sessionId: 'parent-session',
+        cwd: '/tmp/agent-project',
+        timestamp: '2026-04-13T11:25:00.000Z',
+        userType: 'external',
+        message: { role: 'user', content: 'Launch a sub-agent' },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-parent',
+        parentUuid: 'user-parent',
+        sessionId: 'parent-session',
+        cwd: '/tmp/agent-project',
+        timestamp: '2026-04-13T11:25:05.000Z',
+        message: {
+          role: 'assistant',
+          model: 'claude-3-5-sonnet-20241022',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tool-parent',
+              name: 'Bash',
+              input: { command: 'pwd' },
+            },
+          ],
+        },
+      },
+    ]);
+
+    writeSessionFile(homeDir, '-tmp-agent-project', 'agent-agent-123.jsonl', [
+      {
+        type: 'user',
+        uuid: 'user-agent',
+        sessionId: 'parent-session',
+        cwd: '/tmp/agent-project',
+        timestamp: '2026-04-13T11:26:00.000Z',
+        userType: 'external',
+        agentId: 'agent-123',
+        isSidechain: true,
+        message: { role: 'user', content: 'Inspect from a sub-agent' },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-agent',
+        parentUuid: 'user-agent',
+        sessionId: 'parent-session',
+        cwd: '/tmp/agent-project',
+        timestamp: '2026-04-13T11:26:05.000Z',
+        agentId: 'agent-123',
+        isSidechain: true,
+        message: {
+          role: 'assistant',
+          model: 'claude-3-5-sonnet-20241022',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tool-agent',
+              name: 'Read',
+              input: { file_path: '/tmp/agent-project/src/index.ts' },
+            },
+          ],
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+          },
+        },
+      },
+    ]);
+
+    const result = runScannerScript(homeDir, `
+      const { clearSessionCache, getAllSessions } = await import('./src/adapters/claude/scanner.ts');
+      clearSessionCache();
+      await getAllSessions();
+      const sessions = await getAllSessions({ includeSubAgents: true, includeToolCalls: true });
+      console.log(JSON.stringify({
+        sessions: sessions.map((session) => ({
+          sessionId: session.sessionId,
+          parentSessionId: session.parentSessionId ?? null,
+          isSubAgent: session.isSubAgent,
+          toolCalls: session.toolCalls?.map((tool) => tool.name) || [],
+          totalTokens: session.usageStats?.totalTokens || 0,
+        })).sort((a, b) => a.sessionId.localeCompare(b.sessionId)),
+      }));
+    `);
+
+    expect(result.sessions).toEqual([
+      {
+        sessionId: 'agent-agent-123',
+        parentSessionId: 'parent-session',
+        isSubAgent: true,
+        toolCalls: ['Read'],
+        totalTokens: 15,
+      },
+      {
+        sessionId: 'parent-session',
+        parentSessionId: null,
+        isSubAgent: false,
+        toolCalls: ['Bash'],
+        totalTokens: 0,
+      },
+    ]);
+  });
+
   test('persists broken-file skips across subprocess restarts when mtime is unchanged', () => {
     const homeDir = createTempHome();
     const brokenPath = writeSessionFile(homeDir, '-tmp-persist-broken', 'persist-broken.jsonl', [

--- a/src/__tests__/session-repository.test.ts
+++ b/src/__tests__/session-repository.test.ts
@@ -104,4 +104,24 @@ describe('Session Repository Upsert', () => {
     expect(fetched?.usageStats?.totalTokens).toBe(300);
     expect(fetched?.toolCalls?.[1].name).toBe('Bash');
   });
+
+  test('persists completedAt when inserting completed sessions', () => {
+    const completedAt = new Date('2026-04-13T16:00:00.000Z');
+
+    sessionRepository.upsert({
+      sessionId: 'session-completed-insert',
+      directory: '/tmp/repo',
+      status: 'completed',
+      title: 'Completed',
+      initialPrompt: 'Prompt',
+      startedAt: new Date('2026-04-13T15:00:00.000Z'),
+      lastActiveAt: completedAt,
+      completedAt,
+      toolCount: 0,
+      messageCount: 1,
+    });
+
+    const fetched = sessionRepository.findBySessionId('session-completed-insert');
+    expect(fetched?.completedAt?.toISOString()).toBe('2026-04-13T16:00:00.000Z');
+  });
 });

--- a/src/__tests__/session-repository.test.ts
+++ b/src/__tests__/session-repository.test.ts
@@ -61,4 +61,47 @@ describe('Session Repository Upsert', () => {
     expect(updated.pid).toBeUndefined();
     expect(updated.tty).toBeUndefined();
   });
+
+  test('persists multi-agent metadata, usage stats, and tool calls (issue #13)', () => {
+    const created = sessionRepository.upsert({
+      sessionId: 'session-metadata',
+      directory: '/tmp/repo',
+      status: 'running',
+      title: 'Meta',
+      initialPrompt: 'Prompt',
+      lastActiveAt: new Date('2026-04-13T15:00:00.000Z'),
+      toolCount: 3,
+      messageCount: 5,
+      agentId: 'agent-xyz',
+      parentSessionId: 'parent-session-1',
+      isSubAgent: true,
+      usageStats: {
+        totalInputTokens: 100,
+        totalOutputTokens: 200,
+        totalTokens: 300,
+        totalCost: 0.42,
+        apiCalls: 7,
+      },
+      toolCalls: [
+        { name: 'Read', input: { file: 'a.ts' }, timestamp: '2026-04-13T15:00:00.000Z' },
+        { name: 'Bash', input: { cmd: 'ls' }, timestamp: '2026-04-13T15:01:00.000Z' },
+      ],
+    });
+
+    expect(created.agentId).toBe('agent-xyz');
+    expect(created.parentSessionId).toBe('parent-session-1');
+    expect(created.isSubAgent).toBe(true);
+    expect(created.usageStats?.totalInputTokens).toBe(100);
+    expect(created.usageStats?.totalCost).toBe(0.42);
+    expect(created.usageStats?.apiCalls).toBe(7);
+    expect(created.toolCalls).toHaveLength(2);
+    expect(created.toolCalls?.[0].name).toBe('Read');
+
+    // Re-read from DB to confirm true persistence, not just the in-memory return
+    const fetched = sessionRepository.findBySessionId('session-metadata');
+    expect(fetched?.agentId).toBe('agent-xyz');
+    expect(fetched?.isSubAgent).toBe(true);
+    expect(fetched?.usageStats?.totalTokens).toBe(300);
+    expect(fetched?.toolCalls?.[1].name).toBe('Bash');
+  });
 });

--- a/src/adapters/claude/scanner.ts
+++ b/src/adapters/claude/scanner.ts
@@ -26,6 +26,7 @@ import { isValidSessionId } from '../../lib/session-id.js';
 interface SessionCache {
   data: ParsedSessionData | null;
   modifiedAt: number; // File modification time in ms
+  includeToolCalls: boolean;
 }
 const sessionSummaryCache = new Map<string, SessionCache>();
 const sessionDetailCache = new Map<string, SessionCache>();
@@ -113,6 +114,7 @@ export function getSessionCacheStats(): { size: number; keys: string[] } {
 /** Options for scanning session files */
 export interface ScanOptions {
   includeSubAgents?: boolean; // Include agent- prefixed files (default: false for backward compatibility)
+  includeToolCalls?: boolean; // Include full tool call details in bulk parsed results (default: false)
   maxAgeDays?: number; // Only include files modified within this many days (default: all)
 }
 
@@ -221,6 +223,7 @@ function requireValidParsedSession(
 /** Get all sessions with parsed data (optimized with caching) */
 export async function getAllSessions(options: ScanOptions = {}): Promise<ParsedSessionData[]> {
   const sessionFiles = scanProjectsDirectory(options);
+  const includeToolCalls = options.includeToolCalls ?? false;
   const sessions: ParsedSessionData[] = [];
   let cacheHits = 0;
   let cacheMisses = 0;
@@ -238,17 +241,20 @@ export async function getAllSessions(options: ScanOptions = {}): Promise<ParsedS
 
       // Use cache if file hasn't been modified
       if (cached && cached.modifiedAt === fileModTime) {
-        if (cached.data) {
-          sessions.push(cached.data);
+        if (!includeToolCalls || cached.includeToolCalls) {
+          if (cached.data) {
+            sessions.push(cached.data);
+          }
+          cacheHits++;
+          continue;
         }
-        cacheHits++;
-        continue;
       }
 
       if (isPersistedParseFailure(file.filePath, fileModTime)) {
         sessionSummaryCache.set(file.filePath, {
           data: null,
           modifiedAt: fileModTime,
+          includeToolCalls,
         });
         cacheHits++;
         continue;
@@ -256,12 +262,13 @@ export async function getAllSessions(options: ScanOptions = {}): Promise<ParsedS
 
       // Parse file and update cache
       const parsed = requireValidParsedSession(
-        await parseSessionFile(file.filePath, { includeToolCalls: false }),
+        await parseSessionFile(file.filePath, { includeToolCalls }),
         file.filePath
       );
       sessionSummaryCache.set(file.filePath, {
         data: parsed,
         modifiedAt: fileModTime,
+        includeToolCalls,
       });
       clearPersistedParseFailure(file.filePath);
       if (parsed) {
@@ -272,6 +279,7 @@ export async function getAllSessions(options: ScanOptions = {}): Promise<ParsedS
       sessionSummaryCache.set(file.filePath, {
         data: null,
         modifiedAt: file.modifiedAt.getTime(),
+        includeToolCalls,
       });
       recordPersistedParseFailure(file.filePath, file.modifiedAt.getTime());
       parseFailures.push(file.filePath);
@@ -321,6 +329,7 @@ async function getOrParseSession(file: ClaudeSessionFile): Promise<ParsedSession
     sessionDetailCache.set(file.filePath, {
       data: null,
       modifiedAt: fileModTime,
+      includeToolCalls: true,
     });
     return null;
   }
@@ -333,6 +342,7 @@ async function getOrParseSession(file: ClaudeSessionFile): Promise<ParsedSession
     sessionDetailCache.set(file.filePath, {
       data: parsed,
       modifiedAt: fileModTime,
+      includeToolCalls: true,
     });
     clearPersistedParseFailure(file.filePath);
     flushPersistedParseFailures();
@@ -341,6 +351,7 @@ async function getOrParseSession(file: ClaudeSessionFile): Promise<ParsedSession
     sessionDetailCache.set(file.filePath, {
       data: null,
       modifiedAt: fileModTime,
+      includeToolCalls: true,
     });
     recordPersistedParseFailure(file.filePath, fileModTime);
     flushPersistedParseFailures();
@@ -360,6 +371,7 @@ async function getOrParseSessionSummary(file: ClaudeSessionFile): Promise<Parsed
     sessionSummaryCache.set(file.filePath, {
       data: null,
       modifiedAt: fileModTime,
+      includeToolCalls: false,
     });
     return null;
   }
@@ -372,6 +384,7 @@ async function getOrParseSessionSummary(file: ClaudeSessionFile): Promise<Parsed
     sessionSummaryCache.set(file.filePath, {
       data: parsed,
       modifiedAt: fileModTime,
+      includeToolCalls: false,
     });
     clearPersistedParseFailure(file.filePath);
     flushPersistedParseFailures();
@@ -380,6 +393,7 @@ async function getOrParseSessionSummary(file: ClaudeSessionFile): Promise<Parsed
     sessionSummaryCache.set(file.filePath, {
       data: null,
       modifiedAt: fileModTime,
+      includeToolCalls: false,
     });
     recordPersistedParseFailure(file.filePath, fileModTime);
     flushPersistedParseFailures();

--- a/src/domain/session/entity.ts
+++ b/src/domain/session/entity.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Entity } from '../shared/types.js';
-import type { SessionStatus, ToolCallInfo } from './value-objects.js';
+import type { SessionStatus, ToolCallInfo, SessionUsageStats } from './value-objects.js';
 
 /** Session entity - represents a Claude Code session */
 export interface Session extends Entity {
@@ -26,6 +26,14 @@ export interface Session extends Entity {
   currentFile?: string;
   lastMessage?: string;
   toolCalls?: ToolCallInfo[];
+
+  /** Multi-session tracking */
+  agentId?: string;
+  parentSessionId?: string;
+  isSubAgent?: boolean;
+
+  /** Usage statistics */
+  usageStats?: SessionUsageStats;
 
   /** Timeline */
   startedAt?: Date;

--- a/src/domain/session/repository.ts
+++ b/src/domain/session/repository.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Session, SessionListItem } from './entity.js';
-import type { SessionStatus } from './value-objects.js';
+import type { SessionStatus, ToolCallInfo, SessionUsageStats } from './value-objects.js';
 
 export interface ActiveSessionRecord {
   sessionId: string;
@@ -38,6 +38,11 @@ export interface SessionUpsertData {
   tty?: string;
   toolCount?: number;
   messageCount?: number;
+  agentId?: string;
+  parentSessionId?: string;
+  isSubAgent?: boolean;
+  usageStats?: SessionUsageStats;
+  toolCalls?: ToolCallInfo[];
 }
 
 /** Session repository interface */

--- a/src/domain/session/value-objects.ts
+++ b/src/domain/session/value-objects.ts
@@ -36,6 +36,15 @@ export interface ToolCallInfo {
   timestamp: string;
 }
 
+/** Session usage statistics (tokens / cost / API calls) */
+export interface SessionUsageStats {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalTokens: number;
+  totalCost: number;
+  apiCalls: number;
+}
+
 /** Process information from system */
 export interface ProcessInfo {
   pid: number;

--- a/src/infrastructure/database/migrations/005_session_metadata.ts
+++ b/src/infrastructure/database/migrations/005_session_metadata.ts
@@ -1,0 +1,50 @@
+/**
+ * Migration 005: Session multi-agent metadata, usage stats, and tool calls
+ *
+ * Persists parser-produced fields that were previously dropped at the
+ * persistence boundary (issue #13): sub-agent tracking (agent_id /
+ * parent_session_id / is_sub_agent), usage stats (tokens / cost / api_calls),
+ * and the tool_calls array (stored as JSON, consistent with last_tool_input).
+ *
+ * Columns are added idempotently so existing databases upgrade cleanly.
+ */
+
+import type { Migration } from './index.js';
+import { execSql } from '../sqlite.js';
+import { logger } from '../../../lib/logger.js';
+
+const COLUMNS: Array<[string, string]> = [
+  ['agent_id', 'TEXT'],
+  ['parent_session_id', 'TEXT'],
+  ['is_sub_agent', 'INTEGER NOT NULL DEFAULT 0'],
+  ['total_input_tokens', 'INTEGER'],
+  ['total_output_tokens', 'INTEGER'],
+  ['total_tokens', 'INTEGER'],
+  ['total_cost', 'REAL'],
+  ['api_calls', 'INTEGER'],
+  ['tool_calls', 'TEXT'],
+];
+
+export const migration005: Migration = {
+  version: 5,
+  name: 'session_metadata_and_usage',
+
+  up: () => {
+    for (const [name, type] of COLUMNS) {
+      try {
+        execSql(`ALTER TABLE sessions ADD COLUMN ${name} ${type}`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message.includes('duplicate column') || message.includes('already exists')) {
+          logger.debug(`sessions.${name} already exists`);
+          continue;
+        }
+        throw error;
+      }
+    }
+  },
+
+  down: () => {
+    // SQLite cannot drop columns without a table rebuild. Keep as no-op.
+  },
+};

--- a/src/infrastructure/database/migrations/all.ts
+++ b/src/infrastructure/database/migrations/all.ts
@@ -9,6 +9,7 @@ import { migration001 } from './001_initial.js';
 import { migration002 } from './002_memory.js';
 import { migration003 } from './003_terminal_auth.js';
 import { migration004 } from './004_sessions_last_message.js';
+import { migration005 } from './005_session_metadata.js';
 
 /** All available migrations */
 export const allMigrations: Migration[] = [
@@ -16,4 +17,5 @@ export const allMigrations: Migration[] = [
   migration002,
   migration003,
   migration004,
+  migration005,
 ];

--- a/src/infrastructure/database/repositories/session.repository.ts
+++ b/src/infrastructure/database/repositories/session.repository.ts
@@ -361,13 +361,13 @@ class SessionRepository implements ISessionRepository {
           INSERT INTO sessions (
             id, session_id, directory, status, title, initial_prompt,
             last_tool, last_tool_input, current_file, last_message,
-            started_at, last_active_at, pid, tty,
+            started_at, last_active_at, completed_at, pid, tty,
             tool_count, message_count,
             agent_id, parent_session_id, is_sub_agent,
             total_input_tokens, total_output_tokens, total_tokens, total_cost, api_calls,
             tool_calls,
             created_at, updated_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `).run(
           id,
           data.sessionId,
@@ -381,6 +381,7 @@ class SessionRepository implements ISessionRepository {
           data.lastMessage ?? null,
           data.startedAt?.toISOString() ?? null,
           data.lastActiveAt?.toISOString() || now,
+          data.completedAt?.toISOString() ?? null,
           data.pid ?? null,
           data.tty ?? null,
           data.toolCount || 0,

--- a/src/infrastructure/database/repositories/session.repository.ts
+++ b/src/infrastructure/database/repositories/session.repository.ts
@@ -10,6 +10,7 @@ import type {
   Session,
   SessionListItem,
   SessionStatus,
+  ToolCallInfo,
 } from '../../../domain/session/index.js';
 import type { ISessionRepository, SessionUpsertData } from '../../../domain/session/repository.js';
 
@@ -32,6 +33,15 @@ interface SessionRow {
   tty: string | null;
   tool_count: number;
   message_count: number;
+  agent_id: string | null;
+  parent_session_id: string | null;
+  is_sub_agent: number;
+  total_input_tokens: number | null;
+  total_output_tokens: number | null;
+  total_tokens: number | null;
+  total_cost: number | null;
+  api_calls: number | null;
+  tool_calls: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -65,6 +75,17 @@ interface ExistingSessionSummaryRow {
   title: string | null;
 }
 
+/** Safely parse the tool_calls JSON column (returns undefined on missing/corrupt data). */
+function parseToolCalls(raw: string | null): ToolCallInfo[] | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as ToolCallInfo[]) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Convert database row to Session entity */
 function rowToSession(row: SessionRow): Session {
   return {
@@ -85,6 +106,19 @@ function rowToSession(row: SessionRow): Session {
     tty: row.tty || undefined,
     toolCount: row.tool_count,
     messageCount: row.message_count,
+    agentId: row.agent_id || undefined,
+    parentSessionId: row.parent_session_id || undefined,
+    isSubAgent: row.is_sub_agent === 1,
+    usageStats: row.total_tokens != null
+      ? {
+          totalInputTokens: row.total_input_tokens ?? 0,
+          totalOutputTokens: row.total_output_tokens ?? 0,
+          totalTokens: row.total_tokens ?? 0,
+          totalCost: row.total_cost ?? 0,
+          apiCalls: row.api_calls ?? 0,
+        }
+      : undefined,
+    toolCalls: parseToolCalls(row.tool_calls),
     createdAt: new Date(row.created_at),
     updatedAt: new Date(row.updated_at),
   };
@@ -275,6 +309,15 @@ class SessionRepository implements ISessionRepository {
           tty = CASE WHEN ? THEN ? ELSE tty END,
           tool_count = COALESCE(?, tool_count),
           message_count = COALESCE(?, message_count),
+          agent_id = COALESCE(?, agent_id),
+          parent_session_id = COALESCE(?, parent_session_id),
+          is_sub_agent = COALESCE(?, is_sub_agent),
+          total_input_tokens = COALESCE(?, total_input_tokens),
+          total_output_tokens = COALESCE(?, total_output_tokens),
+          total_tokens = COALESCE(?, total_tokens),
+          total_cost = COALESCE(?, total_cost),
+          api_calls = COALESCE(?, api_calls),
+          tool_calls = COALESCE(?, tool_calls),
           updated_at = ?
         WHERE session_id = ?
       `).run(
@@ -294,6 +337,15 @@ class SessionRepository implements ISessionRepository {
         data.tty ?? null,
         data.toolCount ?? null,
         data.messageCount ?? null,
+        data.agentId ?? null,
+        data.parentSessionId ?? null,
+        data.isSubAgent != null ? (data.isSubAgent ? 1 : 0) : null,
+        data.usageStats?.totalInputTokens ?? null,
+        data.usageStats?.totalOutputTokens ?? null,
+        data.usageStats?.totalTokens ?? null,
+        data.usageStats?.totalCost ?? null,
+        data.usageStats?.apiCalls ?? null,
+        data.toolCalls ? JSON.stringify(data.toolCalls) : null,
         now,
         data.sessionId
       );
@@ -310,8 +362,12 @@ class SessionRepository implements ISessionRepository {
             id, session_id, directory, status, title, initial_prompt,
             last_tool, last_tool_input, current_file, last_message,
             started_at, last_active_at, pid, tty,
-            tool_count, message_count, created_at, updated_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            tool_count, message_count,
+            agent_id, parent_session_id, is_sub_agent,
+            total_input_tokens, total_output_tokens, total_tokens, total_cost, api_calls,
+            tool_calls,
+            created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `).run(
           id,
           data.sessionId,
@@ -329,6 +385,15 @@ class SessionRepository implements ISessionRepository {
           data.tty ?? null,
           data.toolCount || 0,
           data.messageCount || 0,
+          data.agentId ?? null,
+          data.parentSessionId ?? null,
+          data.isSubAgent ? 1 : 0,
+          data.usageStats?.totalInputTokens ?? null,
+          data.usageStats?.totalOutputTokens ?? null,
+          data.usageStats?.totalTokens ?? null,
+          data.usageStats?.totalCost ?? null,
+          data.usageStats?.apiCalls ?? null,
+          data.toolCalls ? JSON.stringify(data.toolCalls) : null,
           now,
           now
         );

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -120,7 +120,11 @@ export class SessionService {
       const runningClaudePids = new Set(processes.map((process) => process.pid));
 
       // Get Claude sessions from file system (with optional age filter for performance)
-      const scannedClaudeSessions = await getClaudeSessions({ maxAgeDays });
+      const scannedClaudeSessions = await getClaudeSessions({
+        maxAgeDays,
+        includeSubAgents: true,
+        includeToolCalls: true,
+      });
       const invalidClaudeSessions = scannedClaudeSessions.filter(
         (session) => !isValidSessionId(session.sessionId)
       );

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -182,6 +182,11 @@ export class SessionService {
             tty: process?.tty,
             toolCount: claudeSession.toolCount,
             messageCount: claudeSession.messageCount,
+            agentId: claudeSession.agentId,
+            parentSessionId: claudeSession.parentSessionId,
+            isSubAgent: claudeSession.isSubAgent,
+            usageStats: claudeSession.usageStats,
+            toolCalls: claudeSession.toolCalls,
           });
           existingSessionMap.set(claudeSession.sessionId, updatedSession);
 
@@ -214,6 +219,11 @@ export class SessionService {
             tty: process?.tty,
             toolCount: claudeSession.toolCount,
             messageCount: claudeSession.messageCount,
+            agentId: claudeSession.agentId,
+            parentSessionId: claudeSession.parentSessionId,
+            isSubAgent: claudeSession.isSubAgent,
+            usageStats: claudeSession.usageStats,
+            toolCalls: claudeSession.toolCalls,
           });
           existingSessionMap.set(claudeSession.sessionId, newSession);
           emit('session:discovered', { session: newSession });


### PR DESCRIPTION
## What / Why
Parser produces `agentId`/`parentSessionId`/`isSubAgent`/`usageStats`/`toolCalls`, but they were dropped at the persistence boundary (no schema columns, `SessionUpsertData` did not accept them, repository did not map them). Fixes Critical data-integrity issue #13.

## Changes
- **migration 005** (idempotent ALTER): `agent_id`, `parent_session_id`, `is_sub_agent`, `total_input_tokens`, `total_output_tokens`, `total_tokens`, `total_cost`, `api_calls`, `tool_calls` (JSON)
- `Session` entity + `SessionUpsertData`: add fields
- repository: `SessionRow`/`rowToSession` + upsert UPDATE/INSERT mapping; `tool_calls` stored as JSON, parsed defensively
- service sync: pass parser fields through both upsert paths so the flow is wired end-to-end (U-26)
- test: round-trip assertion

## Proof
- `bun x tsc --noEmit`: 0 errors
- `bun test session-repository.test.ts`: 3 pass / 0 fail (migration 005 applies, fields round-trip)
- Full suite: 233 pass. The 5 `pty-manager` failures pre-exist on clean main (sandbox cwd allowlist) — verified via git stash.

## AI Role
AI-generated (schema migration + repository/service mapping + test). Risk: **medium** — touches persistence + DB migration.

## Review Focus
1. Migration 005 idempotency on existing production DBs (try/catch on duplicate-column)
2. `tool_calls` as JSON column vs normalizing into the existing (unused) `tool_usage` table — chose JSON for minimal change, consistent with `last_tool_input`

Closes #13