### PR TITLE
fix(errors): surface degraded session data failures

### DIFF
--- a/menubar-tauri/src-tauri/src/codex.rs
+++ b/menubar-tauri/src-tauri/src/codex.rs
@@ -2,7 +2,7 @@
 //! account info, session stats, and rate limits.
 
 use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine as _};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{BufRead, BufReader};
@@ -19,6 +19,59 @@ pub struct CodexData {
     pub subscription_until: Option<String>,
     pub email: Option<String>,
     pub error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn ts(value: &str) -> i64 {
+        match DateTime::parse_from_rfc3339(value) {
+            Ok(parsed) => parsed.timestamp(),
+            Err(error) => panic!("invalid fixed test timestamp: {}", error),
+        }
+    }
+
+    fn test_date() -> NaiveDate {
+        match NaiveDate::from_ymd_opt(2026, 4, 13) {
+            Some(date) => date,
+            None => panic!("invalid fixed test date"),
+        }
+    }
+
+    #[test]
+    fn collect_codex_stats_counts_valid_history() {
+        let today = test_date();
+        let history = format!(
+            "{{\"ts\":{}}}\n{{\"ts\":{}}}\n",
+            ts("2026-04-13T10:00:00Z"),
+            ts("2026-04-12T10:00:00Z")
+        );
+
+        let stats = collect_codex_stats(Cursor::new(history), today);
+
+        assert_eq!(stats.total_sessions, 2);
+        assert_eq!(stats.today_sessions, 1);
+        assert!(stats.last_activity.is_some());
+        assert_eq!(stats.error, None);
+    }
+
+    #[test]
+    fn collect_codex_stats_surfaces_malformed_history_line() {
+        let today = test_date();
+        let history = format!("{{\"ts\":{}}}\nnot-json\n", ts("2026-04-13T10:00:00Z"));
+
+        let stats = collect_codex_stats(Cursor::new(history), today);
+
+        assert_eq!(stats.total_sessions, 0);
+        assert_eq!(stats.today_sessions, 0);
+        assert!(stats.last_activity.is_none());
+        assert!(stats
+            .error
+            .as_deref()
+            .is_some_and(|message| message.contains("Failed to parse history.jsonl line 2")));
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -70,6 +123,73 @@ fn get_codex_home() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".codex"))
 }
 
+fn codex_stats_error(message: String) -> CodexStats {
+    CodexStats {
+        total_sessions: 0,
+        today_sessions: 0,
+        last_activity: None,
+        error: Some(message),
+    }
+}
+
+fn collect_codex_stats<R: BufRead>(reader: R, today: NaiveDate) -> CodexStats {
+    let mut total_sessions = 0u32;
+    let mut today_sessions = 0u32;
+    let mut last_ts: Option<i64> = None;
+
+    for (index, line) in reader.lines().enumerate() {
+        let line_number = index + 1;
+        let line_content = match line {
+            Ok(content) => content,
+            Err(e) => {
+                return codex_stats_error(format!(
+                    "Failed to read history.jsonl line {}: {}",
+                    line_number, e
+                ));
+            }
+        };
+
+        if line_content.trim().is_empty() {
+            continue;
+        }
+
+        let entry = match serde_json::from_str::<serde_json::Value>(&line_content) {
+            Ok(entry) => entry,
+            Err(e) => {
+                return codex_stats_error(format!(
+                    "Failed to parse history.jsonl line {}: {}",
+                    line_number, e
+                ));
+            }
+        };
+
+        total_sessions += 1;
+
+        if let Some(ts) = entry["ts"].as_i64() {
+            if let Some(dt) = DateTime::from_timestamp(ts, 0) {
+                if dt.date_naive() == today {
+                    today_sessions += 1;
+                }
+            }
+
+            if last_ts.map_or(true, |old| ts > old) {
+                last_ts = Some(ts);
+            }
+        }
+    }
+
+    let last_activity = last_ts
+        .and_then(|ts| DateTime::from_timestamp(ts, 0))
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string());
+
+    CodexStats {
+        total_sessions,
+        today_sessions,
+        last_activity,
+        error: None,
+    }
+}
+
 // Decode a JWT payload without verification (used to read ChatGPT account
 // metadata from a locally stored token).
 fn decode_jwt_payload(token: &str) -> Option<serde_json::Value> {
@@ -90,7 +210,11 @@ fn decode_jwt_payload(token: &str) -> Option<serde_json::Value> {
     STANDARD_NO_PAD
         .decode(&standard)
         .ok()
-        .or_else(|| base64::engine::general_purpose::STANDARD.decode(&standard).ok())
+        .or_else(|| {
+            base64::engine::general_purpose::STANDARD
+                .decode(&standard)
+                .ok()
+        })
         .and_then(|bytes| String::from_utf8(bytes).ok())
         .and_then(|json| serde_json::from_str(&json).ok())
 }
@@ -275,48 +399,15 @@ pub async fn get_codex_stats() -> Result<CodexStats, String> {
         }
     };
 
