### PR TITLE
Fix active issue queue

### DIFF
--- a/src/__tests__/auth-local-login.test.ts
+++ b/src/__tests__/auth-local-login.test.ts
@@ -15,7 +15,7 @@ async function parseJson(response: Response): Promise<LocalLoginResponse> {
   return (await response.json()) as LocalLoginResponse;
 }
 
-async function postFromLoopback(): Promise<{ status: number; body: LocalLoginResponse }> {
+async function postFromLoopback(headers?: Record<string, string>): Promise<{ status: number; body: LocalLoginResponse }> {
   const server = Bun.serve({
     hostname: '127.0.0.1',
     port: 0,
@@ -27,6 +27,7 @@ async function postFromLoopback(): Promise<{ status: number; body: LocalLoginRes
   try {
     const response = await fetch(`http://127.0.0.1:${server.port}/local`, {
       method: 'POST',
+      headers,
     });
     return { status: response.status, body: await parseJson(response) };
   } finally {
@@ -107,11 +108,57 @@ describe('local auth route', () => {
     expect(response.body.data?.token).toBeUndefined();
   });
 
+  test('rejects a spoofed Host header over an actual loopback socket', async () => {
+    const response = await postFromLoopback({ host: 'evil.test' });
+
+    expect(response.status).toBe(403);
+    expect(response.body.success).toBe(false);
+    expect(response.body.data?.token).toBeUndefined();
+  });
+
+  test('rejects cross-site browser metadata for local login', async () => {
+    const response = await postFromLoopback({
+      origin: 'https://evil.test',
+      'sec-fetch-site': 'cross-site',
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.body.success).toBe(false);
+    expect(response.body.data?.token).toBeUndefined();
+  });
+
   test('allows local login from an actual loopback socket', async () => {
     const response = await postFromLoopback();
 
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(true);
     expect(typeof response.body.data?.token).toBe('string');
+  });
+
+  test('allows same-origin browser metadata from loopback', async () => {
+    const server = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      fetch(req, server) {
+        return auth.fetch(req, { server });
+      },
+    });
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/local`, {
+        method: 'POST',
+        headers: {
+          origin: `http://127.0.0.1:${server.port}`,
+          'sec-fetch-site': 'same-origin',
+        },
+      });
+      const body = await parseJson(response);
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(typeof body.data?.token).toBe('string');
+    } finally {
+      server.stop(true);
+    }
   });
 });

--- a/src/__tests__/codex.scanner.test.ts
+++ b/src/__tests__/codex.scanner.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  getAllCodexSessions,
+  scanCodexSessionsDirectory,
+} from '../adapters/codex/scanner.js';
+import { logger } from '../lib/logger.js';
+
+describe('Codex session scanner', () => {
+  let tempDir = '';
+  let originalWarn: typeof logger.warn;
+  let originalDebug: typeof logger.debug;
+  const warnings: Array<{ message: string; data?: unknown }> = [];
+  const debugs: Array<{ message: string; data?: unknown }> = [];
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'keepline-codex-scan-'));
+    originalWarn = logger.warn.bind(logger);
+    originalDebug = logger.debug.bind(logger);
+    warnings.length = 0;
+    debugs.length = 0;
+    logger.warn = (message: string, data?: unknown) => {
+      warnings.push({ message, data });
+    };
+    logger.debug = (message: string, data?: unknown) => {
+      debugs.push({ message, data });
+    };
+  });
+
+  afterEach(() => {
+    logger.warn = originalWarn;
+    logger.debug = originalDebug;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('treats a missing sessions directory as debug no-op', () => {
+    const missingDir = join(tempDir, 'missing-sessions');
+
+    const sessions = scanCodexSessionsDirectory({ sessionsDir: missingDir });
+
+    expect(sessions).toEqual([]);
+    expect(warnings).toHaveLength(0);
+    expect(debugs[0]).toMatchObject({
+      message: 'Codex sessions directory not found, skipping scan',
+      data: { path: missingDir },
+    });
+  });
+
+  test('warns when the sessions path cannot be read', () => {
+    const filePath = join(tempDir, 'sessions');
+    writeFileSync(filePath, 'not a directory');
+
+    const sessions = scanCodexSessionsDirectory({ sessionsDir: filePath });
+
+    expect(sessions).toEqual([]);
+    expect(warnings[0]).toMatchObject({
+      message: 'Skipped unreadable Codex session paths during scan',
+      data: { count: 1, sample: [filePath] },
+    });
+  });
+
+  test('warns with count and sample for invalid Codex session files', async () => {
+    const sessionsDir = join(tempDir, 'sessions');
+    mkdirSync(sessionsDir);
+    const invalidFile = join(sessionsDir, 'rollout-12345678-1234-1234-1234-123456789abc.jsonl');
+    writeFileSync(invalidFile, '{not-json}\n');
+
+    const sessions = await getAllCodexSessions({ sessionsDir });
+
+    expect(sessions).toEqual([]);
+    expect(warnings[0]).toMatchObject({
+      message: 'Skipped invalid Codex session files during scan',
+      data: { count: 1, sample: [invalidFile] },
+    });
+  });
+});

--- a/src/__tests__/hook.installer.test.ts
+++ b/src/__tests__/hook.installer.test.ts
@@ -9,10 +9,15 @@ import type { ClaudeSettings } from '../adapters/hook/types.js';
 const markedCommand = 'KEEPLINE_HOOK_MARKER=keepline-hook-v1 curl -s -X POST http://127.0.0.1:7890/hook';
 const unrelatedLocalhostCommand = 'curl -s http://127.0.0.1:7777/other-hook';
 const legacyKeeplineCommand = `curl -s -X POST http://127.0.0.1:7890/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
+const foreignLegacyShapeCommand = `curl -s -X POST https://collector.example/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
 
 describe('hook installer ownership detection', () => {
   test('does not claim unrelated localhost hooks', () => {
     expect(isKeeplineHook({ command: unrelatedLocalhostCommand })).toBe(false);
+  });
+
+  test('does not claim non-local legacy-shaped hooks', () => {
+    expect(isKeeplineHook({ command: foreignLegacyShapeCommand })).toBe(false);
   });
 
   test('install coexists with unrelated localhost hooks', () => {

--- a/src/__tests__/hook.installer.test.ts
+++ b/src/__tests__/hook.installer.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  installKeeplineHookConfig,
+  isKeeplineHook,
+  uninstallKeeplineHookConfig,
+} from '../adapters/hook/installer.js';
+import type { ClaudeSettings } from '../adapters/hook/types.js';
+
+const markedCommand = 'KEEPLINE_HOOK_MARKER=keepline-hook-v1 curl -s -X POST http://127.0.0.1:7890/hook';
+const unrelatedLocalhostCommand = 'curl -s http://127.0.0.1:7777/other-hook';
+const legacyKeeplineCommand = `curl -s -X POST http://127.0.0.1:7890/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
+
+describe('hook installer ownership detection', () => {
+  test('does not claim unrelated localhost hooks', () => {
+    expect(isKeeplineHook({ command: unrelatedLocalhostCommand })).toBe(false);
+  });
+
+  test('install coexists with unrelated localhost hooks', () => {
+    const settings: ClaudeSettings = {
+      hooks: {
+        PostToolUse: [{ command: unrelatedLocalhostCommand }],
+      },
+    };
+
+    const changed = installKeeplineHookConfig(settings, markedCommand);
+
+    expect(changed).toBe(true);
+    expect(settings.hooks?.PostToolUse).toHaveLength(2);
+    expect(settings.hooks?.PostToolUse?.[0].command).toBe(unrelatedLocalhostCommand);
+    expect(settings.hooks?.PostToolUse?.[1].command).toBe(markedCommand);
+  });
+
+  test('uninstall removes only Keepline-owned hooks', () => {
+    const settings: ClaudeSettings = {
+      hooks: {
+        PostToolUse: [
+          { command: unrelatedLocalhostCommand },
+          { command: markedCommand },
+        ],
+        Stop: [
+          { command: legacyKeeplineCommand },
+          { command: 'echo keep-me' },
+        ],
+      },
+    };
+
+    const removed = uninstallKeeplineHookConfig(settings);
+
+    expect(removed).toBe(2);
+    expect(settings.hooks?.PostToolUse).toEqual([{ command: unrelatedLocalhostCommand }]);
+    expect(settings.hooks?.Stop).toEqual([{ command: 'echo keep-me' }]);
+  });
+
+  test('install upgrades a legacy Keepline hook without duplicating', () => {
+    const settings: ClaudeSettings = {
+      hooks: {
+        PostToolUse: [{ command: legacyKeeplineCommand }],
+      },
+    };
+
+    const changed = installKeeplineHookConfig(settings, markedCommand);
+
+    expect(changed).toBe(true);
+    expect(settings.hooks?.PostToolUse).toEqual([{ command: markedCommand }]);
+  });
+});

--- a/src/__tests__/session-response.test.ts
+++ b/src/__tests__/session-response.test.ts
@@ -69,4 +69,18 @@ describe('Session Response Serialization', () => {
 
     expect(title).toBe('AGENTS.md: project');
   });
+
+  test('generateTitle skips AGENTS preamble when task text follows', () => {
+    const title = generateTitle(`# AGENTS.md instructions for /Users/me/project
+
+<INSTRUCTIONS>
+repo rules
+</INSTRUCTIONS><environment_context>
+cwd metadata
+</environment_context>
+
+Fix active issue queue`);
+
+    expect(title).toBe('Fix active issue queue');
+  });
 });

--- a/src/__tests__/session-response.test.ts
+++ b/src/__tests__/session-response.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { generateTitle } from '../domain/session/entity.js';
 import { serializeBasicSession } from '../web/api/session-response.js';
 
 describe('Session Response Serialization', () => {
@@ -61,5 +62,11 @@ describe('Session Response Serialization', () => {
     expect('lastToolInput' in serialized).toBe(false);
     expect('currentFile' in serialized).toBe(false);
     expect('lastMessage' in serialized).toBe(false);
+  });
+
+  test('generateTitle summarizes AGENTS instruction payloads by project', () => {
+    const title = generateTitle(`# AGENTS.md instructions for /Users/me/project\n\n<INSTRUCTIONS>\nvery long payload`);
+
+    expect(title).toBe('AGENTS.md: project');
   });
 });

