### PR TITLE
Implement project workspaces

### DIFF
--- a/src/__tests__/project.identity.test.ts
+++ b/src/__tests__/project.identity.test.ts
@@ -59,6 +59,17 @@ describe('Project identity', () => {
     expect(identity.id).not.toBe('unknown');
   });
 
+  test('walks from deleted session directories to an existing parent git root', () => {
+    const root = makeTempRoot('keepline-deleted-leaf-root-');
+    mkdirSync(join(root, '.git'));
+    const deletedLeaf = join(root, 'packages', 'removed-app');
+
+    const identity = resolveProjectIdentity(deletedLeaf);
+
+    expect(identity.rootPath).toBe(root);
+    expect(identity.source).toBe('git-root');
+  });
+
   test('uses collision-resistant IDs rather than lossy slugs', () => {
     expect(projectIdFromPath('/tmp/a-b')).not.toBe(projectIdFromPath('/tmp/a/b'));
     expect(projectIdFromPath('/tmp/Foo')).not.toBe(projectIdFromPath('/tmp/foo'));

--- a/src/__tests__/project.identity.test.ts
+++ b/src/__tests__/project.identity.test.ts
@@ -70,6 +70,23 @@ describe('Project identity', () => {
     expect(identity.source).toBe('git-root');
   });
 
+  test('revalidates cached cwd identities when a git root appears', () => {
+    const root = makeTempRoot('keepline-changing-root-');
+    const repo = join(root, 'repo');
+    mkdirSync(repo);
+    const deletedLeaf = join(repo, 'packages', 'removed-app');
+
+    const beforeGit = resolveProjectIdentity(deletedLeaf);
+    expect(beforeGit.rootPath).toBe(deletedLeaf);
+    expect(beforeGit.source).toBe('cwd');
+
+    mkdirSync(join(repo, '.git'));
+
+    const afterGit = resolveProjectIdentity(deletedLeaf);
+    expect(afterGit.rootPath).toBe(repo);
+    expect(afterGit.source).toBe('git-root');
+  });
+
   test('uses collision-resistant IDs rather than lossy slugs', () => {
     expect(projectIdFromPath('/tmp/a-b')).not.toBe(projectIdFromPath('/tmp/a/b'));
     expect(projectIdFromPath('/tmp/Foo')).not.toBe(projectIdFromPath('/tmp/foo'));

--- a/src/__tests__/project.identity.test.ts
+++ b/src/__tests__/project.identity.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  clearProjectIdentityCache,
+  projectIdFromPath,
+  resolveProjectIdentity,
+} from '../services/project.identity.js';
+
+const tmpRoots: string[] = [];
+
+function makeTempRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  tmpRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  clearProjectIdentityCache();
+  for (const root of tmpRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('Project identity', () => {
+  test('resolves nested directories to the git root', () => {
+    const root = makeTempRoot('keepline-project-root-');
+    mkdirSync(join(root, '.git'));
+    const nested = join(root, 'packages', 'app');
+    mkdirSync(nested, { recursive: true });
+
+    const identity = resolveProjectIdentity(nested);
+
+    expect(identity.rootPath).toBe(root);
+    expect(identity.source).toBe('git-root');
+    expect(identity.name).toBe(root.split('/').pop()!);
+  });
+
+  test('treats .git files as worktree roots', () => {
+    const root = makeTempRoot('keepline-worktree-root-');
+    writeFileSync(join(root, '.git'), 'gitdir: /tmp/example/.git/worktrees/demo');
+    const nested = join(root, 'src');
+    mkdirSync(nested);
+
+    const identity = resolveProjectIdentity(nested);
+
+    expect(identity.rootPath).toBe(root);
+    expect(identity.source).toBe('git-root');
+  });
+
+  test('keeps missing historical directories filterable by cwd', () => {
+    const missing = join(tmpdir(), 'keepline-missing-worktree', 'app');
+
+    const identity = resolveProjectIdentity(missing);
+
+    expect(identity.rootPath).toBe(missing);
+    expect(identity.source).toBe('cwd');
+    expect(identity.id).not.toBe('unknown');
+  });
+
+  test('uses collision-resistant IDs rather than lossy slugs', () => {
+    expect(projectIdFromPath('/tmp/a-b')).not.toBe(projectIdFromPath('/tmp/a/b'));
+    expect(projectIdFromPath('/tmp/Foo')).not.toBe(projectIdFromPath('/tmp/foo'));
+  });
+});

--- a/src/__tests__/projects.route.test.ts
+++ b/src/__tests__/projects.route.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import projects from '../web/api/routes/projects.js';
+import { setupUser } from '../services/auth.service.js';
+import { resetDatabase } from '../db/migrations.js';
+import { closeDatabase } from '../infrastructure/database/sqlite.js';
+import { sessionRepository } from '../infrastructure/database/repositories/session.repository.js';
+
+describe('Projects Route Contract', () => {
+  beforeEach(() => {
+    resetDatabase();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test('fields=basic returns project summaries grouped by directory', async () => {
+    sessionRepository.upsert({
+      sessionId: 'project-route-1',
+      client: 'claude',
+      directory: '/tmp/keepline-project-route-a',
+      status: 'running',
+      title: 'Route project A',
+      initialPrompt: 'A',
+      lastActiveAt: new Date('2026-04-13T10:00:05.000Z'),
+      toolCount: 2,
+      messageCount: 3,
+    });
+    sessionRepository.upsert({
+      sessionId: 'project-route-2',
+      client: 'codex',
+      directory: '/tmp/keepline-project-route-b',
+      status: 'waiting',
+      title: 'Route project B',
+      initialPrompt: 'B',
+      lastActiveAt: new Date('2026-04-13T10:01:05.000Z'),
+      toolCount: 1,
+      messageCount: 4,
+    });
+
+    const { token } = await setupUser('projects-route-user', 'password123');
+    const response = await projects.fetch(new Request(
+      'http://localhost/?fields=basic',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json() as {
+      success: boolean;
+      data: {
+        projects: Array<{
+          id: string;
+          rootPath: string;
+          clientCounts: { claude: number; codex: number; unknown: number };
+          sessions: Array<{ sessionId: string; client: string }>;
+        }>;
+        stats: { total: number; active: number };
+      };
+    };
+
+    expect(body.success).toBe(true);
+    expect(body.data.projects).toHaveLength(2);
+    expect(body.data.stats).toMatchObject({ total: 2 });
+    expect(body.data.projects.map(project => project.id)).not.toContain('unknown');
+
+    const codexProject = body.data.projects.find(project => project.rootPath === '/tmp/keepline-project-route-b');
+    expect(codexProject).toBeDefined();
+    expect(codexProject!.clientCounts.codex).toBe(1);
+    expect(codexProject!.sessions[0].sessionId).toBe('project-route-2');
+  });
+});

--- a/src/__tests__/projects.route.test.ts
+++ b/src/__tests__/projects.route.test.ts
@@ -25,6 +25,13 @@ describe('Projects Route Contract', () => {
       lastActiveAt: new Date('2026-04-13T10:00:05.000Z'),
       toolCount: 2,
       messageCount: 3,
+      usageStats: {
+        totalInputTokens: 100,
+        totalOutputTokens: 50,
+        totalTokens: 150,
+        totalCost: 0.02,
+        apiCalls: 2,
+      },
     });
     sessionRepository.upsert({
       sessionId: 'project-route-2',
@@ -53,6 +60,7 @@ describe('Projects Route Contract', () => {
           id: string;
           rootPath: string;
           clientCounts: { claude: number; codex: number; unknown: number };
+          totalUsage?: { totalCost: number; totalTokens: number; apiCalls: number };
           sessions?: Array<{ sessionId: string; client: string }>;
         }>;
         stats: { total: number; active: number };
@@ -68,5 +76,83 @@ describe('Projects Route Contract', () => {
     expect(codexProject).toBeDefined();
     expect(codexProject!.clientCounts.codex).toBe(1);
     expect(codexProject).not.toHaveProperty('sessions');
+
+    const claudeProject = body.data.projects.find(project => project.rootPath === '/tmp/keepline-project-route-a');
+    expect(claudeProject).toBeDefined();
+    expect(claudeProject).not.toHaveProperty('sessions');
+    expect(claudeProject!.totalUsage).toMatchObject({
+      totalCost: 0.02,
+      totalTokens: 150,
+      apiCalls: 2,
+    });
+  });
+
+  test('fields=full returns full nested sessions', async () => {
+    sessionRepository.upsert({
+      sessionId: 'project-route-full-1',
+      client: 'claude',
+      directory: '/tmp/keepline-project-route-full',
+      status: 'running',
+      title: 'Full route project',
+      initialPrompt: 'Full prompt',
+      lastMessage: 'Detailed latest response',
+      lastActiveAt: new Date('2026-04-13T10:00:05.000Z'),
+      toolCount: 2,
+      messageCount: 3,
+      usageStats: {
+        totalInputTokens: 100,
+        totalOutputTokens: 50,
+        totalTokens: 150,
+        totalCost: 0.02,
+        apiCalls: 2,
+      },
+      toolCalls: [{
+        name: 'Read',
+        input: { file_path: 'src/index.ts' },
+        timestamp: '2026-04-13T10:00:00.000Z',
+      }],
+    });
+
+    const { token } = await setupUser('projects-route-full-user', 'password123');
+    const response = await projects.fetch(new Request(
+      'http://localhost/?fields=full',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json() as {
+      success: boolean;
+      data: {
+        projects: Array<{
+          rootPath: string;
+          sessions?: Array<{
+            sessionId: string;
+            initialPrompt?: string;
+            lastMessage?: string;
+            usageStats?: { totalCost: number; totalTokens: number; apiCalls: number };
+            toolCalls?: Array<{ name: string }>;
+          }>;
+        }>;
+      };
+    };
+
+    expect(body.success).toBe(true);
+    const project = body.data.projects.find(item => item.rootPath === '/tmp/keepline-project-route-full');
+    expect(project).toBeDefined();
+    expect(project!.sessions).toHaveLength(1);
+    expect(project!.sessions![0]).toMatchObject({
+      sessionId: 'project-route-full-1',
+      initialPrompt: 'Full prompt',
+      lastMessage: 'Detailed latest response',
+      usageStats: {
+        totalCost: 0.02,
+        totalTokens: 150,
+        apiCalls: 2,
+      },
+    });
+    expect(project!.sessions![0].toolCalls).toEqual([
+      expect.objectContaining({ name: 'Read' }),
+    ]);
   });
 });

--- a/src/__tests__/projects.route.test.ts
+++ b/src/__tests__/projects.route.test.ts
@@ -53,7 +53,7 @@ describe('Projects Route Contract', () => {
           id: string;
           rootPath: string;
           clientCounts: { claude: number; codex: number; unknown: number };
-          sessions: Array<{ sessionId: string; client: string }>;
+          sessions?: Array<{ sessionId: string; client: string }>;
         }>;
         stats: { total: number; active: number };
       };
@@ -67,6 +67,6 @@ describe('Projects Route Contract', () => {
     const codexProject = body.data.projects.find(project => project.rootPath === '/tmp/keepline-project-route-b');
     expect(codexProject).toBeDefined();
     expect(codexProject!.clientCounts.codex).toBe(1);
-    expect(codexProject!.sessions[0].sessionId).toBe('project-route-2');
+    expect(codexProject).not.toHaveProperty('sessions');
   });
 });

--- a/src/__tests__/projects.test.ts
+++ b/src/__tests__/projects.test.ts
@@ -16,11 +16,9 @@ import {
   findLastActive,
   aggregateUsageStats,
   getProjectActivityStatus,
-} from '../web/client/src/types/project.js'
-import {
   aggregateProjects,
   calculateOverviewStats,
-} from '../web/client/src/hooks/useProjects.js'
+} from '../web/client/src/types/project.js'
 import type { Session, SessionStatus, UsageStats } from '../web/client/src/types/session.js'
 import type { ProjectInfo, ProjectStats } from '../web/client/src/types/project.js'
 
@@ -407,6 +405,22 @@ describe('Aggregate Projects', () => {
       expect(projects[0].path).toBe('/recent-project')
       expect(projects[1].path).toBe('/old-project')
     })
+
+    test('does not merge different roots that share the same basename', () => {
+      const sessions = [
+        createSession({ directory: '/worktrees/a/keepline', title: 'A' }),
+        createSession({ directory: '/worktrees/b/keepline', title: 'B' }),
+      ]
+
+      const projects = aggregateProjects(sessions)
+
+      expect(projects).toHaveLength(2)
+      expect(projects.map(project => project.rootPath).sort()).toEqual([
+        '/worktrees/a/keepline',
+        '/worktrees/b/keepline',
+      ])
+      expect(projects.every(project => project.name === 'keepline')).toBe(true)
+    })
   })
 
   describe('when sessions have no directory', () => {
@@ -438,22 +452,34 @@ describe('Calculate Overview Stats', () => {
   test('counts active and idle projects correctly', () => {
     const projects: ProjectInfo[] = [
       {
+        id: 'active-1',
+        rootPath: '/active-1',
         path: '/active-1',
+        displayPath: '/active-1',
         name: 'active-1',
+        clientCounts: { claude: 1, codex: 0, unknown: 0 },
         sessions: [],
         stats: { running: 1, waiting: 0, idle: 0, lost: 0, completed: 0, total: 1 },
         lastActiveAt: new Date().toISOString(),
       },
       {
+        id: 'active-2',
+        rootPath: '/active-2',
         path: '/active-2',
+        displayPath: '/active-2',
         name: 'active-2',
+        clientCounts: { claude: 1, codex: 0, unknown: 0 },
         sessions: [],
         stats: { running: 0, waiting: 1, idle: 0, lost: 0, completed: 0, total: 1 },
         lastActiveAt: new Date().toISOString(),
       },
       {
+        id: 'idle-1',
+        rootPath: '/idle-1',
         path: '/idle-1',
+        displayPath: '/idle-1',
         name: 'idle-1',
+        clientCounts: { claude: 1, codex: 0, unknown: 0 },
         sessions: [],
         stats: { running: 0, waiting: 0, idle: 2, lost: 0, completed: 0, total: 2 },
         lastActiveAt: new Date().toISOString(),

--- a/src/__tests__/sessions.route-basic.test.ts
+++ b/src/__tests__/sessions.route-basic.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import sessions from '../web/api/routes/sessions.js';
 import { setupUser } from '../services/auth.service.js';
 import { resetDatabase } from '../db/migrations.js';
@@ -6,13 +9,27 @@ import { closeDatabase } from '../infrastructure/database/sqlite.js';
 import { sessionRepository } from '../infrastructure/database/repositories/session.repository.js';
 
 describe('Basic Sessions Route Contract', () => {
+  const tmpRoots: string[] = [];
+
   beforeEach(() => {
     resetDatabase();
   });
 
   afterEach(() => {
+    for (const root of tmpRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
     closeDatabase();
   });
+
+  function makeGitProject(prefix: string): { root: string; nested: string } {
+    const root = mkdtempSync(join(tmpdir(), prefix));
+    tmpRoots.push(root);
+    mkdirSync(join(root, '.git'));
+    const nested = join(root, 'packages', 'app');
+    mkdirSync(nested, { recursive: true });
+    return { root, nested };
+  }
 
   test('fields=basic returns lightweight session payloads without usageStats', async () => {
     sessionRepository.upsert({
@@ -100,5 +117,62 @@ describe('Basic Sessions Route Contract', () => {
 
     expect(body.success).toBe(true);
     expect(body.data.usageStats).toBeNull();
+  });
+
+  test('projectRoot filters sessions by resolved git root exactly', async () => {
+    const target = makeGitProject('keepline-target-project-');
+    const other = makeGitProject('keepline-other-project-');
+
+    sessionRepository.upsert({
+      sessionId: 'target-project-session',
+      client: 'claude',
+      directory: target.nested,
+      status: 'running',
+      title: 'Target project',
+      initialPrompt: 'Target',
+      lastActiveAt: new Date('2026-04-13T10:00:05.000Z'),
+      toolCount: 4,
+      messageCount: 2,
+    });
+    sessionRepository.upsert({
+      sessionId: 'other-project-session',
+      client: 'codex',
+      directory: other.nested,
+      status: 'running',
+      title: 'Other project',
+      initialPrompt: 'Other',
+      lastActiveAt: new Date('2026-04-13T10:00:06.000Z'),
+      toolCount: 4,
+      messageCount: 2,
+    });
+
+    const { token } = await setupUser('project-filter-route-user', 'password123');
+    const params = new URLSearchParams({
+      skipSync: 'true',
+      fields: 'basic',
+      projectRoot: target.root,
+    });
+    const response = await sessions.fetch(new Request(
+      `http://localhost/?${params.toString()}`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json() as {
+      success: boolean;
+      data: {
+        sessions: Array<{ sessionId: string; directory: string }>;
+        stats: { total: number };
+      };
+    };
+
+    expect(body.success).toBe(true);
+    expect(body.data.stats.total).toBe(1);
+    expect(body.data.sessions).toHaveLength(1);
+    expect(body.data.sessions[0]).toMatchObject({
+      sessionId: 'target-project-session',
+      directory: target.nested,
+    });
   });
 });

--- a/src/__tests__/sessions.route-basic.test.ts
+++ b/src/__tests__/sessions.route-basic.test.ts
@@ -175,4 +175,54 @@ describe('Basic Sessions Route Contract', () => {
       directory: target.nested,
     });
   });
+
+  test('projectRoot=Unknown filters sessions with missing project identity', async () => {
+    sessionRepository.upsert({
+      sessionId: 'unknown-project-session',
+      client: 'claude',
+      directory: '',
+      status: 'running',
+      title: 'Unknown project session',
+      initialPrompt: 'Unknown',
+      lastActiveAt: new Date('2026-04-13T10:00:05.000Z'),
+      toolCount: 1,
+      messageCount: 1,
+    });
+    sessionRepository.upsert({
+      sessionId: 'known-project-session',
+      client: 'codex',
+      directory: '/tmp/keepline-known-project',
+      status: 'running',
+      title: 'Known project session',
+      initialPrompt: 'Known',
+      lastActiveAt: new Date('2026-04-13T10:00:06.000Z'),
+      toolCount: 1,
+      messageCount: 1,
+    });
+
+    const { token } = await setupUser('unknown-project-filter-route-user', 'password123');
+    const params = new URLSearchParams({
+      skipSync: 'true',
+      fields: 'basic',
+      projectRoot: 'Unknown',
+    });
+    const response = await sessions.fetch(new Request(
+      `http://localhost/?${params.toString()}`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json() as {
+      success: boolean;
+      data: {
+        sessions: Array<{ sessionId: string; directory: string }>;
+        stats: { total: number };
+      };
+    };
+
+    expect(body.success).toBe(true);
+    expect(body.data.stats.total).toBe(1);
+    expect(body.data.sessions.map(session => session.sessionId)).toEqual(['unknown-project-session']);
+  });
 });

--- a/src/services/project.aggregator.ts
+++ b/src/services/project.aggregator.ts
@@ -1,0 +1,175 @@
+import type { AgentClient, SessionStatus } from '../domain/session/index.js';
+import type { SessionUsageStats } from '../domain/session/value-objects.js';
+import { getSessionStats } from './session.aggregator.js';
+import type { AggregatedSession, BasicAggregatedSession } from './session.types.js';
+import { resolveProjectIdentity, type ProjectIdentity } from './project.identity.js';
+
+export type ProjectClient = AgentClient | 'unknown';
+export type ProjectSession = AggregatedSession | BasicAggregatedSession;
+
+export interface ProjectStatusStats {
+  total: number;
+  running: number;
+  waiting: number;
+  idle: number;
+  lost: number;
+  completed: number;
+  withProcess: number;
+}
+
+export interface ProjectOverviewStats {
+  total: number;
+  active: number;
+  idle: number;
+}
+
+export interface ProjectSummary {
+  id: string;
+  rootPath: string;
+  path: string;
+  name: string;
+  displayPath: string;
+  source: ProjectIdentity['source'];
+  sessions: ProjectSession[];
+  stats: ProjectStatusStats;
+  clientCounts: Record<ProjectClient, number>;
+  currentTask?: string;
+  lastActiveAt: Date;
+  totalUsage?: SessionUsageStats;
+}
+
+export function aggregateProjectSummaries<T extends ProjectSession>(sessions: T[]): ProjectSummary[] {
+  const projectMap = new Map<string, { identity: ProjectIdentity; sessions: T[] }>();
+
+  for (const session of sessions) {
+    const identity = resolveProjectIdentity(session.directory);
+    const existing = projectMap.get(identity.id);
+    if (existing) {
+      existing.sessions.push(session);
+    } else {
+      projectMap.set(identity.id, { identity, sessions: [session] });
+    }
+  }
+
+  return Array.from(projectMap.values())
+    .map(({ identity, sessions: projectSessions }) => buildProjectSummary(identity, projectSessions))
+    .sort((a, b) => b.lastActiveAt.getTime() - a.lastActiveAt.getTime());
+}
+
+export function getProjectOverviewStats(projects: ProjectSummary[]): ProjectOverviewStats {
+  let active = 0;
+  let idle = 0;
+
+  for (const project of projects) {
+    if (project.stats.running > 0 || project.stats.waiting > 0) {
+      active++;
+    } else {
+      idle++;
+    }
+  }
+
+  return {
+    total: projects.length,
+    active,
+    idle,
+  };
+}
+
+export function matchesProjectFilter(
+  session: Pick<ProjectSession, 'directory'>,
+  filter: { projectRoot?: string | null; projectId?: string | null }
+): boolean {
+  if (!filter.projectRoot && !filter.projectId) return true;
+
+  const identity = resolveProjectIdentity(session.directory);
+  if (filter.projectId && identity.id !== filter.projectId) {
+    return false;
+  }
+  if (filter.projectRoot) {
+    const target = resolveProjectIdentity(filter.projectRoot);
+    return identity.id === target.id;
+  }
+  return true;
+}
+
+function buildProjectSummary<T extends ProjectSession>(
+  identity: ProjectIdentity,
+  sessions: T[]
+): ProjectSummary {
+  return {
+    id: identity.id,
+    rootPath: identity.rootPath,
+    path: identity.rootPath,
+    name: identity.name,
+    displayPath: identity.displayPath,
+    source: identity.source,
+    sessions,
+    stats: getSessionStats(sessions) as ProjectStatusStats,
+    clientCounts: countClients(sessions),
+    currentTask: findCurrentTask(sessions),
+    lastActiveAt: findLastActive(sessions),
+    totalUsage: aggregateUsageStats(sessions),
+  };
+}
+
+function countClients(sessions: ProjectSession[]): Record<ProjectClient, number> {
+  const counts: Record<ProjectClient, number> = {
+    claude: 0,
+    codex: 0,
+    unknown: 0,
+  };
+
+  for (const session of sessions) {
+    if (session.client === 'claude' || session.client === 'codex') {
+      counts[session.client]++;
+    } else {
+      counts.unknown++;
+    }
+  }
+
+  return counts;
+}
+
+function findCurrentTask(sessions: ProjectSession[]): string | undefined {
+  const active = sessions.filter((session) => isActiveTaskStatus(session.status));
+  const candidates = active.length > 0 ? active : sessions;
+  return sortByLastActive(candidates)[0]?.title || undefined;
+}
+
+function findLastActive(sessions: ProjectSession[]): Date {
+  return sortByLastActive(sessions)[0]?.lastActiveAt ?? new Date(0);
+}
+
+function aggregateUsageStats(sessions: ProjectSession[]): SessionUsageStats | undefined {
+  const withUsage = sessions.filter(
+    (session): session is ProjectSession & { usageStats: SessionUsageStats } =>
+      'usageStats' in session && session.usageStats !== undefined
+  );
+
+  if (withUsage.length === 0) return undefined;
+
+  return withUsage.reduce<SessionUsageStats>(
+    (acc, session) => ({
+      totalInputTokens: acc.totalInputTokens + session.usageStats.totalInputTokens,
+      totalOutputTokens: acc.totalOutputTokens + session.usageStats.totalOutputTokens,
+      totalTokens: acc.totalTokens + session.usageStats.totalTokens,
+      totalCost: acc.totalCost + session.usageStats.totalCost,
+      apiCalls: acc.apiCalls + session.usageStats.apiCalls,
+    }),
+    {
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalTokens: 0,
+      totalCost: 0,
+      apiCalls: 0,
+    }
+  );
+}
+
+function sortByLastActive<T extends ProjectSession>(sessions: T[]): T[] {
+  return [...sessions].sort((a, b) => b.lastActiveAt.getTime() - a.lastActiveAt.getTime());
+}
+
+function isActiveTaskStatus(status: SessionStatus): boolean {
+  return status === 'running' || status === 'waiting';
+}

--- a/src/services/project.aggregator.ts
+++ b/src/services/project.aggregator.ts
@@ -2,7 +2,12 @@ import type { AgentClient, SessionStatus } from '../domain/session/index.js';
 import type { SessionUsageStats } from '../domain/session/value-objects.js';
 import { getSessionStats } from './session.aggregator.js';
 import type { AggregatedSession, BasicAggregatedSession } from './session.types.js';
-import { resolveProjectIdentity, type ProjectIdentity } from './project.identity.js';
+import {
+  resolveProjectIdentity,
+  UNKNOWN_PROJECT_ID,
+  UNKNOWN_PROJECT_ROOT,
+  type ProjectIdentity,
+} from './project.identity.js';
 
 export type ProjectClient = AgentClient | 'unknown';
 export type ProjectSession = AggregatedSession | BasicAggregatedSession;
@@ -86,6 +91,9 @@ export function matchesProjectFilter(
     return false;
   }
   if (filter.projectRoot) {
+    if (filter.projectRoot === UNKNOWN_PROJECT_ROOT) {
+      return identity.id === UNKNOWN_PROJECT_ID;
+    }
     const target = resolveProjectIdentity(filter.projectRoot);
     return identity.id === target.id;
   }

--- a/src/services/project.identity.ts
+++ b/src/services/project.identity.ts
@@ -13,9 +13,12 @@ export interface ProjectIdentity {
   source: ProjectIdentitySource;
 }
 
+export const UNKNOWN_PROJECT_ID = 'unknown';
+export const UNKNOWN_PROJECT_ROOT = 'Unknown';
+
 const UNKNOWN_PROJECT: ProjectIdentity = {
-  id: 'unknown',
-  rootPath: 'Unknown',
+  id: UNKNOWN_PROJECT_ID,
+  rootPath: UNKNOWN_PROJECT_ROOT,
   name: 'Unknown project',
   displayPath: 'Unknown',
   source: 'unknown',

--- a/src/services/project.identity.ts
+++ b/src/services/project.identity.ts
@@ -1,0 +1,115 @@
+import { createHash } from 'crypto';
+import { existsSync, statSync } from 'fs';
+import { homedir } from 'os';
+import path from 'path';
+
+export type ProjectIdentitySource = 'git-root' | 'cwd' | 'unknown';
+
+export interface ProjectIdentity {
+  id: string;
+  rootPath: string;
+  name: string;
+  displayPath: string;
+  source: ProjectIdentitySource;
+}
+
+const UNKNOWN_PROJECT: ProjectIdentity = {
+  id: 'unknown',
+  rootPath: 'Unknown',
+  name: 'Unknown project',
+  displayPath: 'Unknown',
+  source: 'unknown',
+};
+
+const identityCache = new Map<string, ProjectIdentity>();
+
+export function clearProjectIdentityCache(): void {
+  identityCache.clear();
+}
+
+export function normalizeProjectPath(rawPath: string | undefined | null): string | null {
+  const trimmed = rawPath?.trim();
+  if (!trimmed) return null;
+
+  const expanded = trimmed === '~'
+    ? homedir()
+    : trimmed.startsWith(`~${path.sep}`)
+      ? path.join(homedir(), trimmed.slice(2))
+      : trimmed;
+
+  const resolved = path.isAbsolute(expanded)
+    ? path.normalize(expanded)
+    : path.resolve(expanded);
+
+  const parsed = path.parse(resolved);
+  if (resolved === parsed.root) return resolved;
+  return resolved.replace(new RegExp(`${escapeRegExp(path.sep)}+$`), '') || parsed.root;
+}
+
+export function projectIdFromPath(projectPath: string | undefined | null): string {
+  const normalized = normalizeProjectPath(projectPath);
+  if (!normalized) return UNKNOWN_PROJECT.id;
+  return `path-${createHash('sha256').update(normalized).digest('hex').slice(0, 16)}`;
+}
+
+export function displayProjectPath(projectPath: string): string {
+  const home = homedir();
+  if (projectPath === home) return '~';
+  if (projectPath.startsWith(`${home}${path.sep}`)) {
+    return `~${path.sep}${projectPath.slice(home.length + 1)}`;
+  }
+  return projectPath;
+}
+
+export function getProjectNameFromPath(projectPath: string): string {
+  if (projectPath === UNKNOWN_PROJECT.rootPath) return UNKNOWN_PROJECT.name;
+  const base = path.basename(projectPath);
+  return base || projectPath;
+}
+
+export function resolveProjectIdentity(cwd: string | undefined | null): ProjectIdentity {
+  const normalized = normalizeProjectPath(cwd);
+  if (!normalized) return UNKNOWN_PROJECT;
+
+  const cached = identityCache.get(normalized);
+  if (cached) return cached;
+
+  const gitRoot = findGitRoot(normalized);
+  const rootPath = gitRoot ?? normalized;
+  const identity: ProjectIdentity = {
+    id: projectIdFromPath(rootPath),
+    rootPath,
+    name: getProjectNameFromPath(rootPath),
+    displayPath: displayProjectPath(rootPath),
+    source: gitRoot ? 'git-root' : 'cwd',
+  };
+
+  identityCache.set(normalized, identity);
+  return identity;
+}
+
+function findGitRoot(projectPath: string): string | null {
+  if (!existsSync(projectPath)) return null;
+
+  let current = projectPath;
+  try {
+    if (!statSync(current).isDirectory()) {
+      current = path.dirname(current);
+    }
+  } catch {
+    return null;
+  }
+
+  while (true) {
+    if (existsSync(path.join(current, '.git'))) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/services/project.identity.ts
+++ b/src/services/project.identity.ts
@@ -92,9 +92,9 @@ export function resolveProjectIdentity(cwd: string | undefined | null): ProjectI
 }
 
 function findGitRoot(projectPath: string): string | null {
-  if (!existsSync(projectPath)) return null;
+  let current = nearestExistingPath(projectPath);
+  if (!current) return null;
 
-  let current = projectPath;
   try {
     if (!statSync(current).isDirectory()) {
       current = path.dirname(current);
@@ -111,6 +111,16 @@ function findGitRoot(projectPath: string): string | null {
     if (parent === current) return null;
     current = parent;
   }
+}
+
+function nearestExistingPath(projectPath: string): string | null {
+  let current = projectPath;
+  while (!existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+  return current;
 }
 
 function escapeRegExp(value: string): string {

--- a/src/services/project.identity.ts
+++ b/src/services/project.identity.ts
@@ -75,7 +75,7 @@ export function resolveProjectIdentity(cwd: string | undefined | null): ProjectI
   if (!normalized) return UNKNOWN_PROJECT;
 
   const cached = identityCache.get(normalized);
-  if (cached) return cached;
+  if (cached && isCachedIdentityCurrent(normalized, cached)) return cached;
 
   const gitRoot = findGitRoot(normalized);
   const rootPath = gitRoot ?? normalized;
@@ -89,6 +89,13 @@ export function resolveProjectIdentity(cwd: string | undefined | null): ProjectI
 
   identityCache.set(normalized, identity);
   return identity;
+}
+
+function isCachedIdentityCurrent(normalized: string, cached: ProjectIdentity): boolean {
+  const gitRoot = findGitRoot(normalized);
+  const rootPath = gitRoot ?? normalized;
+  const source: ProjectIdentitySource = gitRoot ? 'git-root' : 'cwd';
+  return cached.rootPath === rootPath && cached.source === source;
 }
 
 function findGitRoot(projectPath: string): string | null {

--- a/src/web/api/project-response.ts
+++ b/src/web/api/project-response.ts
@@ -1,8 +1,10 @@
-import type { ProjectSummary } from '../../services/project.aggregator.js';
-import { serializeBasicSessions } from './session-response.js';
+import type { ProjectSession, ProjectSummary } from '../../services/project.aggregator.js';
+import type { AggregatedSession } from '../../services/session.types.js';
+import { serializeBasicSessions, serializeFullSessions } from './session-response.js';
 
 interface SerializeProjectSummaryOptions {
   includeSessions?: boolean;
+  sessionFields?: 'basic' | 'full';
 }
 
 export function serializeProjectSummary(
@@ -16,13 +18,23 @@ export function serializeProjectSummary(
     name: project.name,
     displayPath: project.displayPath,
     source: project.source,
-    ...(options.includeSessions ? { sessions: serializeBasicSessions(project.sessions) } : {}),
+    ...(options.includeSessions ? { sessions: serializeProjectSessions(project.sessions, options) } : {}),
     stats: project.stats,
     clientCounts: project.clientCounts,
     currentTask: project.currentTask,
     lastActiveAt: project.lastActiveAt.toISOString(),
     totalUsage: project.totalUsage,
   };
+}
+
+function serializeProjectSessions(
+  sessions: ProjectSession[],
+  options: SerializeProjectSummaryOptions
+) {
+  if (options.sessionFields === 'full') {
+    return serializeFullSessions(sessions as AggregatedSession[]);
+  }
+  return serializeBasicSessions(sessions);
 }
 
 export function serializeProjectSummaries(

--- a/src/web/api/project-response.ts
+++ b/src/web/api/project-response.ts
@@ -1,0 +1,23 @@
+import type { ProjectSummary } from '../../services/project.aggregator.js';
+import { serializeBasicSessions } from './session-response.js';
+
+export function serializeProjectSummary(project: ProjectSummary) {
+  return {
+    id: project.id,
+    rootPath: project.rootPath,
+    path: project.path,
+    name: project.name,
+    displayPath: project.displayPath,
+    source: project.source,
+    sessions: serializeBasicSessions(project.sessions),
+    stats: project.stats,
+    clientCounts: project.clientCounts,
+    currentTask: project.currentTask,
+    lastActiveAt: project.lastActiveAt.toISOString(),
+    totalUsage: project.totalUsage,
+  };
+}
+
+export function serializeProjectSummaries(projects: ProjectSummary[]) {
+  return projects.map(serializeProjectSummary);
+}

--- a/src/web/api/project-response.ts
+++ b/src/web/api/project-response.ts
@@ -1,7 +1,14 @@
 import type { ProjectSummary } from '../../services/project.aggregator.js';
 import { serializeBasicSessions } from './session-response.js';
 
-export function serializeProjectSummary(project: ProjectSummary) {
+interface SerializeProjectSummaryOptions {
+  includeSessions?: boolean;
+}
+
+export function serializeProjectSummary(
+  project: ProjectSummary,
+  options: SerializeProjectSummaryOptions = {}
+) {
   return {
     id: project.id,
     rootPath: project.rootPath,
@@ -9,7 +16,7 @@ export function serializeProjectSummary(project: ProjectSummary) {
     name: project.name,
     displayPath: project.displayPath,
     source: project.source,
-    sessions: serializeBasicSessions(project.sessions),
+    ...(options.includeSessions ? { sessions: serializeBasicSessions(project.sessions) } : {}),
     stats: project.stats,
     clientCounts: project.clientCounts,
     currentTask: project.currentTask,
@@ -18,6 +25,9 @@ export function serializeProjectSummary(project: ProjectSummary) {
   };
 }
 
-export function serializeProjectSummaries(projects: ProjectSummary[]) {
-  return projects.map(serializeProjectSummary);
+export function serializeProjectSummaries(
+  projects: ProjectSummary[],
+  options: SerializeProjectSummaryOptions = {}
+) {
+  return projects.map(project => serializeProjectSummary(project, options));
 }

--- a/src/web/api/routes/index.ts
+++ b/src/web/api/routes/index.ts
@@ -10,5 +10,6 @@ import usage from './usage.js';
 import memory from './memory.js';
 import plans from './plans.js';
 import auth from './auth.js';
+import projects from './projects.js';
 
-export { sessions, recovery, usage, memory, plans, auth };
+export { sessions, recovery, usage, memory, plans, auth, projects };

--- a/src/web/api/routes/projects.ts
+++ b/src/web/api/routes/projects.ts
@@ -25,7 +25,7 @@ app.get('/', async (c) => {
     return c.json({
       success: true,
       data: {
-        projects: serializeProjectSummaries(projects),
+        projects: serializeProjectSummaries(projects, { includeSessions: fields === 'full' }),
         stats: getProjectOverviewStats(projects),
       },
     });

--- a/src/web/api/routes/projects.ts
+++ b/src/web/api/routes/projects.ts
@@ -1,0 +1,38 @@
+import { Hono } from 'hono';
+import {
+  getAggregatedSessions,
+  getAggregatedSessionsBasic,
+} from '../../../services/session.aggregator.js';
+import {
+  aggregateProjectSummaries,
+  getProjectOverviewStats,
+} from '../../../services/project.aggregator.js';
+import { logger } from '../../../lib/logger.js';
+import { authMiddleware } from '../middleware/auth.js';
+import { serializeProjectSummaries } from '../project-response.js';
+
+const app = new Hono();
+app.use('*', authMiddleware);
+
+app.get('/', async (c) => {
+  try {
+    const fields = c.req.query('fields') || 'basic';
+    const sessions = fields === 'full'
+      ? getAggregatedSessions()
+      : getAggregatedSessionsBasic();
+    const projects = aggregateProjectSummaries(sessions);
+
+    return c.json({
+      success: true,
+      data: {
+        projects: serializeProjectSummaries(projects),
+        stats: getProjectOverviewStats(projects),
+      },
+    });
+  } catch (error) {
+    logger.error('Failed to get projects', error);
+    return c.json({ success: false, error: 'Failed to get projects' }, 500);
+  }
+});
+
+export default app;

--- a/src/web/api/routes/projects.ts
+++ b/src/web/api/routes/projects.ts
@@ -1,8 +1,5 @@
 import { Hono } from 'hono';
-import {
-  getAggregatedSessions,
-  getAggregatedSessionsBasic,
-} from '../../../services/session.aggregator.js';
+import { getAggregatedSessions } from '../../../services/session.aggregator.js';
 import {
   aggregateProjectSummaries,
   getProjectOverviewStats,
@@ -17,15 +14,16 @@ app.use('*', authMiddleware);
 app.get('/', async (c) => {
   try {
     const fields = c.req.query('fields') || 'basic';
-    const sessions = fields === 'full'
-      ? getAggregatedSessions()
-      : getAggregatedSessionsBasic();
+    const sessions = getAggregatedSessions();
     const projects = aggregateProjectSummaries(sessions);
 
     return c.json({
       success: true,
       data: {
-        projects: serializeProjectSummaries(projects, { includeSessions: fields === 'full' }),
+        projects: serializeProjectSummaries(projects, {
+          includeSessions: fields === 'full',
+          sessionFields: fields === 'full' ? 'full' : 'basic',
+        }),
         stats: getProjectOverviewStats(projects),
       },
     });

--- a/src/web/api/routes/sessions.ts
+++ b/src/web/api/routes/sessions.ts
@@ -23,6 +23,7 @@ import { authMiddleware } from '../middleware/auth.js';
 import { isValidSessionId } from '../middleware/validation.js';
 import { broadcast } from '../websocket.js';
 import { serializeBasicSessions } from '../session-response.js';
+import { matchesProjectFilter } from '../../../services/project.aggregator.js';
 
 const app = new Hono();
 app.use('*', authMiddleware);
@@ -71,6 +72,8 @@ app.get('/', async (c) => {
     const fields = c.req.query('fields') || 'full'; // 'basic' or 'full'
     const skipSync = c.req.query('skipSync') === 'true'; // Skip sync for pagination requests
     const client = c.req.query('client');
+    const projectRoot = c.req.query('projectRoot');
+    const projectId = c.req.query('projectId');
 
     // Smart sync: trigger background sync if needed (non-blocking)
     const now = Date.now();
@@ -83,7 +86,9 @@ app.get('/', async (c) => {
     let sessions = fields === 'basic'
       ? getAggregatedSessionsBasic()
       : getAggregatedSessions();
-    const stats = getSessionStats(sessions);
+    if (projectRoot || projectId) {
+      sessions = sessions.filter(s => matchesProjectFilter(s, { projectRoot, projectId }));
+    }
 
     // Filter by status if provided
     if (status) {
@@ -93,6 +98,8 @@ app.get('/', async (c) => {
     if (client === 'claude' || client === 'codex') {
       sessions = sessions.filter(s => s.client === client);
     }
+
+    const stats = getSessionStats(sessions);
 
     // Sort sessions
     sessions.sort((a, b) => {

--- a/src/web/api/server.ts
+++ b/src/web/api/server.ts
@@ -19,7 +19,7 @@ import { initPricing } from '../../services/usage.pricing.js';
 import { initializeMemoryService } from '../../services/memory.service.js';
 import { logger } from '../../lib/logger.js';
 import { rateLimit } from './middleware/rateLimit.js';
-import { sessions, recovery, usage, memory, plans, auth } from './routes/index.js';
+import { sessions, recovery, usage, memory, plans, auth, projects } from './routes/index.js';
 import { broadcast, wsClients, websocketHandler } from './websocket.js';
 import { terminalWebsocketHandler } from './terminal-websocket.js';
 import { verifyToken } from '../../services/auth.service.js';
@@ -84,6 +84,7 @@ app.get('/assets/*', async (c) => {
 app.route('/api/auth', auth);
 app.route('/api/sessions', sessions);
 app.route('/api/sessions', recovery);
+app.route('/api/projects', projects);
 app.route('/api', usage);
 app.route('/api/memory', memory);
 app.route('/api/plans', plans);
@@ -124,10 +125,18 @@ async function checkAndBroadcastUpdates() {
     const sessions = getAggregatedSessionsBasic();
     const stats = getSessionStats(sessions);
 
-    // Create a simple hash of current state
     const currentState = JSON.stringify({
       stats,
-      sessionIds: sessions.map(s => `${s.sessionId}:${s.status}`).sort(),
+      sessions: sessions
+        .map(s => ({
+          sessionId: s.sessionId,
+          client: s.client,
+          status: s.status,
+          directory: s.directory,
+          lastActiveAt: s.lastActiveAt.toISOString(),
+          title: s.title,
+        }))
+        .sort((a, b) => a.sessionId.localeCompare(b.sessionId)),
     });
 
     // Only broadcast if state changed

--- a/src/web/api/session-response.ts
+++ b/src/web/api/session-response.ts
@@ -1,6 +1,8 @@
-import type { BasicAggregatedSession } from '../../services/session.types.js';
+import type { AggregatedSession, BasicAggregatedSession } from '../../services/session.types.js';
 
-export function serializeBasicSession(session: BasicAggregatedSession) {
+type SerializableBasicSession = AggregatedSession | BasicAggregatedSession;
+
+export function serializeBasicSession(session: SerializableBasicSession) {
   return {
     id: session.id,
     sessionId: session.sessionId,
@@ -23,6 +25,22 @@ export function serializeBasicSession(session: BasicAggregatedSession) {
   };
 }
 
-export function serializeBasicSessions(sessions: BasicAggregatedSession[]) {
+export function serializeBasicSessions(sessions: SerializableBasicSession[]) {
   return sessions.map(serializeBasicSession);
+}
+
+export function serializeFullSession(session: AggregatedSession) {
+  return {
+    ...session,
+    lastActiveAt: session.lastActiveAt.toISOString(),
+    startedAt: session.startedAt?.toISOString(),
+    completedAt: session.completedAt?.toISOString(),
+    createdAt: session.createdAt.toISOString(),
+    updatedAt: session.updatedAt.toISOString(),
+    usageStats: session.usageStats,
+  };
+}
+
+export function serializeFullSessions(sessions: AggregatedSession[]) {
+  return sessions.map(serializeFullSession);
 }

--- a/src/web/client/src/App.tsx
+++ b/src/web/client/src/App.tsx
@@ -36,6 +36,7 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
 
   const {
     sessions,
+    allSessions,
     stats,
     loading,
     syncing,
@@ -91,11 +92,12 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
   // Track previous sessions for notification comparison
   const prevSessionsRef = useRef<typeof sessions>([])
   useEffect(() => {
-    if (sessions.length > 0 && prevSessionsRef.current.length > 0) {
-      checkSessionChanges(prevSessionsRef.current, sessions)
+    const notificationSessions = allSessions.length > 0 ? allSessions : sessions
+    if (notificationSessions.length > 0 && prevSessionsRef.current.length > 0) {
+      checkSessionChanges(prevSessionsRef.current, notificationSessions)
     }
-    prevSessionsRef.current = sessions
-  }, [sessions, checkSessionChanges])
+    prevSessionsRef.current = notificationSessions
+  }, [allSessions, sessions, checkSessionChanges])
 
   const handleSync = useCallback(async () => {
     const success = await sync()

--- a/src/web/client/src/App.tsx
+++ b/src/web/client/src/App.tsx
@@ -15,6 +15,7 @@ import { AuthSetup } from '@/components/AuthSetup'
 import { AuthLogin } from '@/components/AuthLogin'
 import type { TabId } from '@/components/TabNav'
 import { useAuth, useSessions, useKeyboardShortcuts, useSessionFilter, useNotifications, useProjects } from '@/hooks'
+import type { ProjectInfo } from '@/types'
 
 // Lazy load heavy components
 const SessionList = lazy(() => import('@/components/SessionList').then(m => ({ default: m.SessionList })))
@@ -31,6 +32,7 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
   const { theme, setTheme } = useTheme()
   const [showHelp, setShowHelp] = useState(false)
   const [activeTab, setActiveTab] = useState<TabId>('sessions')
+  const [selectedProjectRoot, setSelectedProjectRoot] = useState<string | null>(null)
 
   const {
     sessions,
@@ -53,7 +55,8 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
     loadingMore,
     // WebSocket
     connectionStatus,
-  } = useSessions(token)
+    version: sessionsVersion,
+  } = useSessions(token, { projectRoot: selectedProjectRoot ?? undefined })
 
   // Search & Filter
   const {
@@ -64,9 +67,17 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
     filteredSessions,
   } = useSessionFilter(sessions)
 
-  // Projects aggregation - use ALL sessions, not filtered
-  // This ensures Projects view always shows all projects regardless of search filter
-  const { projects, stats: projectStats } = useProjects(sessions)
+  // Projects come from the backend project API, not the paginated sessions list.
+  const {
+    projects,
+    stats: projectStats,
+    loading: projectsLoading,
+    error: projectsError,
+  } = useProjects(token, sessionsVersion)
+
+  const selectedProject = selectedProjectRoot
+    ? projects.find(project => project.rootPath === selectedProjectRoot)
+    : undefined
 
   // Notifications
   const {
@@ -128,12 +139,16 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
     showToast(`Theme: ${nextTheme}`, 'info')
   }, [theme, setTheme, showToast])
 
-  const handleProjectClick = useCallback((projectPath: string) => {
-    // Switch to sessions tab and filter by project directory
+  const handleProjectClick = useCallback((project: ProjectInfo) => {
+    setSelectedProjectRoot(project.rootPath)
     setActiveTab('sessions')
-    setSearchQuery(projectPath)
-    showToast(`Filtered to: ${projectPath.split('/').pop()}`, 'info')
-  }, [setSearchQuery, showToast])
+    showToast(`Filtered to: ${project.name}`, 'info')
+  }, [showToast])
+
+  const handleClearProjectFilter = useCallback(() => {
+    setSelectedProjectRoot(null)
+    showToast('Project filter cleared', 'info')
+  }, [showToast])
 
   // Keyboard shortcuts
   useKeyboardShortcuts({
@@ -176,6 +191,24 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
       {/* Sessions Tab */}
       {activeTab === 'sessions' && !loading && (
         <Suspense fallback={<SessionCardSkeleton count={4} />}>
+          {selectedProjectRoot && (
+            <div className={layoutStyles.projectFilterBar}>
+              <span className={layoutStyles.projectFilterText}>
+                Project:
+                <strong>{selectedProject?.name || selectedProjectRoot.split('/').pop() || selectedProjectRoot}</strong>
+                <span className={layoutStyles.projectFilterPath}>
+                  {selectedProject?.displayPath || selectedProjectRoot}
+                </span>
+              </span>
+              <button
+                type="button"
+                className={layoutStyles.projectFilterClear}
+                onClick={handleClearProjectFilter}
+              >
+                Clear
+              </button>
+            </div>
+          )}
           <SessionList
             sessions={filteredSessions}
             onRecover={handleRecover}
@@ -199,11 +232,20 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
       {/* Projects Tab */}
       {activeTab === 'projects' && !loading && (
         <>
+          {projectsError && (
+            <div className={layoutStyles.errorBox} role="alert">
+              Error: {projectsError}
+            </div>
+          )}
           <ProjectStatsBar stats={projectStats} />
-          <ProjectsGrid
-            projects={projects}
-            onProjectClick={handleProjectClick}
-          />
+          {projectsLoading ? (
+            <SessionCardSkeleton count={4} />
+          ) : (
+            <ProjectsGrid
+              projects={projects}
+              onProjectClick={handleProjectClick}
+            />
+          )}
         </>
       )}
 

--- a/src/web/client/src/App.tsx
+++ b/src/web/client/src/App.tsx
@@ -143,9 +143,10 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
 
   const handleProjectClick = useCallback((project: ProjectInfo) => {
     setSelectedProjectRoot(project.rootPath)
+    setSearchQuery('')
     setActiveTab('sessions')
     showToast(`Filtered to: ${project.name}`, 'info')
-  }, [showToast])
+  }, [setSearchQuery, showToast])
 
   const handleClearProjectFilter = useCallback(() => {
     setSelectedProjectRoot(null)

--- a/src/web/client/src/components/Layout/Layout.module.css
+++ b/src/web/client/src/components/Layout/Layout.module.css
@@ -37,3 +37,49 @@
   color: var(--danger);
   margin-bottom: var(--space-lg);
 }
+
+.projectFilterBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--primary);
+  border-radius: var(--radius-sm);
+}
+
+.projectFilterText {
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+  color: var(--text);
+}
+
+.projectFilterPath {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+}
+
+.projectFilterClear {
+  flex: 0 0 auto;
+  padding: 0.35rem 0.65rem;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.projectFilterClear:hover,
+.projectFilterClear:focus-visible {
+  border-color: var(--primary);
+  color: var(--primary);
+}

--- a/src/web/client/src/components/ProjectCard/ProjectCard.module.css
+++ b/src/web/client/src/components/ProjectCard/ProjectCard.module.css
@@ -44,6 +44,13 @@
   gap: 0.5rem;
 }
 
+.identity {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
 .projectName {
   margin: 0;
   font-size: 1rem;
@@ -53,11 +60,36 @@
   word-break: break-word;
 }
 
+.projectPath {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+}
+
 .cost {
   font-size: 0.75rem;
   font-weight: 500;
   color: var(--warning);
   white-space: nowrap;
+  font-family: var(--font-mono);
+}
+
+.clientRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.clientBadge {
+  padding: 0.1rem 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-dim);
+  font-size: 0.68rem;
   font-family: var(--font-mono);
 }
 

--- a/src/web/client/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/web/client/src/components/ProjectCard/ProjectCard.tsx
@@ -6,7 +6,7 @@ import styles from './ProjectCard.module.css'
 
 export interface ProjectCardProps {
   project: ProjectInfo
-  onClick?: (projectPath: string) => void
+  onClick?: (project: ProjectInfo) => void
 }
 
 /** Status indicator emojis and colors */
@@ -22,20 +22,28 @@ export const ProjectCard = memo(function ProjectCard({
   project,
   onClick,
 }: ProjectCardProps) {
-  const { name, path, stats, currentTask, lastActiveAt, totalUsage } = project
+  const {
+    name,
+    displayPath,
+    stats,
+    clientCounts,
+    currentTask,
+    lastActiveAt,
+    totalUsage,
+  } = project
 
   const handleClick = useCallback(() => {
-    onClick?.(path)
-  }, [onClick, path])
+    onClick?.(project)
+  }, [onClick, project])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault()
-        onClick?.(path)
+        onClick?.(project)
       }
     },
-    [onClick, path]
+    [onClick, project]
   )
 
   const activityStatus = getProjectActivityStatus(stats)
@@ -57,9 +65,26 @@ export const ProjectCard = memo(function ProjectCard({
       aria-label={`Project ${name}, ${stats.total} sessions`}
     >
       <div className={styles.header}>
-        <h3 className={styles.projectName}>{name}</h3>
+        <div className={styles.identity}>
+          <h3 className={styles.projectName}>{name}</h3>
+          <span className={styles.projectPath} title={displayPath}>
+            {displayPath}
+          </span>
+        </div>
         {totalUsage && totalUsage.totalCost > 0 && (
           <span className={styles.cost}>{formatCost(totalUsage.totalCost)}</span>
+        )}
+      </div>
+
+      <div className={styles.clientRow}>
+        {clientCounts.claude > 0 && (
+          <span className={styles.clientBadge}>Claude {clientCounts.claude}</span>
+        )}
+        {clientCounts.codex > 0 && (
+          <span className={styles.clientBadge}>Codex {clientCounts.codex}</span>
+        )}
+        {clientCounts.unknown > 0 && (
+          <span className={styles.clientBadge}>Unknown {clientCounts.unknown}</span>
         )}
       </div>
 

--- a/src/web/client/src/components/ProjectsGrid/ProjectsGrid.tsx
+++ b/src/web/client/src/components/ProjectsGrid/ProjectsGrid.tsx
@@ -5,7 +5,7 @@ import styles from './ProjectsGrid.module.css'
 
 export interface ProjectsGridProps {
   projects: ProjectInfo[]
-  onProjectClick?: (projectPath: string) => void
+  onProjectClick?: (project: ProjectInfo) => void
 }
 
 export const ProjectsGrid = memo(function ProjectsGrid({
@@ -28,7 +28,7 @@ export const ProjectsGrid = memo(function ProjectsGrid({
     <div className={styles.grid}>
       {projects.map((project) => (
         <ProjectCard
-          key={project.path}
+          key={project.id}
           project={project}
           onClick={onProjectClick}
         />

--- a/src/web/client/src/hooks/useProjects.ts
+++ b/src/web/client/src/hooks/useProjects.ts
@@ -29,10 +29,13 @@ export function useProjects(_token: string, refreshKey = 0): UseProjectsReturn {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const mountedRef = useRef(true)
+  const refreshRequestIdRef = useRef(0)
 
   const refresh = useCallback(async () => {
+    const requestId = ++refreshRequestIdRef.current
     const response = await api.fetchProjects('basic')
     if (!mountedRef.current) return
+    if (requestId !== refreshRequestIdRef.current) return
 
     if (response.success && response.data) {
       setProjects(response.data.projects)

--- a/src/web/client/src/hooks/useProjects.ts
+++ b/src/web/client/src/hooks/useProjects.ts
@@ -1,13 +1,6 @@
-import { useMemo } from 'react'
-import type { Session } from '@/types'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { api } from '@/services/api'
 import type { ProjectInfo, ProjectOverviewStats } from '@/types/project'
-import {
-  extractProjectName,
-  calculateProjectStats,
-  findCurrentTask,
-  findLastActive,
-  aggregateUsageStats,
-} from '@/types/project'
 
 export interface UseProjectsReturn {
   /** List of projects, sorted by last activity */
@@ -16,92 +9,59 @@ export interface UseProjectsReturn {
   stats: ProjectOverviewStats
   /** Whether any projects exist */
   hasProjects: boolean
+  /** Whether projects are loading */
+  loading: boolean
+  /** Last project API error */
+  error: string | null
+  /** Refresh project summaries */
+  refresh: () => Promise<void>
 }
 
 /**
- * Aggregates sessions by directory into project groups.
+ * Loads project summaries from the backend project API.
  *
- * @param sessions - Array of sessions to aggregate
- * @returns Aggregated project data with statistics
+ * The optional refreshKey lets the sessions websocket drive a project refresh
+ * without deriving projects from a paginated sessions list.
  */
-export function useProjects(sessions: Session[]): UseProjectsReturn {
-  const projects = useMemo(() => {
-    return aggregateProjects(sessions)
-  }, [sessions])
+export function useProjects(_token: string, refreshKey = 0): UseProjectsReturn {
+  const [projects, setProjects] = useState<ProjectInfo[]>([])
+  const [stats, setStats] = useState<ProjectOverviewStats>({ total: 0, active: 0, idle: 0 })
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const mountedRef = useRef(true)
 
-  const stats = useMemo(() => {
-    return calculateOverviewStats(projects)
-  }, [projects])
+  const refresh = useCallback(async () => {
+    const response = await api.fetchProjects('basic')
+    if (!mountedRef.current) return
+
+    if (response.success && response.data) {
+      setProjects(response.data.projects)
+      setStats(response.data.stats)
+      setError(null)
+    } else {
+      setError(response.error || 'Failed to load projects')
+    }
+    setLoading(false)
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    setLoading(true)
+    refresh()
+  }, [refresh, refreshKey])
 
   return {
     projects,
     stats,
     hasProjects: projects.length > 0,
-  }
-}
-
-/**
- * Aggregate sessions by project name (not full path).
- * This merges sessions from different directories with the same project name.
- * Exported for testing.
- */
-export function aggregateProjects(sessions: Session[]): ProjectInfo[] {
-  // Group sessions by project name (last segment of path)
-  const projectMap = new Map<string, Session[]>()
-
-  for (const session of sessions) {
-    const directory = session.directory || 'Unknown'
-    const projectName = extractProjectName(directory)
-    const existing = projectMap.get(projectName) || []
-    projectMap.set(projectName, [...existing, session])
-  }
-
-  // Transform to ProjectInfo array
-  const projects: ProjectInfo[] = Array.from(projectMap.entries()).map(
-    ([name, projectSessions]) => {
-      // Use the most recent session's directory as the primary path
-      const sortedByTime = [...projectSessions].sort(
-        (a, b) => new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime()
-      )
-      const primaryPath = sortedByTime[0]?.directory || 'Unknown'
-
-      return {
-        path: primaryPath,
-        name,
-        sessions: projectSessions,
-        stats: calculateProjectStats(projectSessions),
-        currentTask: findCurrentTask(projectSessions),
-        lastActiveAt: findLastActive(projectSessions),
-        totalUsage: aggregateUsageStats(projectSessions),
-      }
-    }
-  )
-
-  // Sort by last activity (most recent first)
-  return projects.sort(
-    (a, b) => new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime()
-  )
-}
-
-/**
- * Calculate overview statistics from projects.
- * Exported for testing.
- */
-export function calculateOverviewStats(projects: ProjectInfo[]): ProjectOverviewStats {
-  let active = 0
-  let idle = 0
-
-  for (const project of projects) {
-    if (project.stats.running > 0 || project.stats.waiting > 0) {
-      active++
-    } else {
-      idle++
-    }
-  }
-
-  return {
-    total: projects.length,
-    active,
-    idle,
+    loading,
+    error,
+    refresh,
   }
 }

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -8,6 +8,43 @@ export type ConnectionStatus = 'polling' | 'realtime' | 'disconnected'
 
 // Number of sessions to load per page
 const PAGE_SIZE = 50
+const SNAPSHOT_PAGE_SIZE = 100
+
+async function fetchAllBasicSessionsSnapshot(): Promise<{ sessions: Session[]; error: string | null }> {
+  const sessions: Session[] = []
+  let offset = 0
+
+  while (true) {
+    const response = await api.fetchSessions('basic', {
+      limit: SNAPSHOT_PAGE_SIZE,
+      offset,
+      skipSync: true,
+    })
+
+    if (!response.success || !response.data) {
+      return {
+        sessions: [],
+        error: response.error || 'Failed to load unfiltered sessions',
+      }
+    }
+
+    const page = response.data.sessions
+    sessions.push(...page)
+
+    if (!response.data.pagination?.hasMore) {
+      return { sessions, error: null }
+    }
+
+    if (page.length === 0) {
+      return {
+        sessions: [],
+        error: 'Failed to load complete unfiltered sessions',
+      }
+    }
+
+    offset += page.length
+  }
+}
 
 interface UseSessionsReturn {
   sessions: Session[]
@@ -54,6 +91,7 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
   const mountedRef = useRef(true)
   const wsConnectedRef = useRef(false)
   const projectRootRef = useRef<string | undefined>(options.projectRoot)
+  const loadRequestIdRef = useRef(0)
 
   // Full data cache for lazy loading - use refs to avoid re-render loops
   // Now caches combined data from /full endpoint (details + tools + subagents)
@@ -115,29 +153,31 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
 
   // Use ref to avoid stale closures in interval
   const loadSessions = useCallback(async () => {
+    const requestId = ++loadRequestIdRef.current
+    const requestedProjectRoot = options.projectRoot
+
     // Use 'basic' mode for faster loading, with pagination
     const [response, unfilteredResponse] = await Promise.all([
       api.fetchSessions('basic', {
         limit: PAGE_SIZE,
-        projectRoot: options.projectRoot,
+        projectRoot: requestedProjectRoot,
       }),
-      options.projectRoot
-        ? api.fetchSessions('basic', {
-          limit: PAGE_SIZE,
-          skipSync: true,
-        })
+      requestedProjectRoot
+        ? fetchAllBasicSessionsSnapshot()
         : Promise.resolve(null),
     ])
 
     // Only update state if component is still mounted
     if (!mountedRef.current) return
+    if (requestId !== loadRequestIdRef.current) return
+    if (requestedProjectRoot !== projectRootRef.current) return
 
     if (response.success && response.data) {
       setSessions(response.data.sessions)
       let unfilteredError: string | null = null
-      if (options.projectRoot) {
-        if (unfilteredResponse?.success && unfilteredResponse.data) {
-          setAllSessions(unfilteredResponse.data.sessions)
+      if (requestedProjectRoot) {
+        if (unfilteredResponse && !unfilteredResponse.error) {
+          setAllSessions(unfilteredResponse.sessions)
         } else {
           unfilteredError = unfilteredResponse?.error || 'Failed to load unfiltered sessions'
         }

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -197,21 +197,26 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
   const loadMore = useCallback(async () => {
     if (!pagination?.hasMore || loadingMore) return
 
+    const requestedProjectRoot = options.projectRoot
     setLoadingMore(true)
     const response = await api.fetchSessions('basic', {
       limit: PAGE_SIZE,
       offset: sessions.length,
       skipSync: true, // Don't trigger sync for pagination requests
-      projectRoot: options.projectRoot,
+      projectRoot: requestedProjectRoot,
     })
 
     if (!mountedRef.current) return
+    if (requestedProjectRoot !== projectRootRef.current) {
+      setLoadingMore(false)
+      return
+    }
 
     if (response.success && response.data) {
       // Append new sessions to existing list
       const nextSessions = response.data.sessions
       setSessions(prev => [...prev, ...nextSessions])
-      if (!options.projectRoot) {
+      if (!requestedProjectRoot) {
         setAllSessions(prev => [...prev, ...nextSessions])
       }
       setPagination(response.data.pagination || null)

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -46,6 +46,23 @@ async function fetchAllBasicSessionsSnapshot(): Promise<{ sessions: Session[]; e
   }
 }
 
+function getSessionVersionSignature(sessions: Session[]): string {
+  return sessions
+    .map(session => [
+      session.sessionId,
+      session.client,
+      session.directory,
+      session.status,
+      session.title,
+      session.lastActiveAt,
+      session.completedAt || '',
+      session.toolCount,
+      session.messageCount,
+      session.updatedAt,
+    ].join(':'))
+    .join('|')
+}
+
 interface UseSessionsReturn {
   sessions: Session[]
   allSessions: Session[]
@@ -92,6 +109,7 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
   const wsConnectedRef = useRef(false)
   const projectRootRef = useRef<string | undefined>(options.projectRoot)
   const loadRequestIdRef = useRef(0)
+  const versionSignatureRef = useRef('')
 
   // Full data cache for lazy loading - use refs to avoid re-render loops
   // Now caches combined data from /full endpoint (details + tools + subagents)
@@ -99,6 +117,13 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
   const loadingFullRef = useRef<Set<string>>(new Set())
   // Trigger re-render when cache updates
   const [, forceUpdate] = useState(0)
+
+  const bumpVersionIfChanged = useCallback((snapshot: Session[]) => {
+    const nextSignature = getSessionVersionSignature(snapshot)
+    if (nextSignature === versionSignatureRef.current) return
+    versionSignatureRef.current = nextSignature
+    setVersion(v => v + 1)
+  }, [])
 
   useEffect(() => {
     projectRootRef.current = options.projectRoot
@@ -111,6 +136,7 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
     if (message.type === 'sessions:update' && message.data) {
       const data = message.data as { sessions: Session[]; stats: SessionStats }
       setAllSessions(data.sessions)
+      bumpVersionIfChanged(data.sessions)
       if (projectRootRef.current) {
         loadSessionsRef.current()
         return
@@ -119,9 +145,8 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
       setStats(data.stats)
       setPagination(null)
       setError(null)
-      setVersion(v => v + 1)
     }
-  }, [])
+  }, [bumpVersionIfChanged])
 
   // WebSocket connection
   useWebSocket({
@@ -157,15 +182,10 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
     const requestedProjectRoot = options.projectRoot
 
     // Use 'basic' mode for faster loading, with pagination
-    const [response, unfilteredResponse] = await Promise.all([
-      api.fetchSessions('basic', {
-        limit: PAGE_SIZE,
-        projectRoot: requestedProjectRoot,
-      }),
-      requestedProjectRoot
-        ? fetchAllBasicSessionsSnapshot()
-        : Promise.resolve(null),
-    ])
+    const response = await api.fetchSessions('basic', {
+      limit: PAGE_SIZE,
+      projectRoot: requestedProjectRoot,
+    })
 
     // Only update state if component is still mounted
     if (!mountedRef.current) return
@@ -174,24 +194,30 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
 
     if (response.success && response.data) {
       setSessions(response.data.sessions)
-      let unfilteredError: string | null = null
       if (requestedProjectRoot) {
-        if (unfilteredResponse && !unfilteredResponse.error) {
-          setAllSessions(unfilteredResponse.sessions)
-        } else {
-          unfilteredError = unfilteredResponse?.error || 'Failed to load unfiltered sessions'
-        }
+        fetchAllBasicSessionsSnapshot().then(unfilteredResponse => {
+          if (!mountedRef.current) return
+          if (requestId !== loadRequestIdRef.current) return
+          if (requestedProjectRoot !== projectRootRef.current) return
+
+          if (!unfilteredResponse.error) {
+            setAllSessions(unfilteredResponse.sessions)
+            bumpVersionIfChanged(unfilteredResponse.sessions)
+          } else {
+            setError(unfilteredResponse.error)
+          }
+        })
       } else {
         setAllSessions(response.data.sessions)
+        bumpVersionIfChanged(response.data.sessions)
       }
       setStats(response.data.stats)
       setPagination(response.data.pagination || null)
-      setError(unfilteredError)
-      setVersion(v => v + 1)
+      setError(null)
     } else {
       setError(response.error || 'Failed to load sessions')
     }
-  }, [options.projectRoot])
+  }, [bumpVersionIfChanged, options.projectRoot])
 
   // Load more sessions (pagination)
   const loadMore = useCallback(async () => {
@@ -218,12 +244,12 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
       setSessions(prev => [...prev, ...nextSessions])
       if (!requestedProjectRoot) {
         setAllSessions(prev => [...prev, ...nextSessions])
+        bumpVersionIfChanged([...sessions, ...nextSessions])
       }
       setPagination(response.data.pagination || null)
-      setVersion(v => v + 1)
     }
     setLoadingMore(false)
-  }, [pagination, loadingMore, sessions.length, options.projectRoot])
+  }, [bumpVersionIfChanged, pagination, loadingMore, sessions, options.projectRoot])
 
   // Keep loadSessionsRef updated
   useEffect(() => {

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -30,9 +30,15 @@ interface UseSessionsReturn {
   loadingMore: boolean
   // WebSocket status
   connectionStatus: ConnectionStatus
+  // Incremented when session data changes
+  version: number
 }
 
-export function useSessions(token: string): UseSessionsReturn {
+interface UseSessionsOptions {
+  projectRoot?: string
+}
+
+export function useSessions(token: string, options: UseSessionsOptions = {}): UseSessionsReturn {
   const [sessions, setSessions] = useState<Session[]>([])
   const [stats, setStats] = useState<SessionStats | null>(null)
   const [loading, setLoading] = useState(true)
@@ -41,9 +47,11 @@ export function useSessions(token: string): UseSessionsReturn {
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('polling')
   const [pagination, setPagination] = useState<PaginationInfo | null>(null)
   const [loadingMore, setLoadingMore] = useState(false)
+  const [version, setVersion] = useState(0)
   const intervalRef = useRef<number | null>(null)
   const mountedRef = useRef(true)
   const wsConnectedRef = useRef(false)
+  const projectRootRef = useRef<string | undefined>(options.projectRoot)
 
   // Full data cache for lazy loading - use refs to avoid re-render loops
   // Now caches combined data from /full endpoint (details + tools + subagents)
@@ -52,15 +60,25 @@ export function useSessions(token: string): UseSessionsReturn {
   // Trigger re-render when cache updates
   const [, forceUpdate] = useState(0)
 
+  useEffect(() => {
+    projectRootRef.current = options.projectRoot
+  }, [options.projectRoot])
+
   // Handle WebSocket messages
   const handleWebSocketMessage = useCallback((message: WebSocketMessage) => {
     if (!mountedRef.current) return
 
     if (message.type === 'sessions:update' && message.data) {
+      if (projectRootRef.current) {
+        loadSessionsRef.current()
+        return
+      }
       const data = message.data as { sessions: Session[]; stats: SessionStats }
       setSessions(data.sessions)
       setStats(data.stats)
+      setPagination(null)
       setError(null)
+      setVersion(v => v + 1)
     }
   }, [])
 
@@ -95,7 +113,10 @@ export function useSessions(token: string): UseSessionsReturn {
   // Use ref to avoid stale closures in interval
   const loadSessions = useCallback(async () => {
     // Use 'basic' mode for faster loading, with pagination
-    const response = await api.fetchSessions('basic', { limit: PAGE_SIZE })
+    const response = await api.fetchSessions('basic', {
+      limit: PAGE_SIZE,
+      projectRoot: options.projectRoot,
+    })
 
     // Only update state if component is still mounted
     if (!mountedRef.current) return
@@ -105,10 +126,11 @@ export function useSessions(token: string): UseSessionsReturn {
       setStats(response.data.stats)
       setPagination(response.data.pagination || null)
       setError(null)
+      setVersion(v => v + 1)
     } else {
       setError(response.error || 'Failed to load sessions')
     }
-  }, [])
+  }, [options.projectRoot])
 
   // Load more sessions (pagination)
   const loadMore = useCallback(async () => {
@@ -119,6 +141,7 @@ export function useSessions(token: string): UseSessionsReturn {
       limit: PAGE_SIZE,
       offset: sessions.length,
       skipSync: true, // Don't trigger sync for pagination requests
+      projectRoot: options.projectRoot,
     })
 
     if (!mountedRef.current) return
@@ -127,9 +150,10 @@ export function useSessions(token: string): UseSessionsReturn {
       // Append new sessions to existing list
       setSessions(prev => [...prev, ...response.data!.sessions])
       setPagination(response.data.pagination || null)
+      setVersion(v => v + 1)
     }
     setLoadingMore(false)
-  }, [pagination, loadingMore, sessions.length])
+  }, [pagination, loadingMore, sessions.length, options.projectRoot])
 
   // Keep loadSessionsRef updated
   useEffect(() => {
@@ -224,15 +248,17 @@ export function useSessions(token: string): UseSessionsReturn {
     return loadingFullRef.current.has(sessionId)
   }, []) // No dependencies - uses ref
 
-  // Initial load - run once on mount
   useEffect(() => {
     mountedRef.current = true
-    refresh()
 
     return () => {
       mountedRef.current = false
     }
   }, []) // Empty deps - only run on mount
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
 
   // Auto-refresh interval (only when WebSocket is not connected)
   useEffect(() => {
@@ -272,5 +298,6 @@ export function useSessions(token: string): UseSessionsReturn {
     loadingMore,
     // WebSocket status
     connectionStatus,
+    version,
   }
 }

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -11,6 +11,7 @@ const PAGE_SIZE = 50
 
 interface UseSessionsReturn {
   sessions: Session[]
+  allSessions: Session[]
   stats: SessionStats | null
   loading: boolean
   syncing: boolean
@@ -40,6 +41,7 @@ interface UseSessionsOptions {
 
 export function useSessions(token: string, options: UseSessionsOptions = {}): UseSessionsReturn {
   const [sessions, setSessions] = useState<Session[]>([])
+  const [allSessions, setAllSessions] = useState<Session[]>([])
   const [stats, setStats] = useState<SessionStats | null>(null)
   const [loading, setLoading] = useState(true)
   const [syncing, setSyncing] = useState(false)
@@ -69,11 +71,12 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
     if (!mountedRef.current) return
 
     if (message.type === 'sessions:update' && message.data) {
+      const data = message.data as { sessions: Session[]; stats: SessionStats }
+      setAllSessions(data.sessions)
       if (projectRootRef.current) {
         loadSessionsRef.current()
         return
       }
-      const data = message.data as { sessions: Session[]; stats: SessionStats }
       setSessions(data.sessions)
       setStats(data.stats)
       setPagination(null)
@@ -113,19 +116,37 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
   // Use ref to avoid stale closures in interval
   const loadSessions = useCallback(async () => {
     // Use 'basic' mode for faster loading, with pagination
-    const response = await api.fetchSessions('basic', {
-      limit: PAGE_SIZE,
-      projectRoot: options.projectRoot,
-    })
+    const [response, unfilteredResponse] = await Promise.all([
+      api.fetchSessions('basic', {
+        limit: PAGE_SIZE,
+        projectRoot: options.projectRoot,
+      }),
+      options.projectRoot
+        ? api.fetchSessions('basic', {
+          limit: PAGE_SIZE,
+          skipSync: true,
+        })
+        : Promise.resolve(null),
+    ])
 
     // Only update state if component is still mounted
     if (!mountedRef.current) return
 
     if (response.success && response.data) {
       setSessions(response.data.sessions)
+      let unfilteredError: string | null = null
+      if (options.projectRoot) {
+        if (unfilteredResponse?.success && unfilteredResponse.data) {
+          setAllSessions(unfilteredResponse.data.sessions)
+        } else {
+          unfilteredError = unfilteredResponse?.error || 'Failed to load unfiltered sessions'
+        }
+      } else {
+        setAllSessions(response.data.sessions)
+      }
       setStats(response.data.stats)
       setPagination(response.data.pagination || null)
-      setError(null)
+      setError(unfilteredError)
       setVersion(v => v + 1)
     } else {
       setError(response.error || 'Failed to load sessions')
@@ -148,7 +169,11 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
 
     if (response.success && response.data) {
       // Append new sessions to existing list
-      setSessions(prev => [...prev, ...response.data!.sessions])
+      const nextSessions = response.data.sessions
+      setSessions(prev => [...prev, ...nextSessions])
+      if (!options.projectRoot) {
+        setAllSessions(prev => [...prev, ...nextSessions])
+      }
       setPagination(response.data.pagination || null)
       setVersion(v => v + 1)
     }
@@ -279,6 +304,7 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
 
   return {
     sessions,
+    allSessions,
     stats,
     loading,
     syncing,

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -209,7 +209,22 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
         })
       } else {
         setAllSessions(response.data.sessions)
-        bumpVersionIfChanged(response.data.sessions)
+        if (!response.data.pagination?.hasMore) {
+          bumpVersionIfChanged(response.data.sessions)
+        } else {
+          fetchAllBasicSessionsSnapshot().then(unfilteredResponse => {
+            if (!mountedRef.current) return
+            if (requestId !== loadRequestIdRef.current) return
+            if (requestedProjectRoot !== projectRootRef.current) return
+
+            if (!unfilteredResponse.error) {
+              setAllSessions(unfilteredResponse.sessions)
+              bumpVersionIfChanged(unfilteredResponse.sessions)
+            } else {
+              setError(unfilteredResponse.error)
+            }
+          })
+        }
       }
       setStats(response.data.stats)
       setPagination(response.data.pagination || null)

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -208,8 +208,8 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
           }
         })
       } else {
-        setAllSessions(response.data.sessions)
         if (!response.data.pagination?.hasMore) {
+          setAllSessions(response.data.sessions)
           bumpVersionIfChanged(response.data.sessions)
         } else {
           fetchAllBasicSessionsSnapshot().then(unfilteredResponse => {
@@ -257,14 +257,10 @@ export function useSessions(token: string, options: UseSessionsOptions = {}): Us
       // Append new sessions to existing list
       const nextSessions = response.data.sessions
       setSessions(prev => [...prev, ...nextSessions])
-      if (!requestedProjectRoot) {
-        setAllSessions(prev => [...prev, ...nextSessions])
-        bumpVersionIfChanged([...sessions, ...nextSessions])
-      }
       setPagination(response.data.pagination || null)
     }
     setLoadingMore(false)
-  }, [bumpVersionIfChanged, pagination, loadingMore, sessions, options.projectRoot])
+  }, [pagination, loadingMore, sessions.length, options.projectRoot])
 
   // Keep loadSessionsRef updated
   useEffect(() => {

--- a/src/web/client/src/services/api.ts
+++ b/src/web/client/src/services/api.ts
@@ -5,6 +5,7 @@
 import type {
   ApiResponse,
   SessionsData,
+  ProjectsData,
   SyncResult,
   SessionDetailData,
   SessionDetailsData,
@@ -113,6 +114,10 @@ export async function fetchSessions(
     limit?: number
     offset?: number
     skipSync?: boolean
+    client?: 'claude' | 'codex'
+    status?: string
+    projectRoot?: string
+    projectId?: string
   },
   signal?: AbortSignal
 ): Promise<ApiResponse<SessionsData>> {
@@ -120,7 +125,22 @@ export async function fetchSessions(
   if (options?.limit) params.set('limit', String(options.limit))
   if (options?.offset) params.set('offset', String(options.offset))
   if (options?.skipSync) params.set('skipSync', 'true')
+  if (options?.client) params.set('client', options.client)
+  if (options?.status) params.set('status', options.status)
+  if (options?.projectRoot) params.set('projectRoot', options.projectRoot)
+  if (options?.projectId) params.set('projectId', options.projectId)
   return request<SessionsData>(`/sessions?${params}`, undefined, signal)
+}
+
+/**
+ * GET /api/projects - Fetch project summaries with stats
+ */
+export async function fetchProjects(
+  fields: 'basic' | 'full' = 'basic',
+  signal?: AbortSignal
+): Promise<ApiResponse<ProjectsData>> {
+  const params = new URLSearchParams({ fields })
+  return request<ProjectsData>(`/projects?${params}`, undefined, signal)
 }
 
 /**
@@ -448,6 +468,7 @@ export async function logoutAuth(
 // Export all API functions
 export const api = {
   fetchSessions,
+  fetchProjects,
   syncSessions,
   fetchSession,
   recoverSession,

--- a/src/web/client/src/types/api.ts
+++ b/src/web/client/src/types/api.ts
@@ -2,6 +2,7 @@
  * API response types
  */
 
+import type { ProjectInfo, ProjectOverviewStats } from './project'
 import type { Session, SessionStats, ToolCallInfo, SubAgent } from './session'
 
 // Base API response
@@ -25,6 +26,12 @@ export interface SessionsData {
   sessions: Session[]
   stats: SessionStats
   pagination?: PaginationInfo
+}
+
+// GET /api/projects
+export interface ProjectsData {
+  projects: ProjectInfo[]
+  stats: ProjectOverviewStats
 }
 
 // POST /api/sync

--- a/src/web/client/src/types/project.ts
+++ b/src/web/client/src/types/project.ts
@@ -2,7 +2,9 @@
  * Project types - for grouping sessions by directory
  */
 
-import type { Session, SessionStatus, UsageStats } from './session'
+import type { AgentClient, Session, SessionStatus, UsageStats } from './session'
+
+export type ProjectClient = AgentClient | 'unknown'
 
 /** Statistics for a single project */
 export interface ProjectStats {
@@ -16,14 +18,24 @@ export interface ProjectStats {
 
 /** Aggregated project information */
 export interface ProjectInfo {
+  /** Stable project identity */
+  id: string
+  /** Canonical project root path */
+  rootPath: string
   /** Full directory path */
   path: string
+  /** Compact display path */
+  displayPath: string
   /** Extracted project name (last segment of path) */
   name: string
+  /** Project identity source */
+  source?: 'git-root' | 'cwd' | 'unknown'
   /** All sessions in this directory */
   sessions: Session[]
   /** Session status counts */
   stats: ProjectStats
+  /** Session counts by agent client */
+  clientCounts: Record<ProjectClient, number>
   /** Title/prompt of the most recently active session */
   currentTask?: string
   /** Most recent activity timestamp */
@@ -65,6 +77,95 @@ export function getProjectActivityStatus(stats: ProjectStats): ProjectActivitySt
 export function extractProjectName(path: string): string {
   const segments = path.split('/').filter(Boolean)
   return segments[segments.length - 1] || path
+}
+
+export function normalizeProjectPath(path: string): string {
+  const trimmed = path.trim()
+  if (!trimmed) return 'Unknown'
+  const withoutTrailing = trimmed.replace(/\/+$/, '')
+  return withoutTrailing || trimmed
+}
+
+export function projectIdFromPath(path: string): string {
+  return `path:${encodeURIComponent(normalizeProjectPath(path))}`
+}
+
+export function createClientCounts(sessions: Session[]): Record<ProjectClient, number> {
+  const counts: Record<ProjectClient, number> = {
+    claude: 0,
+    codex: 0,
+    unknown: 0,
+  }
+
+  for (const session of sessions) {
+    if (session.client === 'claude' || session.client === 'codex') {
+      counts[session.client]++
+    } else {
+      counts.unknown++
+    }
+  }
+
+  return counts
+}
+
+/**
+ * Aggregate sessions by exact directory path for tests and full-list fallbacks.
+ */
+export function aggregateProjects(sessions: Session[]): ProjectInfo[] {
+  const projectMap = new Map<string, Session[]>()
+
+  for (const session of sessions) {
+    const directory = normalizeProjectPath(session.directory || 'Unknown')
+    const existing = projectMap.get(directory) || []
+    projectMap.set(directory, [...existing, session])
+  }
+
+  const projects: ProjectInfo[] = Array.from(projectMap.entries()).map(
+    ([path, projectSessions]) => {
+      const sortedByTime = [...projectSessions].sort(
+        (a, b) => new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime()
+      )
+      const primaryPath = normalizeProjectPath(sortedByTime[0]?.directory || path)
+
+      return {
+        id: projectIdFromPath(path),
+        rootPath: path,
+        path: primaryPath,
+        displayPath: path,
+        name: extractProjectName(path),
+        source: path === 'Unknown' ? 'unknown' : 'cwd',
+        sessions: projectSessions,
+        stats: calculateProjectStats(projectSessions),
+        clientCounts: createClientCounts(projectSessions),
+        currentTask: findCurrentTask(projectSessions),
+        lastActiveAt: findLastActive(projectSessions),
+        totalUsage: aggregateUsageStats(projectSessions),
+      }
+    }
+  )
+
+  return projects.sort(
+    (a, b) => new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime()
+  )
+}
+
+export function calculateOverviewStats(projects: ProjectInfo[]): ProjectOverviewStats {
+  let active = 0
+  let idle = 0
+
+  for (const project of projects) {
+    if (project.stats.running > 0 || project.stats.waiting > 0) {
+      active++
+    } else {
+      idle++
+    }
+  }
+
+  return {
+    total: projects.length,
+    active,
+    idle,
+  }
 }
 
 /**

--- a/src/web/client/src/types/project.ts
+++ b/src/web/client/src/types/project.ts
@@ -30,8 +30,8 @@ export interface ProjectInfo {
   name: string
   /** Project identity source */
   source?: 'git-root' | 'cwd' | 'unknown'
-  /** All sessions in this directory */
-  sessions: Session[]
+  /** Sessions are only present in full project responses */
+  sessions?: Session[]
   /** Session status counts */
   stats: ProjectStats
   /** Session counts by agent client */


### PR DESCRIPTION
## Summary
- add backend project identity resolution from git root/cwd with collision-resistant ids
- add `/api/projects` summaries and exact `projectRoot`/`projectId` session filtering
- update Projects UI to use backend project data and filter sessions by selected project
- expand tests for git roots, missing cwd history, project route grouping, and session filtering

## Verification
- bun test
- bun run typecheck
- bun run build
- authenticated smoke against `http://127.0.0.1:3388/api/projects?fields=basic`
- authenticated smoke for `/api/sessions?fields=basic&projectRoot=...`

Implements the project workspaces spec merged in #42.