-    let reader = BufReader::new(file);
-    let today = Utc::now().date_naive();
-    let mut total_sessions = 0u32;
-    let mut today_sessions = 0u32;
-    let mut last_ts: Option<i64> = None;
-
-    for line in reader.lines() {
-        if let Ok(line_content) = line {
-            if let Ok(entry) = serde_json::from_str::<serde_json::Value>(&line_content) {
-                total_sessions += 1;
-
-                if let Some(ts) = entry["ts"].as_i64() {
-                    if let Some(dt) = DateTime::from_timestamp(ts, 0) {
-                        if dt.date_naive() == today {
-                            today_sessions += 1;
-                        }
-                    }
-
-                    if last_ts.map_or(true, |old| ts > old) {
-                        last_ts = Some(ts);
-                    }
-                }
-            }
-        }
-    }
-
-    let last_activity = last_ts
-        .and_then(|ts| DateTime::from_timestamp(ts, 0))
-        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string());
-
-    Ok(CodexStats {
-        total_sessions,
-        today_sessions,
-        last_activity,
-        error: None,
-    })
+    Ok(collect_codex_stats(
+        BufReader::new(file),
+        Utc::now().date_naive(),
+    ))
 }
 
 #[tauri::command]
 pub async fn open_chatgpt_quota() -> Result<(), String> {
-    tauri_plugin_opener::open_url("https://chatgpt.com", None::<&str>)
-        .map_err(|e| e.to_string())
+    tauri_plugin_opener::open_url("https://chatgpt.com", None::<&str>).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -426,46 +517,45 @@ pub async fn get_codex_rate_limits() -> Result<CodexRateLimits, String> {
                     Ok(data) => {
                         let plan_type = data["plan_type"].as_str().map(|s| s.to_string());
 
-                        let primary = data["rate_limit"]
-                            .get("primary_window")
-                            .and_then(|w| {
-                                if w.is_null() {
-                                    None
-                                } else {
-                                    Some(CodexRateLimitWindow {
-                                        used_percent: w["used_percent"].as_f64().unwrap_or(0.0),
-                                        window_minutes: w["limit_window_seconds"]
-                                            .as_i64()
-                                            .map(|s| (s + 59) / 60),
-                                        resets_at: w["reset_at"].as_i64(),
-                                    })
-                                }
-                            });
+                        let primary = data["rate_limit"].get("primary_window").and_then(|w| {
+                            if w.is_null() {
+                                None
+                            } else {
+                                Some(CodexRateLimitWindow {
+                                    used_percent: w["used_percent"].as_f64().unwrap_or(0.0),
+                                    window_minutes: w["limit_window_seconds"]
+                                        .as_i64()
+                                        .map(|s| (s + 59) / 60),
+                                    resets_at: w["reset_at"].as_i64(),
+                                })
+                            }
+                        });
 
-                        let secondary = data["rate_limit"]
-                            .get("secondary_window")
-                            .and_then(|w| {
-                                if w.is_null() {
-                                    None
-                                } else {
-                                    Some(CodexRateLimitWindow {
-                                        used_percent: w["used_percent"].as_f64().unwrap_or(0.0),
-                                        window_minutes: w["limit_window_seconds"]
-                                            .as_i64()
-                                            .map(|s| (s + 59) / 60),
-                                        resets_at: w["reset_at"].as_i64(),
-                                    })
-                                }
-                            });
+                        let secondary = data["rate_limit"].get("secondary_window").and_then(|w| {
+                            if w.is_null() {
+                                None
+                            } else {
+                                Some(CodexRateLimitWindow {
+                                    used_percent: w["used_percent"].as_f64().unwrap_or(0.0),
+                                    window_minutes: w["limit_window_seconds"]
+                                        .as_i64()
+                                        .map(|s| (s + 59) / 60),
+                                    resets_at: w["reset_at"].as_i64(),
+                                })
+                            }
+                        });
 
                         let credits = data["credits"].as_object().map(|c| CodexCredits {
-                            has_credits: c.get("has_credits")
+                            has_credits: c
+                                .get("has_credits")
                                 .and_then(|v| v.as_bool())
                                 .unwrap_or(false),
-                            unlimited: c.get("unlimited")
+                            unlimited: c
+                                .get("unlimited")
                                 .and_then(|v| v.as_bool())
                                 .unwrap_or(false),
-                            balance: c.get("balance")
+                            balance: c
+                                .get("balance")
                                 .and_then(|v| v.as_str())
                                 .map(|s| s.to_string()),
                         });

--- a/src/__tests__/auth-token-safety.test.ts
+++ b/src/__tests__/auth-token-safety.test.ts
@@ -14,9 +14,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { setupUser, verifyToken } from '../services/auth.service.js';
+import { login, setupUser, verifyToken } from '../services/auth.service.js';
 import { resetDatabase } from '../db/migrations.js';
-import { closeDatabase } from '../infrastructure/database/sqlite.js';
+import { closeDatabase, execSql } from '../infrastructure/database/sqlite.js';
 
 describe('verifyToken hardening', () => {
   beforeEach(() => {
@@ -91,5 +91,12 @@ describe('verifyToken hardening', () => {
     expect(verifyToken('not-a-token')).toBeNull();
     expect(verifyToken('a.b')).toBeNull();
     expect(verifyToken('a.b.c.d')).toBeNull();
+  });
+
+  test('login fails closed when audit logging is unavailable', async () => {
+    await setupUser('alice', 'password123');
+    execSql('DROP TABLE terminal_audit_log');
+
+    await expect(login('alice', 'password123')).rejects.toThrow('Failed to write audit log');
   });
 });

--- a/src/__tests__/sessions.route-basic.test.ts
+++ b/src/__tests__/sessions.route-basic.test.ts
@@ -70,4 +70,35 @@ describe('Basic Sessions Route Contract', () => {
     expect('lastTool' in session).toBe(false);
     expect('lastToolInput' in session).toBe(false);
   });
+
+  test('details returns null usageStats when parsed source data is unavailable', async () => {
+    sessionRepository.upsert({
+      sessionId: 'session-no-source',
+      directory: '/tmp/claude-hub-no-source',
+      status: 'completed',
+      title: 'No parsed source',
+      initialPrompt: 'No source',
+      lastActiveAt: new Date('2026-04-13T10:00:05.000Z'),
+      toolCount: 0,
+      messageCount: 1,
+    });
+
+    const { token } = await setupUser('details-route-user', 'password123');
+    const response = await sessions.fetch(new Request(
+      'http://localhost/session-no-source/details',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json() as {
+      success: boolean;
+      data: {
+        usageStats: unknown;
+      };
+    };
+
+    expect(body.success).toBe(true);
+    expect(body.data.usageStats).toBeNull();
+  });
 });

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -246,6 +246,7 @@ export function logAudit(userId: string | null, action: string, ip?: string, det
     );
   } catch (e) {
     logger.error('Failed to write audit log', e);
+    throw new Error('Failed to write audit log');
   }
 }
 

--- a/src/services/pty.manager.ts
+++ b/src/services/pty.manager.ts
@@ -157,7 +157,8 @@ class PtyManager {
         try {
           client.send(msg);
         } catch (e) {
-          logger.debug(`PTY ${sessionId}: client send failed (likely disconnected)`, e);
+          session.attachedClients.delete(client);
+          logger.warn(`PTY ${sessionId}: client send failed; detached disconnected client`, e);
         }
       }
     });
@@ -171,7 +172,8 @@ class PtyManager {
         try {
           client.send(msg);
         } catch (e) {
-          logger.debug(`PTY ${sessionId}: client send (exit) failed`, e);
+          session.attachedClients.delete(client);
+          logger.warn(`PTY ${sessionId}: client send (exit) failed; detached disconnected client`, e);
         }
       }
       // Update DB

--- a/src/web/api/routes/sessions.ts
+++ b/src/web/api/routes/sessions.ts
@@ -323,13 +323,7 @@ app.get('/:id/details', async (c) => {
         lastTool: dbSession.lastTool || '',
         lastToolInput: dbSession.lastToolInput || '',
         currentFile: dbSession.currentFile || '',
-        usageStats: parsedSession?.usageStats || {
-          totalInputTokens: 0,
-          totalOutputTokens: 0,
-          totalTokens: 0,
-          totalCost: 0,
-          apiCalls: 0,
-        },
+        usageStats: parsedSession?.usageStats ?? null,
       },
     });
   } catch (error) {
@@ -387,13 +381,7 @@ app.get('/:id/full', async (c) => {
           lastTool: dbSession.lastTool || '',
           lastToolInput: dbSession.lastToolInput || '',
           currentFile: dbSession.currentFile || '',
-          usageStats: parsedSession?.usageStats || {
-            totalInputTokens: 0,
-            totalOutputTokens: 0,
-            totalTokens: 0,
-            totalCost: 0,
-            apiCalls: 0,
-          },
+          usageStats: parsedSession?.usageStats ?? null,
         },
         // Tool calls
         tools: {

--- a/src/web/api/terminal-websocket.ts
+++ b/src/web/api/terminal-websocket.ts
@@ -22,7 +22,7 @@ function send(ws: ServerWebSocket<any>, msg: object) {
   try {
     ws.send(JSON.stringify(msg));
   } catch (e) {
-    logger.debug('Terminal WS send failed (client likely disconnected)', e);
+    logger.warn('Terminal WS send failed (client likely disconnected)', e);
   }
 }
 


### PR DESCRIPTION
## What / Why\nFixes #15 by making previously silent degradation paths visible instead of returning synthetic zero-data or swallowing operational failures.\n\n## Changes\n- session details/full APIs return `usageStats: null` when parsed source data is unavailable, instead of fabricated zero totals\n- Tauri Codex stats now surfaces history.jsonl read/parse failures via `CodexStats.error`\n- terminal WS send failures are logged at warn level; PTY broadcast detaches disconnected clients\n- audit log write failures now fail closed instead of letting login continue silently\n\n## Proof\n- `bun run typecheck`\n- `bun test` (242 pass / 0 fail)\n- `cargo check` in `menubar-tauri/src-tauri`\n- `cargo test --lib` in `menubar-tauri/src-tauri` (11 pass / 0 fail)\n- `git diff --check`\n\n## Notes\n- Full `cargo fmt --check` still reports pre-existing formatting drift in unrelated Tauri files; this PR only formatted the touched `src/codex.rs` with `rustfmt --edition 2021 --check src/codex.rs`.