--- a/src/__tests__/sessions.route-basic.test.ts
+++ b/src/__tests__/sessions.route-basic.test.ts
@@ -145,4 +145,35 @@ describe('Basic Sessions Route Contract', () => {
     expect(body.data.pagination.hasMore).toBe(false);
     expect(body.data.sessions.map((session) => session.sessionId)).toEqual(['session-search-match']);
   });
+
+  test('rejects invalid status filters instead of returning unfiltered sessions', async () => {
+    sessionRepository.upsert({
+      sessionId: 'session-invalid-status-filter',
+      directory: '/tmp/keepline-invalid-status-filter',
+      status: 'completed',
+      title: 'Should not leak through invalid filter',
+      initialPrompt: 'No source',
+      lastActiveAt: new Date('2026-04-13T10:00:05.000Z'),
+      toolCount: 0,
+      messageCount: 1,
+    });
+
+    const { token } = await setupUser('invalid-status-route-user', 'password123');
+    const response = await sessions.fetch(new Request(
+      'http://localhost/?skipSync=true&fields=basic&status=runing',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(400);
+
+    const body = await response.json() as {
+      success: boolean;
+      error: string;
+      data?: { sessions: Array<{ sessionId: string }> };
+    };
+
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Invalid status filter: runing');
+    expect(body.data).toBeUndefined();
+  });
 });

--- a/src/__tests__/sessions.route-basic.test.ts
+++ b/src/__tests__/sessions.route-basic.test.ts
@@ -101,4 +101,48 @@ describe('Basic Sessions Route Contract', () => {
     expect(body.success).toBe(true);
     expect(body.data.usageStats).toBeNull();
   });
+
+  test('fields=basic search filters globally before pagination', async () => {
+    sessionRepository.upsert({
+      sessionId: 'session-search-match',
+      directory: '/tmp/keepline-search',
+      status: 'completed',
+      title: 'Unrelated title',
+      initialPrompt: 'Find the hidden global needle',
+      lastActiveAt: new Date('2026-04-13T10:00:05.000Z'),
+      toolCount: 0,
+      messageCount: 1,
+    });
+    sessionRepository.upsert({
+      sessionId: 'session-search-miss',
+      directory: '/tmp/keepline-other',
+      status: 'completed',
+      title: 'Other work',
+      initialPrompt: 'No matching text here',
+      lastActiveAt: new Date('2026-04-13T10:00:06.000Z'),
+      toolCount: 0,
+      messageCount: 1,
+    });
+
+    const { token } = await setupUser('search-route-user', 'password123');
+    const response = await sessions.fetch(new Request(
+      'http://localhost/?skipSync=true&fields=basic&q=needle&limit=1',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json() as {
+      success: boolean;
+      data: {
+        sessions: Array<{ sessionId: string }>;
+        pagination: { total: number; hasMore: boolean };
+      };
+    };
+
+    expect(body.success).toBe(true);
+    expect(body.data.pagination.total).toBe(1);
+    expect(body.data.pagination.hasMore).toBe(false);
+    expect(body.data.sessions.map((session) => session.sessionId)).toEqual(['session-search-match']);
+  });
 });

--- a/src/__tests__/terminal-security.test.ts
+++ b/src/__tests__/terminal-security.test.ts
@@ -52,6 +52,20 @@ describe('terminal WebSocket Origin guard', () => {
       ['https://hub.example.com'],
     )).toBe(true);
   });
+
+  test('accepts local interface origins for wildcard-bound servers', () => {
+    const req = new Request('http://192.168.1.10:3377/ws/terminal', {
+      headers: { Origin: 'http://192.168.1.10:3377' },
+    });
+    expect(isAllowedTerminalOrigin(
+      req,
+      '0.0.0.0',
+      3377,
+      false,
+      [],
+      ['192.168.1.10'],
+    )).toBe(true);
+  });
 });
 
 describe('request Host allowlist', () => {
@@ -85,6 +99,20 @@ describe('request Host allowlist', () => {
       3377,
       ['https://hub.example.com'],
     )).toBe(true);
+  });
+
+  test('accepts local interface hosts for wildcard-bound servers', () => {
+    const req = new Request('http://192.168.1.10:3377/ws', {
+      headers: { host: '192.168.1.10:3377' },
+    });
+    expect(isAllowedRequestHost(req, '0.0.0.0', 3377, [], ['192.168.1.10'])).toBe(true);
+  });
+
+  test('rejects arbitrary hosts for wildcard-bound servers', () => {
+    const req = new Request('http://attacker.example:3377/ws', {
+      headers: { host: 'attacker.example:3377' },
+    });
+    expect(isAllowedRequestHost(req, '0.0.0.0', 3377, [], ['192.168.1.10'])).toBe(false);
   });
 });
 

--- a/src/__tests__/terminal-security.test.ts
+++ b/src/__tests__/terminal-security.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { resolveAllowedTerminalCwd } from '../services/pty.manager.js';
 import { isAllowedTerminalOrigin } from '../web/api/terminal-security.js';
+import { isAllowedRequestHost } from '../web/api/request-security.js';
 
 describe('terminal WebSocket Origin guard', () => {
   test('rejects missing Origin headers', () => {
@@ -48,6 +49,40 @@ describe('terminal WebSocket Origin guard', () => {
       '127.0.0.1',
       3377,
       false,
+      ['https://hub.example.com'],
+    )).toBe(true);
+  });
+});
+
+describe('request Host allowlist', () => {
+  test('accepts loopback aliases for a loopback-bound server', () => {
+    expect(isAllowedRequestHost(
+      new Request('http://127.0.0.1:3377/ws', { headers: { host: 'localhost:3377' } }),
+      '127.0.0.1',
+      3377,
+    )).toBe(true);
+    expect(isAllowedRequestHost(
+      new Request('http://127.0.0.1:3377/ws', { headers: { host: '[::1]:3377' } }),
+      '127.0.0.1',
+      3377,
+    )).toBe(true);
+  });
+
+  test('rejects attacker-controlled Host values', () => {
+    const req = new Request('http://127.0.0.1:3377/ws', {
+      headers: { host: 'evil.test' },
+    });
+    expect(isAllowedRequestHost(req, '127.0.0.1', 3377)).toBe(false);
+  });
+
+  test('accepts configured public hosts for reverse proxies', () => {
+    const req = new Request('http://127.0.0.1:3377/ws', {
+      headers: { host: 'hub.example.com' },
+    });
+    expect(isAllowedRequestHost(
+      req,
+      '127.0.0.1',
+      3377,
       ['https://hub.example.com'],
     )).toBe(true);
   });

--- a/src/adapters/codex/scanner.ts
+++ b/src/adapters/codex/scanner.ts
@@ -13,6 +13,7 @@ import type { CodexParsedSessionData, CodexSessionFile } from './types.js';
 export interface CodexScanOptions {
   includeToolCalls?: boolean;
   maxAgeDays?: number;
+  sessionsDir?: string;
 }
 
 interface CodexSessionCache {
@@ -32,12 +33,21 @@ export function clearCodexSessionCache(): void {
 function scanDirectoryRecursive(
   dir: string,
   cutoffTime: number,
-  sessions: CodexSessionFile[]
+  sessions: CodexSessionFile[],
+  readFailures: string[]
 ): void {
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    readFailures.push(dir);
+    return;
+  }
+
+  for (const entry of entries) {
     const path = join(dir, entry.name);
     if (entry.isDirectory()) {
-      scanDirectoryRecursive(path, cutoffTime, sessions);
+      scanDirectoryRecursive(path, cutoffTime, sessions, readFailures);
       continue;
     }
 
@@ -45,7 +55,13 @@ function scanDirectoryRecursive(
       continue;
     }
 
-    const fileStat = statSync(path);
+    let fileStat;
+    try {
+      fileStat = statSync(path);
+    } catch {
+      readFailures.push(path);
+      continue;
+    }
     if (cutoffTime > 0 && fileStat.mtime.getTime() < cutoffTime) {
       continue;
     }
@@ -72,8 +88,9 @@ function scanDirectoryRecursive(
 }
 
 export function scanCodexSessionsDirectory(options: CodexScanOptions = {}): CodexSessionFile[] {
-  if (!existsSync(CODEX_SESSIONS)) {
-    logger.warn('Codex sessions directory not found');
+  const sessionsDir = options.sessionsDir ?? CODEX_SESSIONS;
+  if (!existsSync(sessionsDir)) {
+    logger.debug('Codex sessions directory not found, skipping scan', { path: sessionsDir });
     return [];
   }
 
@@ -81,7 +98,14 @@ export function scanCodexSessionsDirectory(options: CodexScanOptions = {}): Code
     ? Date.now() - options.maxAgeDays * 24 * 60 * 60 * 1000
     : 0;
   const sessions: CodexSessionFile[] = [];
-  scanDirectoryRecursive(CODEX_SESSIONS, cutoffTime, sessions);
+  const readFailures: string[] = [];
+  scanDirectoryRecursive(sessionsDir, cutoffTime, sessions, readFailures);
+  if (readFailures.length > 0) {
+    logger.warn('Skipped unreadable Codex session paths during scan', {
+      count: readFailures.length,
+      sample: readFailures.slice(0, 5),
+    });
+  }
   return sessions;
 }
 

--- a/src/adapters/hook/installer.ts
+++ b/src/adapters/hook/installer.ts
@@ -43,7 +43,7 @@ function getHookCommand(): string {
 function isLegacyKeeplineHookCommand(command: string): boolean {
   return (
     command.includes('curl -s -X POST') &&
-    command.includes('/hook') &&
+    /\bhttp:\/\/127\.0\.0\.1:\d+\/hook\b/.test(command) &&
     command.includes('"event_type":"$CLAUDE_EVENT_TYPE"') &&
     command.includes('"session_id":"$CLAUDE_SESSION_ID"') &&
     command.includes('"cwd":"$PWD"') &&

--- a/src/adapters/hook/installer.ts
+++ b/src/adapters/hook/installer.ts
@@ -8,6 +8,9 @@ import { config } from '../../lib/config.js';
 import { logger } from '../../lib/logger.js';
 import type { ClaudeSettings, ClaudeHookConfig } from './types.js';
 
+const KEEPLINE_HOOK_MARKER = 'KEEPLINE_HOOK_MARKER=keepline-hook-v1';
+const HOOK_TYPES = ['PreToolUse', 'PostToolUse', 'Notification', 'Stop', 'UserPromptSubmit'] as const;
+
 /** Get current Claude settings */
 function getClaudeSettings(): ClaudeSettings {
   if (!existsSync(CLAUDE_SETTINGS)) {
@@ -34,54 +37,97 @@ function saveClaudeSettings(settings: ClaudeSettings): void {
 /** Generate hook command */
 function getHookCommand(): string {
   const port = config.get().hookPort;
-  return `curl -s -X POST http://127.0.0.1:${port}/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
+  return `${KEEPLINE_HOOK_MARKER} curl -s -X POST http://127.0.0.1:${port}/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
 }
 
-function isKeeplineHook(hook: unknown): hook is ClaudeHookConfig {
+function isLegacyKeeplineHookCommand(command: string): boolean {
+  return (
+    command.includes('curl -s -X POST') &&
+    command.includes('/hook') &&
+    command.includes('"event_type":"$CLAUDE_EVENT_TYPE"') &&
+    command.includes('"session_id":"$CLAUDE_SESSION_ID"') &&
+    command.includes('"cwd":"$PWD"') &&
+    command.includes('"tool_name":"$CLAUDE_TOOL_NAME"') &&
+    command.includes('CLAUDE_TOOL_INPUT')
+  );
+}
+
+export function isKeeplineHook(hook: unknown): hook is ClaudeHookConfig {
+  if (
+    !hook ||
+    typeof hook !== 'object' ||
+    typeof (hook as Partial<ClaudeHookConfig>).command !== 'string'
+  ) {
+    return false;
+  }
+  const command = (hook as ClaudeHookConfig).command;
+  return command.includes(KEEPLINE_HOOK_MARKER) || isLegacyKeeplineHookCommand(command);
+}
+
+export function installKeeplineHookConfig(
+  settings: ClaudeSettings,
+  hookCommand: string = getHookCommand()
+): boolean {
+  if (!settings.hooks) {
+    settings.hooks = {};
+  }
+
+  if (!settings.hooks.PostToolUse) {
+    settings.hooks.PostToolUse = [];
+  }
+
+  const existingIndex = settings.hooks.PostToolUse.findIndex(isKeeplineHook);
+  const keeplineHook: ClaudeHookConfig = {
+    command: hookCommand,
+  };
+
+  if (existingIndex >= 0) {
+    const existing = settings.hooks.PostToolUse[existingIndex];
+    if (existing.command !== hookCommand) {
+      settings.hooks.PostToolUse[existingIndex] = {
+        ...existing,
+        command: hookCommand,
+      };
+      return true;
+    }
+    return false;
+  }
+
+  settings.hooks.PostToolUse.push(keeplineHook);
+  return true;
+}
+
+export function uninstallKeeplineHookConfig(settings: ClaudeSettings): number {
+  if (!settings.hooks) return 0;
+
+  let removed = 0;
+  for (const hookType of HOOK_TYPES) {
+    const hooks = settings.hooks[hookType];
+    if (!hooks) continue;
+    const nextHooks = hooks.filter((hook) => !isKeeplineHook(hook));
+    removed += hooks.length - nextHooks.length;
+    settings.hooks[hookType] = nextHooks;
+  }
+
+  return removed;
+}
+
+function hasKeeplineHook(settings: ClaudeSettings): boolean {
   return Boolean(
-    hook &&
-    typeof hook === 'object' &&
-    typeof (hook as Partial<ClaudeHookConfig>).command === 'string' &&
-    (hook as ClaudeHookConfig).command.includes('127.0.0.1')
+    settings.hooks?.PostToolUse?.some(isKeeplineHook)
   );
 }
 
 /** Check if keepline hooks are installed */
 export function areHooksInstalled(): boolean {
   const settings = getClaudeSettings();
-  const hooks = settings.hooks;
-
-  if (!hooks) return false;
-
-  // Check if our hook is in PostToolUse
-  const postToolUse = hooks.PostToolUse || [];
-  return postToolUse.some(isKeeplineHook);
+  return hasKeeplineHook(settings);
 }
 
 /** Install keepline hooks into Claude settings */
 export function installHooks(): void {
   const settings = getClaudeSettings();
-  const hookCommand = getHookCommand();
-
-  const keeplineHook: ClaudeHookConfig = {
-    command: hookCommand,
-  };
-
-  // Initialize hooks if not exists
-  if (!settings.hooks) {
-    settings.hooks = {};
-  }
-
-  // Add to PostToolUse
-  if (!settings.hooks.PostToolUse) {
-    settings.hooks.PostToolUse = [];
-  }
-
-  // Check if already installed
-  const existing = settings.hooks.PostToolUse.find(isKeeplineHook);
-
-  if (!existing) {
-    settings.hooks.PostToolUse.push(keeplineHook);
+  if (installKeeplineHookConfig(settings)) {
     saveClaudeSettings(settings);
     logger.info('Keepline hooks installed');
   } else {
@@ -93,22 +139,13 @@ export function installHooks(): void {
 export function uninstallHooks(): void {
   const settings = getClaudeSettings();
 
-  if (!settings.hooks) return;
-
-  // Remove from all hook types
-  const hookTypes = ['PreToolUse', 'PostToolUse', 'Notification', 'Stop'] as const;
-
-  for (const hookType of hookTypes) {
-    const hooks = settings.hooks[hookType];
-    if (hooks) {
-      settings.hooks[hookType] = hooks.filter(
-        (h) => !isKeeplineHook(h)
-      );
-    }
+  const removed = uninstallKeeplineHookConfig(settings);
+  if (removed > 0) {
+    saveClaudeSettings(settings);
+    logger.info('Keepline hooks uninstalled');
+  } else {
+    logger.debug('Keepline hooks not installed');
   }
-
-  saveClaudeSettings(settings);
-  logger.info('Keepline hooks uninstalled');
 }
 
 /** Get hook status info */

--- a/src/domain/session/entity.ts
+++ b/src/domain/session/entity.ts
@@ -157,6 +157,11 @@ export interface SessionStats {
 export function generateTitle(prompt: string): string {
   const instructionMatch = prompt.match(/^#\s*AGENTS\.md instructions for ([^\n<]+)/i);
   if (instructionMatch) {
+    const taskPrompt = extractPromptAfterAgentInstructions(prompt);
+    if (taskPrompt) {
+      return summarizePrompt(taskPrompt);
+    }
+
     const targetPath = instructionMatch[1]?.trim();
     if (targetPath) {
       const projectName = targetPath.split('/').filter(Boolean).pop();
@@ -165,6 +170,10 @@ export function generateTitle(prompt: string): string {
     return 'AGENTS.md instructions';
   }
 
+  return summarizePrompt(prompt);
+}
+
+function summarizePrompt(prompt: string): string {
   if (prompt.length <= 80) return prompt;
 
   const truncated = prompt.slice(0, 80);
@@ -173,4 +182,20 @@ export function generateTitle(prompt: string): string {
     return truncated.slice(0, lastSpace) + '...';
   }
   return truncated + '...';
+}
+
+function extractPromptAfterAgentInstructions(prompt: string): string | null {
+  const environmentClose = prompt.lastIndexOf('</environment_context>');
+  if (environmentClose !== -1) {
+    const rest = prompt.slice(environmentClose + '</environment_context>'.length).trim();
+    return rest || null;
+  }
+
+  const instructionsClose = prompt.lastIndexOf('</INSTRUCTIONS>');
+  if (instructionsClose !== -1) {
+    const rest = prompt.slice(instructionsClose + '</INSTRUCTIONS>'.length).trim();
+    return rest || null;
+  }
+
+  return null;
 }

--- a/src/domain/session/entity.ts
+++ b/src/domain/session/entity.ts
@@ -155,6 +155,16 @@ export interface SessionStats {
 
 /** Generate title from prompt */
 export function generateTitle(prompt: string): string {
+  const instructionMatch = prompt.match(/^#\s*AGENTS\.md instructions for ([^\n<]+)/i);
+  if (instructionMatch) {
+    const targetPath = instructionMatch[1]?.trim();
+    if (targetPath) {
+      const projectName = targetPath.split('/').filter(Boolean).pop();
+      return projectName ? `AGENTS.md: ${projectName}` : 'AGENTS.md instructions';
+    }
+    return 'AGENTS.md instructions';
+  }
+
   if (prompt.length <= 80) return prompt;
 
   const truncated = prompt.slice(0, 80);

--- a/src/web/api/request-security.ts
+++ b/src/web/api/request-security.ts
@@ -1,0 +1,94 @@
+/**
+ * Request host/origin allowlist helpers for browser-facing local services.
+ */
+
+import { getConfiguredAllowedOrigins, isLoopbackHost } from './terminal-security.js';
+
+export function getAllowedRequestHosts(
+  hostname: string,
+  port: number,
+  configuredOrigins: string[] = getConfiguredAllowedOrigins(),
+): Set<string> {
+  const allowed = new Set<string>();
+  addHost(allowed, hostname, port);
+
+  if (isLoopbackHost(hostname) || hostname === '0.0.0.0' || hostname === '::') {
+    addHost(allowed, '127.0.0.1', port);
+    addHost(allowed, 'localhost', port);
+    addHost(allowed, '[::1]', port);
+  }
+
+  for (const origin of configuredOrigins) {
+    addConfiguredOriginHost(allowed, origin);
+  }
+
+  return allowed;
+}
+
+export function isAllowedRequestHost(
+  req: Request,
+  hostname: string,
+  port: number,
+  configuredOrigins?: string[],
+): boolean {
+  const normalizedHost = normalizeHostHeader(req.headers.get('host'));
+  if (!normalizedHost) return false;
+  return getAllowedRequestHosts(hostname, port, configuredOrigins).has(normalizedHost);
+}
+
+export function isLoopbackHostHeader(hostHeader: string | null | undefined): boolean {
+  const host = normalizeHostHeader(hostHeader);
+  if (!host) return false;
+  return isLoopbackHost(stripPort(host));
+}
+
+export function isLoopbackOrigin(origin: string | null | undefined): boolean {
+  if (!origin) return false;
+  try {
+    return isLoopbackHost(new URL(origin).hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function isAllowedFetchMetadata(req: Request): boolean {
+  const fetchSite = req.headers.get('sec-fetch-site');
+  if (!fetchSite) return true;
+  return ['same-origin', 'same-site', 'none'].includes(fetchSite.trim().toLowerCase());
+}
+
+function addHost(allowed: Set<string>, hostname: string, port: number) {
+  const host = normalizeHostHeader(formatHost(hostname));
+  if (!host) return;
+  allowed.add(host);
+  allowed.add(normalizeHostHeader(`${host}:${port}`) ?? `${host}:${port}`);
+}
+
+function addConfiguredOriginHost(allowed: Set<string>, origin: string) {
+  try {
+    allowed.add(new URL(origin).host.toLowerCase());
+  } catch {
+    // Ignore malformed opt-in origins rather than widening the allowlist.
+  }
+}
+
+function normalizeHostHeader(hostHeader: string | null | undefined): string | null {
+  if (!hostHeader) return null;
+  try {
+    return new URL(`http://${hostHeader.trim()}`).host.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function stripPort(host: string): string {
+  if (host.startsWith('[')) {
+    const end = host.indexOf(']');
+    return end >= 0 ? host.slice(0, end + 1) : host;
+  }
+  return host.split(':')[0] ?? host;
+}
+
+function formatHost(hostname: string): string {
+  return hostname.includes(':') && !hostname.startsWith('[') ? `[${hostname}]` : hostname;
+}

--- a/src/web/api/request-security.ts
+++ b/src/web/api/request-security.ts
@@ -2,20 +2,32 @@
  * Request host/origin allowlist helpers for browser-facing local services.
  */
 
-import { getConfiguredAllowedOrigins, isLoopbackHost } from './terminal-security.js';
+import {
+  getConfiguredAllowedOrigins,
+  getLocalInterfaceHosts,
+  isLoopbackHost,
+  isWildcardBindHost,
+} from './terminal-security.js';
 
 export function getAllowedRequestHosts(
   hostname: string,
   port: number,
   configuredOrigins: string[] = getConfiguredAllowedOrigins(),
+  localHosts: string[] = getLocalInterfaceHosts(),
 ): Set<string> {
   const allowed = new Set<string>();
   addHost(allowed, hostname, port);
 
-  if (isLoopbackHost(hostname) || hostname === '0.0.0.0' || hostname === '::') {
+  if (isLoopbackHost(hostname) || isWildcardBindHost(hostname)) {
     addHost(allowed, '127.0.0.1', port);
     addHost(allowed, 'localhost', port);
     addHost(allowed, '[::1]', port);
+  }
+
+  if (isWildcardBindHost(hostname)) {
+    for (const localHost of localHosts) {
+      addHost(allowed, localHost, port);
+    }
   }
 
   for (const origin of configuredOrigins) {
@@ -30,10 +42,11 @@ export function isAllowedRequestHost(
   hostname: string,
   port: number,
   configuredOrigins?: string[],
+  localHosts?: string[],
 ): boolean {
   const normalizedHost = normalizeHostHeader(req.headers.get('host'));
   if (!normalizedHost) return false;
-  return getAllowedRequestHosts(hostname, port, configuredOrigins).has(normalizedHost);
+  return getAllowedRequestHosts(hostname, port, configuredOrigins, localHosts).has(normalizedHost);
 }
 
 export function isLoopbackHostHeader(hostHeader: string | null | undefined): boolean {

--- a/src/web/api/routes/auth.ts
+++ b/src/web/api/routes/auth.ts
@@ -19,6 +19,12 @@ import {
 } from '../../../services/auth.service.js';
 import type { JwtPayload } from '../../../services/auth.service.js';
 import { logger } from '../../../lib/logger.js';
+import {
+  isAllowedFetchMetadata,
+  isLoopbackHostHeader,
+  isLoopbackOrigin,
+} from '../request-security.js';
+import { isLoopbackHost } from '../terminal-security.js';
 
 const auth = new Hono();
 const LOGIN_USERNAME_RATE_LIMIT_SCOPE = 'auth-login-username';
@@ -42,11 +48,6 @@ function isLoopbackPeer(address: string | undefined): boolean {
   return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1';
 }
 
-function isLoopbackServerHost(hostname: string): boolean {
-  const host = hostname.trim().toLowerCase();
-  return host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === '[::1]';
-}
-
 function hasConfiguredPublicOrigin(): boolean {
   const configuredOrigins = [
     process.env.KEEPLINE_PUBLIC_ORIGIN,
@@ -59,7 +60,17 @@ function hasConfiguredPublicOrigin(): boolean {
 
 function isLoopbackOnlyServerMode(): boolean {
   const hostname = process.env.KEEPLINE_HOST || '127.0.0.1';
-  return isLoopbackServerHost(hostname) && !hasConfiguredPublicOrigin();
+  return isLoopbackHost(hostname) && !hasConfiguredPublicOrigin();
+}
+
+function isAllowedLocalLoginBrowserContext(c: Context): boolean {
+  const host = c.req.header('host');
+  if (!isLoopbackHostHeader(host)) return false;
+
+  const origin = c.req.header('origin');
+  if (origin && !isLoopbackOrigin(origin)) return false;
+
+  return isAllowedFetchMetadata(c.req.raw);
 }
 
 /**
@@ -170,7 +181,11 @@ auth.post(
 // POST /api/auth/local - Localhost passwordless login
 auth.post('/local', rateLimit(10, 60 * 1000), async (c) => {
   const peerAddress = getTcpPeerAddress(c);
-  if (!isLoopbackOnlyServerMode() || !isLoopbackPeer(peerAddress)) {
+  if (
+    !isLoopbackOnlyServerMode() ||
+    !isLoopbackPeer(peerAddress) ||
+    !isAllowedLocalLoginBrowserContext(c)
+  ) {
     return c.json({ success: false, error: 'Local login only available from localhost' }, 403);
   }
 

--- a/src/web/api/routes/recovery.ts
+++ b/src/web/api/routes/recovery.ts
@@ -6,7 +6,7 @@
 
 import { Hono } from 'hono';
 import { getAllSessions, completeSession } from '../../../services/session.service.js';
-import { recoverSession, getRecoveryInfo } from '../../../services/recovery.service.js';
+import { buildRecoveryCommand, recoverSession, getRecoveryInfo } from '../../../services/recovery.service.js';
 import { stopProcess, isProcessRunning } from '../../../adapters/process/scanner.js';
 import { logger } from '../../../lib/logger.js';
 import { authMiddleware } from '../middleware/auth.js';
@@ -71,7 +71,16 @@ app.post('/:id/recover', async (c) => {
       terminalApp: terminalApp ?? 'auto',
     });
 
-    return c.json({ success: result.success, error: result.error });
+    return c.json({
+      success: result.success,
+      error: result.error,
+      data: {
+        method: result.method,
+        command: result.success
+          ? undefined
+          : buildRecoveryCommand(session, recoveryMethod, skipPermissions),
+      },
+    });
   } catch (error) {
     logger.error('Failed to recover session', error);
     return c.json({ success: false, error: 'Recovery failed' }, 500);

--- a/src/web/api/routes/sessions.ts
+++ b/src/web/api/routes/sessions.ts
@@ -53,15 +53,22 @@ type SearchableSession = {
 
 const VALID_STATUSES = new Set(['running', 'waiting', 'idle', 'lost', 'completed']);
 
-function parseStatusFilters(url: string): Set<string> {
+function parseStatusFilters(url: string): { filters: Set<string>; invalid: string[] } {
   const params = new URL(url).searchParams;
-  return new Set(
-    params
-      .getAll('status')
-      .flatMap((value) => value.split(','))
-      .map((value) => value.trim())
-      .filter((value) => VALID_STATUSES.has(value))
-  );
+  const filters = new Set<string>();
+  const invalid = new Set<string>();
+
+  for (const value of params.getAll('status').flatMap((entry) => entry.split(','))) {
+    const status = value.trim();
+    if (!status) continue;
+    if (VALID_STATUSES.has(status)) {
+      filters.add(status);
+    } else {
+      invalid.add(status);
+    }
+  }
+
+  return { filters, invalid: [...invalid] };
 }
 
 function matchesSessionQuery(session: SearchableSession, query: string): boolean {
@@ -107,7 +114,14 @@ app.get('/', async (c) => {
     // Parse pagination parameters
     const limit = Math.min(parseInt(c.req.query('limit') || '50'), 100);
     const offset = parseInt(c.req.query('offset') || '0');
-    const statusFilters = parseStatusFilters(c.req.url);
+    const statusParseResult = parseStatusFilters(c.req.url);
+    if (statusParseResult.invalid.length > 0) {
+      return c.json({
+        success: false,
+        error: `Invalid status filter: ${statusParseResult.invalid.join(', ')}`,
+      }, 400);
+    }
+    const statusFilters = statusParseResult.filters;
     const sort = c.req.query('sort') || 'lastActiveAt';
     const order = c.req.query('order') === 'asc' ? 'asc' : 'desc';
     const fields = c.req.query('fields') || 'full'; // 'basic' or 'full'

--- a/src/web/api/routes/sessions.ts
+++ b/src/web/api/routes/sessions.ts
@@ -40,6 +40,48 @@ async function getParsedSessionById(sessionId: string) {
   return getClaudeSessionById(sessionId);
 }
 
+type SearchableSession = {
+  sessionId?: string;
+  client?: string;
+  directory?: string;
+  status?: string;
+  title?: string;
+  initialPrompt?: string;
+  lastTool?: string;
+  currentFile?: string;
+};
+
+const VALID_STATUSES = new Set(['running', 'waiting', 'idle', 'lost', 'completed']);
+
+function parseStatusFilters(url: string): Set<string> {
+  const params = new URL(url).searchParams;
+  return new Set(
+    params
+      .getAll('status')
+      .flatMap((value) => value.split(','))
+      .map((value) => value.trim())
+      .filter((value) => VALID_STATUSES.has(value))
+  );
+}
+
+function matchesSessionQuery(session: SearchableSession, query: string): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+
+  const searchableValues = [
+    session.title,
+    session.directory,
+    session.initialPrompt,
+    session.sessionId,
+    session.client,
+    session.status,
+    session.lastTool,
+    session.currentFile,
+  ];
+
+  return searchableValues.some((value) => value?.toLowerCase().includes(normalizedQuery));
+}
+
 // Background sync function (non-blocking)
 async function backgroundSync() {
   if (isSyncingInBackground) return;
@@ -65,12 +107,13 @@ app.get('/', async (c) => {
     // Parse pagination parameters
     const limit = Math.min(parseInt(c.req.query('limit') || '50'), 100);
     const offset = parseInt(c.req.query('offset') || '0');
-    const status = c.req.query('status'); // Optional filter by status
+    const statusFilters = parseStatusFilters(c.req.url);
     const sort = c.req.query('sort') || 'lastActiveAt';
     const order = c.req.query('order') === 'asc' ? 'asc' : 'desc';
     const fields = c.req.query('fields') || 'full'; // 'basic' or 'full'
     const skipSync = c.req.query('skipSync') === 'true'; // Skip sync for pagination requests
     const client = c.req.query('client');
+    const query = c.req.query('q') || c.req.query('query') || '';
 
     // Smart sync: trigger background sync if needed (non-blocking)
     const now = Date.now();
@@ -80,18 +123,24 @@ app.get('/', async (c) => {
     }
 
     // Return data immediately from database (fast)
-    let sessions = fields === 'basic'
+    let sessions = query.trim()
+      ? getAggregatedSessions()
+      : fields === 'basic'
       ? getAggregatedSessionsBasic()
       : getAggregatedSessions();
     const stats = getSessionStats(sessions);
 
     // Filter by status if provided
-    if (status) {
-      sessions = sessions.filter(s => s.status === status);
+    if (statusFilters.size > 0) {
+      sessions = sessions.filter(s => statusFilters.has(s.status));
     }
 
     if (client === 'claude' || client === 'codex') {
       sessions = sessions.filter(s => s.client === client);
+    }
+
+    if (query.trim()) {
+      sessions = sessions.filter(s => matchesSessionQuery(s, query));
     }
 
     // Sort sessions

--- a/src/web/api/server.ts
+++ b/src/web/api/server.ts
@@ -31,6 +31,7 @@ import {
   shouldRunRealtimeFullSync,
 } from './realtime-updates.js';
 import { isAllowedTerminalOrigin } from './terminal-security.js';
+import { isAllowedRequestHost } from './request-security.js';
 
 const app = new Hono();
 
@@ -170,6 +171,13 @@ export async function startWebServer(port: number = 3377) {
     idleTimeout: 255, // max value, prevents cloudflared/proxy timeout
     fetch(req, server) {
       const url = new URL(req.url);
+      if (!isAllowedRequestHost(req, hostname, port)) {
+        logger.warn('Rejected request with invalid Host', {
+          host: req.headers.get('host') ?? '<missing>',
+          path: url.pathname,
+        });
+        return new Response('Forbidden', { status: 403 });
+      }
 
       // Handle WebSocket upgrade - dashboard
       if (url.pathname === '/ws') {

--- a/src/web/api/terminal-security.ts
+++ b/src/web/api/terminal-security.ts
@@ -2,20 +2,29 @@
  * Security helpers for the browser-backed terminal endpoint.
  */
 
+import { hostname as osHostname, networkInterfaces } from 'os';
+
 export function getAllowedTerminalOrigins(
   hostname: string,
   port: number,
   tlsEnabled: boolean,
   configuredOrigins: string[] = getConfiguredAllowedOrigins(),
+  localHosts: string[] = getLocalInterfaceHosts(),
 ): Set<string> {
   const allowed = new Set<string>();
   const protocol = tlsEnabled ? 'https' : 'http';
   addOrigin(allowed, protocol, hostname, port);
 
-  if (isLoopbackHost(hostname) || hostname === '0.0.0.0' || hostname === '::') {
+  if (isLoopbackHost(hostname) || isWildcardBindHost(hostname)) {
     addOrigin(allowed, protocol, '127.0.0.1', port);
     addOrigin(allowed, protocol, 'localhost', port);
     addOrigin(allowed, protocol, '[::1]', port);
+  }
+
+  if (isWildcardBindHost(hostname)) {
+    for (const localHost of localHosts) {
+      addOrigin(allowed, protocol, localHost, port);
+    }
   }
 
   for (const origin of configuredOrigins) {
@@ -31,6 +40,7 @@ export function isAllowedTerminalOrigin(
   port: number,
   tlsEnabled: boolean,
   configuredOrigins?: string[],
+  localHosts?: string[],
 ): boolean {
   const origin = req.headers.get('origin');
   if (!origin) return false;
@@ -42,7 +52,7 @@ export function isAllowedTerminalOrigin(
     return false;
   }
 
-  return getAllowedTerminalOrigins(hostname, port, tlsEnabled, configuredOrigins).has(normalizedOrigin);
+  return getAllowedTerminalOrigins(hostname, port, tlsEnabled, configuredOrigins, localHosts).has(normalizedOrigin);
 }
 
 function addOrigin(allowed: Set<string>, protocol: string, hostname: string, port: number) {
@@ -70,5 +80,28 @@ export function getConfiguredAllowedOrigins(): string[] {
 }
 
 export function isLoopbackHost(hostname: string): boolean {
-  return hostname === '127.0.0.1' || hostname === 'localhost' || hostname === '::1' || hostname === '[::1]';
+  const host = hostname.trim().toLowerCase();
+  return host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === '[::1]';
+}
+
+export function isWildcardBindHost(hostname: string): boolean {
+  const host = hostname.trim().toLowerCase();
+  return host === '0.0.0.0' || host === '::' || host === '[::]';
+}
+
+export function getLocalInterfaceHosts(): string[] {
+  const hosts = new Set<string>();
+  const machineHostname = osHostname().trim();
+  if (machineHostname) {
+    hosts.add(machineHostname);
+  }
+
+  for (const interfaces of Object.values(networkInterfaces())) {
+    for (const address of interfaces ?? []) {
+      if (address.internal || !address.address || address.address.includes('%')) continue;
+      hosts.add(address.address);
+    }
+  }
+
+  return [...hosts];
 }

--- a/src/web/api/terminal-security.ts
+++ b/src/web/api/terminal-security.ts
@@ -58,7 +58,7 @@ function addConfiguredOrigin(allowed: Set<string>, origin: string) {
   }
 }
 
-function getConfiguredAllowedOrigins(): string[] {
+export function getConfiguredAllowedOrigins(): string[] {
   const values = [
     process.env.KEEPLINE_PUBLIC_ORIGIN,
     process.env.KEEPLINE_ALLOWED_ORIGINS,
@@ -69,6 +69,6 @@ function getConfiguredAllowedOrigins(): string[] {
     .filter(Boolean);
 }
 
-function isLoopbackHost(hostname: string): boolean {
+export function isLoopbackHost(hostname: string): boolean {
   return hostname === '127.0.0.1' || hostname === 'localhost' || hostname === '::1' || hostname === '[::1]';
 }

--- a/src/web/client/src/App.tsx
+++ b/src/web/client/src/App.tsx
@@ -14,7 +14,8 @@ import { TerminalPanel } from '@/components/TerminalPanel'
 import { AuthSetup } from '@/components/AuthSetup'
 import { AuthLogin } from '@/components/AuthLogin'
 import type { TabId } from '@/components/TabNav'
-import { useAuth, useSessions, useKeyboardShortcuts, useSessionFilter, useNotifications, useProjects } from '@/hooks'
+import type { SessionStatus } from '@/types'
+import { useAuth, useSessions, useKeyboardShortcuts, useNotifications, useProjects } from '@/hooks'
 
 // Lazy load heavy components
 const SessionList = lazy(() => import('@/components/SessionList').then(m => ({ default: m.SessionList })))
@@ -31,6 +32,8 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
   const { theme, setTheme } = useTheme()
   const [showHelp, setShowHelp] = useState(false)
   const [activeTab, setActiveTab] = useState<TabId>('sessions')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [statusFilters, setStatusFilters] = useState<Set<SessionStatus>>(new Set())
 
   const {
     sessions,
@@ -53,16 +56,15 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
     loadingMore,
     // WebSocket
     connectionStatus,
-  } = useSessions(token)
+  } = useSessions(
+    token,
+    activeTab === 'sessions' ? { searchQuery, statusFilters } : {}
+  )
 
-  // Search & Filter
-  const {
-    searchQuery,
-    setSearchQuery,
-    statusFilters,
-    setStatusFilters,
-    filteredSessions,
-  } = useSessionFilter(sessions)
+  const filteredSessions = sessions
+  const totalSessionCount = stats?.total ?? sessions.length
+  const matchedSessionCount = pagination?.total ?? sessions.length
+  const hasActiveFilters = searchQuery.trim().length > 0 || statusFilters.size > 0
 
   // Projects aggregation - use ALL sessions, not filtered
   // This ensures Projects view always shows all projects regardless of search filter
@@ -92,10 +94,12 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
   }, [sync, showToast])
 
   const handleRecover = useCallback(async (sessionId: string, terminalApp?: import('@/types').TerminalApp) => {
-    const success = await recoverSession(sessionId, terminalApp)
+    const result = await recoverSession(sessionId, terminalApp)
     showToast(
-      success ? `Session opened in ${terminalApp || 'terminal'}` : 'Failed to recover session',
-      success ? 'success' : 'error'
+      result.success
+        ? `Session opened in ${terminalApp || 'terminal'}`
+        : result.error || 'Failed to recover session',
+      result.success ? 'success' : 'error'
     )
   }, [recoverSession, showToast])
 
@@ -154,8 +158,8 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
       onSearchChange={setSearchQuery}
       statusFilters={statusFilters}
       onFilterChange={setStatusFilters}
-      totalCount={sessions.length}
-      filteredCount={filteredSessions.length}
+      totalCount={totalSessionCount}
+      filteredCount={matchedSessionCount}
       sessions={filteredSessions}
       notificationSettings={notificationSettings}
       onUpdateNotificationSettings={updateNotificationSettings}
@@ -187,6 +191,9 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
             pagination={pagination}
             onLoadMore={loadMore}
             loadingMore={loadingMore}
+            hasActiveFilters={hasActiveFilters}
+            totalCount={totalSessionCount}
+            globalMatchCount={matchedSessionCount}
           />
         </Suspense>
       )}

--- a/src/web/client/src/App.tsx
+++ b/src/web/client/src/App.tsx
@@ -37,6 +37,7 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
 
   const {
     sessions,
+    allSessions,
     stats,
     loading,
     syncing,
@@ -62,13 +63,14 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
   )
 
   const filteredSessions = sessions
+  const unfilteredSessions = allSessions.length > 0 ? allSessions : sessions
   const totalSessionCount = stats?.total ?? sessions.length
   const matchedSessionCount = pagination?.total ?? sessions.length
   const hasActiveFilters = searchQuery.trim().length > 0 || statusFilters.size > 0
 
   // Projects aggregation - use ALL sessions, not filtered
   // This ensures Projects view always shows all projects regardless of search filter
-  const { projects, stats: projectStats } = useProjects(sessions)
+  const { projects, stats: projectStats } = useProjects(unfilteredSessions)
 
   // Notifications
   const {
@@ -82,11 +84,11 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
   // Track previous sessions for notification comparison
   const prevSessionsRef = useRef<typeof sessions>([])
   useEffect(() => {
-    if (sessions.length > 0 && prevSessionsRef.current.length > 0) {
-      checkSessionChanges(prevSessionsRef.current, sessions)
+    if (unfilteredSessions.length > 0 && prevSessionsRef.current.length > 0) {
+      checkSessionChanges(prevSessionsRef.current, unfilteredSessions)
     }
-    prevSessionsRef.current = sessions
-  }, [sessions, checkSessionChanges])
+    prevSessionsRef.current = unfilteredSessions
+  }, [unfilteredSessions, checkSessionChanges])
 
   const handleSync = useCallback(async () => {
     const success = await sync()

--- a/src/web/client/src/components/SessionList/SessionList.tsx
+++ b/src/web/client/src/components/SessionList/SessionList.tsx
@@ -17,6 +17,9 @@ interface SessionListProps {
   pagination?: PaginationInfo | null
   onLoadMore?: () => Promise<void>
   loadingMore?: boolean
+  hasActiveFilters?: boolean
+  totalCount?: number
+  globalMatchCount?: number
 }
 
 type SessionStatus = 'running' | 'waiting' | 'idle' | 'lost' | 'completed'
@@ -40,6 +43,9 @@ export const SessionList = memo(function SessionList({
   pagination,
   onLoadMore,
   loadingMore,
+  hasActiveFilters = false,
+  totalCount = sessions.length,
+  globalMatchCount = pagination?.total ?? sessions.length,
 }: SessionListProps) {
   // Memoize grouped and sorted sessions
   const groupedSessions = useMemo(() => {
@@ -74,9 +80,15 @@ export const SessionList = memo(function SessionList({
   }, [sessions])
 
   if (sessions.length === 0) {
+    const message = totalCount === 0
+      ? 'No sessions found. Click Sync to scan for sessions.'
+      : hasActiveFilters && globalMatchCount === 0
+        ? 'No sessions match the current search or filters.'
+        : 'No sessions are loaded for this page.'
+
     return (
       <div className={styles.empty}>
-        No sessions found. Click Sync to scan for sessions.
+        {message}
       </div>
     )
   }

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -122,27 +122,42 @@ export function useSessions(token: string, options: SessionQueryOptions = {}): U
   const loadSessions = useCallback(async () => {
     const requestSeq = ++listRequestSeqRef.current
     // Use 'basic' mode for faster loading, with pagination
-    const response = await api.fetchSessions('basic', {
-      limit: PAGE_SIZE,
-      query: searchQuery,
-      status: statusFilterValues,
-    })
+    const [response, unfilteredResponse] = await Promise.all([
+      api.fetchSessions('basic', {
+        limit: PAGE_SIZE,
+        query: searchQuery,
+        status: statusFilterValues,
+      }),
+      hasServerFilters
+        ? api.fetchSessions('basic', {
+          limit: PAGE_SIZE,
+          skipSync: true,
+        })
+        : Promise.resolve(null),
+    ])
 
     // Only update state if component is still mounted
     if (!mountedRef.current || requestSeq !== listRequestSeqRef.current) return
 
     if (response.success && response.data) {
       setSessions(response.data.sessions)
-      if (!hasServerFilters) {
+      let unfilteredError: string | null = null
+      if (hasServerFilters) {
+        if (unfilteredResponse?.success && unfilteredResponse.data) {
+          setAllSessions(unfilteredResponse.data.sessions)
+        } else {
+          unfilteredError = unfilteredResponse?.error || 'Failed to load unfiltered sessions'
+        }
+      } else {
         setAllSessions(response.data.sessions)
       }
       setStats(response.data.stats)
       setPagination(response.data.pagination || null)
-      setError(null)
+      setError(unfilteredError)
     } else {
       setError(response.error || 'Failed to load sessions')
     }
-  }, [searchQuery, statusFilterKey])
+  }, [searchQuery, statusFilterKey, hasServerFilters])
 
   // Load more sessions (pagination)
   const loadMore = useCallback(async () => {

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -46,6 +46,7 @@ export function useSessions(token: string, options: SessionQueryOptions = {}): U
   const searchQuery = options.searchQuery?.trim() ?? ''
   const statusFilterValues = Array.from(options.statusFilters ?? []).sort()
   const statusFilterKey = statusFilterValues.join(',')
+  const listQueryKey = `${searchQuery}\u0000${statusFilterKey}`
   const hasServerFilters = searchQuery.length > 0 || statusFilterValues.length > 0
   const [sessions, setSessions] = useState<Session[]>([])
   const [stats, setStats] = useState<SessionStats | null>(null)
@@ -60,6 +61,11 @@ export function useSessions(token: string, options: SessionQueryOptions = {}): U
   const wsConnectedRef = useRef(false)
   const loadSessionsRef = useRef<() => Promise<void>>(() => Promise.resolve())
   const listRequestSeqRef = useRef(0)
+  const loadMoreRequestSeqRef = useRef(0)
+  const listQueryKeyRef = useRef(listQueryKey)
+  const sessionsLengthRef = useRef(0)
+  listQueryKeyRef.current = listQueryKey
+  sessionsLengthRef.current = sessions.length
 
   // Full data cache for lazy loading - use refs to avoid re-render loops
   // Now caches combined data from /full endpoint (details + tools + subagents)
@@ -137,15 +143,30 @@ export function useSessions(token: string, options: SessionQueryOptions = {}): U
     if (!pagination?.hasMore || loadingMore) return
 
     setLoadingMore(true)
+    const requestSeq = listRequestSeqRef.current
+    const loadMoreSeq = ++loadMoreRequestSeqRef.current
+    const requestQueryKey = listQueryKey
+    const requestOffset = sessions.length
     const response = await api.fetchSessions('basic', {
       limit: PAGE_SIZE,
-      offset: sessions.length,
+      offset: requestOffset,
       skipSync: true, // Don't trigger sync for pagination requests
       query: searchQuery,
       status: statusFilterValues,
     })
 
-    if (!mountedRef.current) return
+    if (
+      !mountedRef.current ||
+      loadMoreSeq !== loadMoreRequestSeqRef.current ||
+      requestSeq !== listRequestSeqRef.current ||
+      requestQueryKey !== listQueryKeyRef.current ||
+      requestOffset !== sessionsLengthRef.current
+    ) {
+      if (mountedRef.current && loadMoreSeq === loadMoreRequestSeqRef.current) {
+        setLoadingMore(false)
+      }
+      return
+    }
 
     if (response.success && response.data) {
       // Append new sessions to existing list
@@ -153,7 +174,7 @@ export function useSessions(token: string, options: SessionQueryOptions = {}): U
       setPagination(response.data.pagination || null)
     }
     setLoadingMore(false)
-  }, [pagination, loadingMore, sessions.length, searchQuery, statusFilterKey])
+  }, [pagination, loadingMore, sessions.length, searchQuery, statusFilterKey, listQueryKey])
 
   // Keep loadSessionsRef updated
   useEffect(() => {

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -18,6 +18,43 @@ export interface SessionActionResult {
 
 // Number of sessions to load per page
 const PAGE_SIZE = 50
+const SNAPSHOT_PAGE_SIZE = 100
+
+async function fetchAllBasicSessionsSnapshot(): Promise<{ sessions: Session[]; error: string | null }> {
+  const sessions: Session[] = []
+  let offset = 0
+
+  while (true) {
+    const response = await api.fetchSessions('basic', {
+      limit: SNAPSHOT_PAGE_SIZE,
+      offset,
+      skipSync: true,
+    })
+
+    if (!response.success || !response.data) {
+      return {
+        sessions: [],
+        error: response.error || 'Failed to load unfiltered sessions',
+      }
+    }
+
+    const page = response.data.sessions
+    sessions.push(...page)
+
+    if (!response.data.pagination?.hasMore) {
+      return { sessions, error: null }
+    }
+
+    if (page.length === 0) {
+      return {
+        sessions: [],
+        error: 'Failed to load complete unfiltered sessions',
+      }
+    }
+
+    offset += page.length
+  }
+}
 
 interface UseSessionsReturn {
   sessions: Session[]
@@ -129,10 +166,7 @@ export function useSessions(token: string, options: SessionQueryOptions = {}): U
         status: statusFilterValues,
       }),
       hasServerFilters
-        ? api.fetchSessions('basic', {
-          limit: PAGE_SIZE,
-          skipSync: true,
-        })
+        ? fetchAllBasicSessionsSnapshot()
         : Promise.resolve(null),
     ])
 
@@ -143,8 +177,8 @@ export function useSessions(token: string, options: SessionQueryOptions = {}): U
       setSessions(response.data.sessions)
       let unfilteredError: string | null = null
       if (hasServerFilters) {
-        if (unfilteredResponse?.success && unfilteredResponse.data) {
-          setAllSessions(unfilteredResponse.data.sessions)
+        if (unfilteredResponse && !unfilteredResponse.error) {
+          setAllSessions(unfilteredResponse.sessions)
         } else {
           unfilteredError = unfilteredResponse?.error || 'Failed to load unfiltered sessions'
         }

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -175,12 +175,15 @@ export function useSessions(token: string, options: SessionQueryOptions = {}): U
     }
 
     if (response.success && response.data) {
-      // Append new sessions to existing list
-      setSessions(prev => [...prev, ...response.data!.sessions])
+      const nextSessions = response.data.sessions
+      setSessions(prev => [...prev, ...nextSessions])
+      if (!hasServerFilters) {
+        setAllSessions(prev => [...prev, ...nextSessions])
+      }
       setPagination(response.data.pagination || null)
     }
     setLoadingMore(false)
-  }, [pagination, loadingMore, sessions.length, searchQuery, statusFilterKey, listQueryKey])
+  }, [pagination, loadingMore, sessions.length, searchQuery, statusFilterKey, listQueryKey, hasServerFilters])
 
   // Keep loadSessionsRef updated
   useEffect(() => {

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -2,9 +2,19 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { api } from '@/services/api'
 import { REFRESH_INTERVAL_MS } from '@/constants'
 import { useWebSocket, type WebSocketMessage } from './useWebSocket'
-import type { Session, SessionStats, SessionFullData, PaginationInfo, TerminalApp } from '@/types'
+import type { Session, SessionStats, SessionFullData, PaginationInfo, TerminalApp, SessionStatus } from '@/types'
 
 export type ConnectionStatus = 'polling' | 'realtime' | 'disconnected'
+export interface SessionQueryOptions {
+  searchQuery?: string
+  statusFilters?: Set<SessionStatus>
+}
+
+export interface SessionActionResult {
+  success: boolean
+  error?: string
+  command?: string
+}
 
 // Number of sessions to load per page
 const PAGE_SIZE = 50
@@ -17,7 +27,7 @@ interface UseSessionsReturn {
   error: string | null
   refresh: () => Promise<void>
   sync: () => Promise<boolean>
-  recoverSession: (sessionId: string, terminalApp?: TerminalApp) => Promise<boolean>
+  recoverSession: (sessionId: string, terminalApp?: TerminalApp) => Promise<SessionActionResult>
   stopSession: (sessionId: string) => Promise<boolean>
   completeSession: (sessionId: string) => Promise<boolean>
   // Lazy loading - now uses combined /full endpoint (1 request instead of 3)
@@ -32,7 +42,11 @@ interface UseSessionsReturn {
   connectionStatus: ConnectionStatus
 }
 
-export function useSessions(token: string): UseSessionsReturn {
+export function useSessions(token: string, options: SessionQueryOptions = {}): UseSessionsReturn {
+  const searchQuery = options.searchQuery?.trim() ?? ''
+  const statusFilterValues = Array.from(options.statusFilters ?? []).sort()
+  const statusFilterKey = statusFilterValues.join(',')
+  const hasServerFilters = searchQuery.length > 0 || statusFilterValues.length > 0
   const [sessions, setSessions] = useState<Session[]>([])
   const [stats, setStats] = useState<SessionStats | null>(null)
   const [loading, setLoading] = useState(true)
@@ -44,6 +58,8 @@ export function useSessions(token: string): UseSessionsReturn {
   const intervalRef = useRef<number | null>(null)
   const mountedRef = useRef(true)
   const wsConnectedRef = useRef(false)
+  const loadSessionsRef = useRef<() => Promise<void>>(() => Promise.resolve())
+  const listRequestSeqRef = useRef(0)
 
   // Full data cache for lazy loading - use refs to avoid re-render loops
   // Now caches combined data from /full endpoint (details + tools + subagents)
@@ -57,12 +73,16 @@ export function useSessions(token: string): UseSessionsReturn {
     if (!mountedRef.current) return
 
     if (message.type === 'sessions:update' && message.data) {
+      if (hasServerFilters) {
+        loadSessionsRef.current()
+        return
+      }
       const data = message.data as { sessions: Session[]; stats: SessionStats }
       setSessions(data.sessions)
       setStats(data.stats)
       setError(null)
     }
-  }, [])
+  }, [hasServerFilters])
 
   // WebSocket connection
   useWebSocket({
@@ -89,16 +109,18 @@ export function useSessions(token: string): UseSessionsReturn {
     },
   })
 
-  // Use ref for loadSessions to avoid stale closures
-  const loadSessionsRef = useRef<() => Promise<void>>(() => Promise.resolve())
-
   // Use ref to avoid stale closures in interval
   const loadSessions = useCallback(async () => {
+    const requestSeq = ++listRequestSeqRef.current
     // Use 'basic' mode for faster loading, with pagination
-    const response = await api.fetchSessions('basic', { limit: PAGE_SIZE })
+    const response = await api.fetchSessions('basic', {
+      limit: PAGE_SIZE,
+      query: searchQuery,
+      status: statusFilterValues,
+    })
 
     // Only update state if component is still mounted
-    if (!mountedRef.current) return
+    if (!mountedRef.current || requestSeq !== listRequestSeqRef.current) return
 
     if (response.success && response.data) {
       setSessions(response.data.sessions)
@@ -108,7 +130,7 @@ export function useSessions(token: string): UseSessionsReturn {
     } else {
       setError(response.error || 'Failed to load sessions')
     }
-  }, [])
+  }, [searchQuery, statusFilterKey])
 
   // Load more sessions (pagination)
   const loadMore = useCallback(async () => {
@@ -119,6 +141,8 @@ export function useSessions(token: string): UseSessionsReturn {
       limit: PAGE_SIZE,
       offset: sessions.length,
       skipSync: true, // Don't trigger sync for pagination requests
+      query: searchQuery,
+      status: statusFilterValues,
     })
 
     if (!mountedRef.current) return
@@ -129,7 +153,7 @@ export function useSessions(token: string): UseSessionsReturn {
       setPagination(response.data.pagination || null)
     }
     setLoadingMore(false)
-  }, [pagination, loadingMore, sessions.length])
+  }, [pagination, loadingMore, sessions.length, searchQuery, statusFilterKey])
 
   // Keep loadSessionsRef updated
   useEffect(() => {
@@ -164,7 +188,14 @@ export function useSessions(token: string): UseSessionsReturn {
     if (response.success) {
       await loadSessions()
     }
-    return response.success
+    const command = response.data?.command
+    return {
+      success: response.success,
+      error: command && response.error
+        ? `${response.error}. Run manually: ${command}`
+        : response.error,
+      command,
+    }
   }, [loadSessions])
 
   const stopSession = useCallback(async (sessionId: string) => {
@@ -224,15 +255,28 @@ export function useSessions(token: string): UseSessionsReturn {
     return loadingFullRef.current.has(sessionId)
   }, []) // No dependencies - uses ref
 
-  // Initial load - run once on mount
   useEffect(() => {
     mountedRef.current = true
-    refresh()
-
     return () => {
       mountedRef.current = false
     }
-  }, []) // Empty deps - only run on mount
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    const timeoutId = window.setTimeout(async () => {
+      setLoading(true)
+      await loadSessions()
+      if (!cancelled && mountedRef.current) {
+        setLoading(false)
+      }
+    }, searchQuery ? 250 : 0)
+
+    return () => {
+      cancelled = true
+      clearTimeout(timeoutId)
+    }
+  }, [loadSessions, searchQuery])
 
   // Auto-refresh interval (only when WebSocket is not connected)
   useEffect(() => {

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -21,6 +21,7 @@ const PAGE_SIZE = 50
 
 interface UseSessionsReturn {
   sessions: Session[]
+  allSessions: Session[]
   stats: SessionStats | null
   loading: boolean
   syncing: boolean
@@ -49,6 +50,7 @@ export function useSessions(token: string, options: SessionQueryOptions = {}): U
   const listQueryKey = `${searchQuery}\u0000${statusFilterKey}`
   const hasServerFilters = searchQuery.length > 0 || statusFilterValues.length > 0
   const [sessions, setSessions] = useState<Session[]>([])
+  const [allSessions, setAllSessions] = useState<Session[]>([])
   const [stats, setStats] = useState<SessionStats | null>(null)
   const [loading, setLoading] = useState(true)
   const [syncing, setSyncing] = useState(false)
@@ -79,11 +81,12 @@ export function useSessions(token: string, options: SessionQueryOptions = {}): U
     if (!mountedRef.current) return
 
     if (message.type === 'sessions:update' && message.data) {
+      const data = message.data as { sessions: Session[]; stats: SessionStats }
+      setAllSessions(data.sessions)
       if (hasServerFilters) {
         loadSessionsRef.current()
         return
       }
-      const data = message.data as { sessions: Session[]; stats: SessionStats }
       setSessions(data.sessions)
       setStats(data.stats)
       setError(null)
@@ -130,6 +133,9 @@ export function useSessions(token: string, options: SessionQueryOptions = {}): U
 
     if (response.success && response.data) {
       setSessions(response.data.sessions)
+      if (!hasServerFilters) {
+        setAllSessions(response.data.sessions)
+      }
       setStats(response.data.stats)
       setPagination(response.data.pagination || null)
       setError(null)
@@ -318,6 +324,7 @@ export function useSessions(token: string, options: SessionQueryOptions = {}): U
 
   return {
     sessions,
+    allSessions,
     stats,
     loading,
     syncing,

--- a/src/web/client/src/services/api.ts
+++ b/src/web/client/src/services/api.ts
@@ -10,6 +10,7 @@ import type {
   SessionDetailsData,
   SessionFullData,
   RecoverBody,
+  RecoverResponseData,
   StopBody,
   ProcessStatusData,
   ToolCallsData,
@@ -29,6 +30,8 @@ import type {
   LoginResponse,
   SetupRequest,
   SetupResponse,
+  AgentClient,
+  SessionStatus,
 } from '@/types'
 import { API_BASE, API_TIMEOUT_MS } from '@/constants'
 
@@ -113,6 +116,9 @@ export async function fetchSessions(
     limit?: number
     offset?: number
     skipSync?: boolean
+    query?: string
+    status?: SessionStatus[]
+    client?: AgentClient
   },
   signal?: AbortSignal
 ): Promise<ApiResponse<SessionsData>> {
@@ -120,6 +126,11 @@ export async function fetchSessions(
   if (options?.limit) params.set('limit', String(options.limit))
   if (options?.offset) params.set('offset', String(options.offset))
   if (options?.skipSync) params.set('skipSync', 'true')
+  if (options?.query?.trim()) params.set('q', options.query.trim())
+  if (options?.client) params.set('client', options.client)
+  for (const status of options?.status ?? []) {
+    params.append('status', status)
+  }
   return request<SessionsData>(`/sessions?${params}`, undefined, signal)
 }
 
@@ -147,8 +158,8 @@ export async function recoverSession(
   sessionId: string,
   body: RecoverBody,
   signal?: AbortSignal
-): Promise<ApiResponse> {
-  return request(`/sessions/${sessionId}/recover`, {
+): Promise<ApiResponse<RecoverResponseData>> {
+  return request<RecoverResponseData>(`/sessions/${sessionId}/recover`, {
     method: 'POST',
     body: JSON.stringify(body),
   }, signal)

--- a/src/web/client/src/types/api.ts
+++ b/src/web/client/src/types/api.ts
@@ -45,17 +45,26 @@ export interface RecoveryInfo {
   canRecover: boolean
   reason?: string
   sessionFile?: string
+  availableMethods?: RecoveryMethod[]
+  recommendedMethod?: RecoveryMethod
+  command?: string
 }
 
 // Terminal app options
 export type TerminalApp = 'Terminal' | 'iTerm' | 'Warp' | 'auto'
+export type RecoveryMethod = 'resume' | 'continue' | 'new'
 
 // POST /api/sessions/:id/recover body
 export interface RecoverBody {
-  method?: 'resume' | 'continue' | 'new'
+  method?: RecoveryMethod
   openTerminal?: boolean
   skipPermissions?: boolean
   terminalApp?: TerminalApp
+}
+
+export interface RecoverResponseData {
+  method?: RecoveryMethod
+  command?: string
 }
 
 // POST /api/sessions/:id/stop body


### PR DESCRIPTION
## Summary
- harden request Host/Origin validation and local-login checks
- make hook install/uninstall ownership strict to Keepline hooks
- treat missing Codex sessions directories as a no-op while warning on real read/parse failures
- add server-side session search/status filters, stale-response protection, recovery fallback commands, and AGENTS title cleanup

## Verification
- bun test
- bun run typecheck
- bun run build
- cd src/web/client && bun run typecheck

Fixes #36
Fixes #37
Fixes #38
Fixes #39