### PR TITLE
Add runtime adapter domain and registry

### DIFF
--- a/src/__tests__/claude.scanner.test.ts
+++ b/src/__tests__/claude.scanner.test.ts
@@ -375,6 +375,44 @@ describe('Claude Scanner', () => {
     expect(secondRun.stdout.includes(brokenPath)).toBe(false);
   });
 
+  test('reports persisted broken-file failures through detailed scan results', () => {
+    const homeDir = createTempHome();
+    const brokenPath = writeSessionFile(homeDir, '-tmp-persist-runtime-error', 'persist-error.jsonl', [
+      {
+        type: 'user',
+        uuid: 'user-1',
+        sessionId: 'persist-error',
+        cwd: '/tmp/persist-runtime-error',
+        timestamp: '2026-04-13T12:05:00.000Z',
+        userType: 'external',
+        message: { role: 'user', content: 'broken file should still report errors' },
+      },
+      '{"type":"assistant", invalid json',
+    ]);
+
+    const firstRun = runScannerScript(homeDir, `
+      const { clearSessionCache, getAllSessionsWithFailures } = await import('./src/adapters/claude/scanner.ts');
+      clearSessionCache();
+      const result = await getAllSessionsWithFailures();
+      console.log(JSON.stringify({
+        count: result.sessions.length,
+        failures: result.failures.map((failure) => failure.filePath),
+      }));
+    `);
+    const secondRun = runScannerScript(homeDir, `
+      const { clearSessionCache, getAllSessionsWithFailures } = await import('./src/adapters/claude/scanner.ts');
+      clearSessionCache();
+      const result = await getAllSessionsWithFailures();
+      console.log(JSON.stringify({
+        count: result.sessions.length,
+        failures: result.failures.map((failure) => failure.filePath),
+      }));
+    `);
+
+    expect(firstRun).toEqual({ count: 0, failures: [brokenPath] });
+    expect(secondRun).toEqual({ count: 0, failures: [brokenPath] });
+  });
+
   test('summarizes bulk parse failures instead of logging each file individually', () => {
     const homeDir = createTempHome();
 

--- a/src/__tests__/codex.parser.test.ts
+++ b/src/__tests__/codex.parser.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -19,6 +19,51 @@ function createCodexJsonlFile(lines: Array<Record<string, unknown> | string>): s
     .join('\n');
   writeFileSync(filePath, `${contents}\n`);
   return filePath;
+}
+
+function createTempHome(): string {
+  const homeDir = mkdtempSync(join(tmpdir(), 'keepline-codex-home-'));
+  tempDirs.push(homeDir);
+  return homeDir;
+}
+
+function writeCodexSessionFile(
+  homeDir: string,
+  rawSessionId: string,
+  lines: Array<Record<string, unknown> | string>
+): string {
+  const sessionDir = join(homeDir, '.codex', 'sessions', '2026', '06', '23');
+  mkdirSync(sessionDir, { recursive: true });
+  const filePath = join(sessionDir, `rollout-${rawSessionId}.jsonl`);
+  const contents = lines
+    .map((line) => (typeof line === 'string' ? line : JSON.stringify(line)))
+    .join('\n');
+  writeFileSync(filePath, `${contents}\n`);
+  return filePath;
+}
+
+function runCodexScannerScript(homeDir: string, script: string) {
+  const proc = Bun.spawnSync({
+    cmd: [process.execPath, '--eval', script],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      KEEPLINE_HOME: join(homeDir, '.keepline'),
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  if (proc.exitCode !== 0) {
+    throw new Error(proc.stderr.toString() || `codex scanner subprocess failed with code ${proc.exitCode}`);
+  }
+
+  const jsonLine = proc.stdout.toString().trim().split('\n').filter(Boolean).pop();
+  if (!jsonLine) {
+    throw new Error('codex scanner subprocess produced no JSON output');
+  }
+  return JSON.parse(jsonLine) as Record<string, unknown>;
 }
 
 afterEach(() => {
@@ -97,5 +142,63 @@ describe('Codex JSONL parser', () => {
         timestamp: '2026-06-17T01:00:05.000Z',
       },
     ]);
+  });
+});
+
+describe('Codex scanner', () => {
+  test('reports cached per-file parse failures while preserving healthy sessions', () => {
+    const homeDir = createTempHome();
+    const healthyId = '019ed4a3-2186-7e51-9aa1-ca1e376549b8';
+    const brokenId = '019ed4a3-2186-7e51-9aa1-ca1e376549b9';
+    const brokenPath = writeCodexSessionFile(homeDir, brokenId, [
+      {
+        type: 'session_meta',
+        timestamp: '2026-06-23T01:00:00.000Z',
+        payload: {
+          id: brokenId,
+          cwd: '/tmp/broken-codex',
+        },
+      },
+      '{"type":"response_item", invalid json',
+    ]);
+    writeCodexSessionFile(homeDir, healthyId, [
+      {
+        type: 'session_meta',
+        timestamp: '2026-06-23T01:00:00.000Z',
+        payload: {
+          id: healthyId,
+          cwd: '/tmp/healthy-codex',
+        },
+      },
+      {
+        type: 'response_item',
+        timestamp: '2026-06-23T01:00:01.000Z',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'Healthy Codex session' }],
+        },
+      },
+    ]);
+
+    const result = runCodexScannerScript(homeDir, `
+      const { clearCodexSessionCache, getAllCodexSessionsWithFailures } = await import('./src/adapters/codex/scanner.ts');
+      clearCodexSessionCache();
+      const first = await getAllCodexSessionsWithFailures();
+      const second = await getAllCodexSessionsWithFailures();
+      console.log(JSON.stringify({
+        firstSessions: first.sessions.map((session) => session.rawSessionId),
+        firstFailures: first.failures.map((failure) => failure.filePath),
+        secondSessions: second.sessions.map((session) => session.rawSessionId),
+        secondFailures: second.failures.map((failure) => failure.filePath),
+      }));
+    `);
+
+    expect(result).toEqual({
+      firstSessions: [healthyId],
+      firstFailures: [brokenPath],
+      secondSessions: [healthyId],
+      secondFailures: [brokenPath],
+    });
   });
 });

--- a/src/__tests__/runtime.registry.test.ts
+++ b/src/__tests__/runtime.registry.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import type {
   AgentRuntimeAdapter,
   RuntimeDescriptor,
@@ -12,8 +15,13 @@ import {
   ClaudeCodeRuntimeAdapter,
   CodexRuntimeAdapter,
   RuntimeRegistry,
+  attributeRuntimeProcesses,
   createDefaultRuntimeRegistry,
 } from '../adapters/runtimes/index.js';
+
+function skipProcessAttribution(sessions: RuntimeSession[]) {
+  return { sessions, errors: [] };
+}
 
 function runtimeSession(overrides: Partial<RuntimeSession> = {}): RuntimeSession {
   return {
@@ -125,6 +133,102 @@ describe('RuntimeRegistry', () => {
       },
     ]);
   });
+
+  test('normalizes cwd roots and filters scans by projectRoot', async () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'runtime-registry-'));
+    try {
+      const repoRoot = join(tmpRoot, 'repo');
+      const repoChild = join(repoRoot, 'packages', 'app');
+      const otherRoot = join(tmpRoot, 'other');
+      mkdirSync(join(repoRoot, '.git'), { recursive: true });
+      mkdirSync(repoChild, { recursive: true });
+      mkdirSync(otherRoot, { recursive: true });
+
+      const descriptor = stubDescriptor({ id: 'root-filter-runtime' });
+      const adapter = stubAdapter({
+        descriptor,
+        scanSessions: async () => ({
+          runtime: descriptor,
+          sessions: [
+            runtimeSession({
+              runtimeId: descriptor.id,
+              sessionId: 'repo-session',
+              cwd: repoChild,
+            }),
+            runtimeSession({
+              runtimeId: descriptor.id,
+              sessionId: 'other-session',
+              cwd: otherRoot,
+            }),
+          ],
+          errors: [],
+        }),
+      });
+
+      const result = await new RuntimeRegistry([adapter]).scanAll({ projectRoot: repoRoot });
+
+      expect(result[0].sessions.map((session) => session.sessionId)).toEqual(['repo-session']);
+      expect(result[0].sessions[0].projectRoot).toBe(realpathSync(repoRoot));
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('runtime process attribution', () => {
+  test('decorates matched runtime sessions with live process state', () => {
+    const now = new Date();
+    const result = attributeRuntimeProcesses(
+      'codex',
+      [runtimeSession({
+        runtimeId: 'codex',
+        sessionId: 'codex-session',
+        cwd: '/tmp/project',
+        startedAt: now,
+        lastActiveAt: now,
+      })],
+      () => [{
+        client: 'codex',
+        pid: 4242,
+        cwd: '/tmp/project',
+        tty: 'ttys001',
+        cpu: 0.1,
+        memory: 1.2,
+        startTime: now,
+        args: ['resume'],
+      }]
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.sessions[0]).toMatchObject({
+      pid: 4242,
+      tty: 'ttys001',
+      processRunning: true,
+      cpuUsage: 0.1,
+      memoryUsage: 1.2,
+    });
+    expect(result.sessions[0].status).not.toBe('unknown');
+  });
+
+  test('surfaces process scanner failures without dropping history sessions', () => {
+    const result = attributeRuntimeProcesses(
+      'claude-code',
+      [runtimeSession({ runtimeId: 'claude-code' })],
+      () => {
+        throw new Error('ps failed');
+      }
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.errors).toEqual([
+      {
+        runtimeId: 'claude-code',
+        code: 'unknown',
+        message: 'ps failed',
+        recoverable: true,
+      },
+    ]);
+  });
 });
 
 describe('ClaudeCodeRuntimeAdapter', () => {
@@ -161,7 +265,7 @@ describe('ClaudeCodeRuntimeAdapter', () => {
       isSubAgent: true,
     };
 
-    const adapter = new ClaudeCodeRuntimeAdapter(async () => [parsed]);
+    const adapter = new ClaudeCodeRuntimeAdapter(async () => [parsed], skipProcessAttribution);
     const result = await adapter.scanSessions({ mode: 'full', includeSubAgents: true });
     const session = result.sessions[0];
 
@@ -171,7 +275,6 @@ describe('ClaudeCodeRuntimeAdapter', () => {
       sessionId: 'claude-session-123',
       cwd: '/tmp/project',
       agentId: 'agent-123',
-      parentSessionId: 'parent-session-123',
       parentRuntimeSessionId: 'parent-session-123',
       isSubAgent: true,
       usageStats: {
@@ -182,6 +285,7 @@ describe('ClaudeCodeRuntimeAdapter', () => {
         apiCalls: 1,
       },
     });
+    expect(session.parentSessionId).toBeUndefined();
     expect(session.filesTouched).toEqual(['/tmp/project/src/index.ts']);
     expect(session.toolCalls).toHaveLength(1);
   });
@@ -248,7 +352,7 @@ describe('ClaudeCodeRuntimeAdapter', () => {
         filePath: '/tmp/project/bad-session.jsonl',
         message: 'Invalid JSONL at line 3',
       }],
-    }));
+    }), skipProcessAttribution);
 
     const result = await adapter.scanSessions();
 
@@ -281,7 +385,7 @@ describe('CodexRuntimeAdapter', () => {
       lastActiveAt: new Date('2026-01-01T00:05:00.000Z'),
     };
 
-    const adapter = new CodexRuntimeAdapter(async () => [parsed]);
+    const adapter = new CodexRuntimeAdapter(async () => [parsed], skipProcessAttribution);
     const result = await adapter.scanSessions();
 
     expect(result.sessions[0]).toMatchObject({
@@ -343,7 +447,7 @@ describe('CodexRuntimeAdapter', () => {
         filePath: '/tmp/codex/bad-rollout.jsonl',
         message: 'Invalid JSONL at line 7',
       }],
-    }));
+    }), skipProcessAttribution);
 
     const result = await adapter.scanSessions();
 

--- a/src/__tests__/runtime.registry.test.ts
+++ b/src/__tests__/runtime.registry.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, test } from 'bun:test';
+import type {
+  AgentRuntimeAdapter,
+  RuntimeDescriptor,
+  RuntimeScanResult,
+  RuntimeSession,
+} from '../domain/runtime/index.js';
+import { scopeCodexSessionId } from '../adapters/codex/parser.js';
+import type { CodexParsedSessionData } from '../adapters/codex/types.js';
+import type { ParsedSessionData } from '../domain/session/index.js';
+import {
+  ClaudeCodeRuntimeAdapter,
+  CodexRuntimeAdapter,
+  RuntimeRegistry,
+  createDefaultRuntimeRegistry,
+} from '../adapters/runtimes/index.js';
+
+function runtimeSession(overrides: Partial<RuntimeSession> = {}): RuntimeSession {
+  return {
+    runtimeId: 'good-runtime',
+    sessionId: 'safe-session-123',
+    cwd: '/tmp/project',
+    status: 'unknown',
+    title: 'Runtime session',
+    filesTouched: [],
+    toolCount: 0,
+    messageCount: 1,
+    lastActiveAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function stubDescriptor(overrides: Partial<RuntimeDescriptor> = {}): RuntimeDescriptor {
+  return {
+    id: 'good-runtime',
+    displayName: 'Good Runtime',
+    kind: 'cli',
+    executableNames: ['good-runtime'],
+    sessionPathHints: [],
+    capabilities: ['session-history'],
+    ...overrides,
+  };
+}
+
+function stubAdapter(overrides: Partial<AgentRuntimeAdapter> = {}): AgentRuntimeAdapter {
+  const descriptor = overrides.descriptor ?? stubDescriptor();
+  return {
+    descriptor,
+    scanSessions: async (): Promise<RuntimeScanResult> => ({
+      runtime: descriptor,
+      sessions: [runtimeSession({ runtimeId: descriptor.id })],
+      errors: [],
+    }),
+    ...overrides,
+  };
+}
+
+describe('RuntimeRegistry', () => {
+  test('default registry includes Claude Code and Codex adapters', () => {
+    const ids = createDefaultRuntimeRegistry()
+      .list()
+      .map((adapter) => adapter.descriptor.id);
+
+    expect(ids).toEqual(['claude-code', 'codex']);
+  });
+
+  test('rejects duplicate runtime IDs', () => {
+    const descriptor = stubDescriptor({ id: 'dupe-runtime' });
+    const registry = new RuntimeRegistry([stubAdapter({ descriptor })]);
+
+    expect(() => registry.register(stubAdapter({ descriptor }))).toThrow(
+      'Runtime adapter already registered: dupe-runtime'
+    );
+  });
+
+  test('rejects resume capability without a recovery command builder', () => {
+    expect(() =>
+      new RuntimeRegistry([
+        stubAdapter({
+          descriptor: stubDescriptor({
+            id: 'bad-resume-runtime',
+            capabilities: ['session-history', 'resume'],
+          }),
+          buildRecoveryCommand: undefined,
+        }),
+      ])
+    ).toThrow('declares resume without buildRecoveryCommand');
+  });
+
+  test('rejects feature capabilities without providers or compatibility routes', () => {
+    expect(() =>
+      new RuntimeRegistry([
+        stubAdapter({
+          descriptor: stubDescriptor({
+            id: 'bad-quota-runtime',
+            capabilities: ['session-history', 'quota'],
+          }),
+        }),
+      ])
+    ).toThrow('declares quota without a provider or compatibility route');
+  });
+
+  test('isolates scan failure from one adapter without hiding healthy sessions', async () => {
+    const good = stubAdapter({
+      descriptor: stubDescriptor({ id: 'healthy-runtime' }),
+    });
+    const badDescriptor = stubDescriptor({ id: 'broken-runtime' });
+    const bad = stubAdapter({
+      descriptor: badDescriptor,
+      scanSessions: async () => {
+        throw new Error('scan exploded');
+      },
+    });
+
+    const results = await new RuntimeRegistry([good, bad]).scanAll();
+
+    expect(results).toHaveLength(2);
+    expect(results.find((result) => result.runtime.id === 'healthy-runtime')?.sessions).toHaveLength(1);
+    expect(results.find((result) => result.runtime.id === 'broken-runtime')?.errors).toEqual([
+      {
+        runtimeId: 'broken-runtime',
+        code: 'unknown',
+        message: 'scan exploded',
+        recoverable: true,
+      },
+    ]);
+  });
+});
+
+describe('ClaudeCodeRuntimeAdapter', () => {
+  test('maps parsed sessions without losing usage, sub-agent, and tool metadata', async () => {
+    const startedAt = new Date('2026-01-01T00:00:00.000Z');
+    const lastActiveAt = new Date('2026-01-01T00:05:00.000Z');
+    const parsed: ParsedSessionData = {
+      sessionId: 'claude-session-123',
+      client: 'claude',
+      directory: '/tmp/project',
+      firstMessage: 'Implement runtime registry',
+      lastMessage: 'Done',
+      messageCount: 2,
+      toolCount: 1,
+      lastTool: 'Edit',
+      lastToolInput: { path: '/tmp/project/src/index.ts' },
+      currentFile: '/tmp/project/src/index.ts',
+      startedAt,
+      lastActiveAt,
+      toolCalls: [{
+        name: 'Edit',
+        input: { path: '/tmp/project/src/index.ts' },
+        timestamp: '2026-01-01T00:04:00.000Z',
+      }],
+      usageStats: {
+        totalInputTokens: 10,
+        totalOutputTokens: 20,
+        totalTokens: 30,
+        totalCost: 0.001,
+        apiCalls: 1,
+      },
+      agentId: 'agent-123',
+      parentSessionId: 'parent-session-123',
+      isSubAgent: true,
+    };
+
+    const adapter = new ClaudeCodeRuntimeAdapter(async () => [parsed]);
+    const result = await adapter.scanSessions({ mode: 'full', includeSubAgents: true });
+    const session = result.sessions[0];
+
+    expect(result.errors).toEqual([]);
+    expect(session).toMatchObject({
+      runtimeId: 'claude-code',
+      sessionId: 'claude-session-123',
+      cwd: '/tmp/project',
+      agentId: 'agent-123',
+      parentSessionId: 'parent-session-123',
+      parentRuntimeSessionId: 'parent-session-123',
+      isSubAgent: true,
+      usageStats: {
+        totalInputTokens: 10,
+        totalOutputTokens: 20,
+        totalTokens: 30,
+        totalCost: 0.001,
+        apiCalls: 1,
+      },
+    });
+    expect(session.filesTouched).toEqual(['/tmp/project/src/index.ts']);
+    expect(session.toolCalls).toHaveLength(1);
+  });
+
+  test('builds structured recovery commands', () => {
+    const adapter = new ClaudeCodeRuntimeAdapter(async () => []);
+    const session = runtimeSession({
+      runtimeId: 'claude-code',
+      sessionId: 'claude-session-123',
+      cwd: '/tmp/project',
+      initialPrompt: 'Continue this work',
+    });
+
+    expect(adapter.buildRecoveryCommand?.(session, { method: 'resume' })).toEqual({
+      executable: 'claude',
+      args: ['--resume', 'claude-session-123'],
+      cwd: '/tmp/project',
+    });
+    expect(adapter.buildRecoveryCommand?.(session, {
+      method: 'continue',
+      skipPermissions: true,
+    })).toEqual({
+      executable: 'claude',
+      args: ['--dangerously-skip-permissions', '--continue'],
+      cwd: '/tmp/project',
+    });
+    expect(adapter.buildRecoveryCommand?.(session, { method: 'new' })).toEqual({
+      executable: 'claude',
+      args: ['Continue this work'],
+      cwd: '/tmp/project',
+    });
+  });
+
+  test('returns structured scan errors when the legacy scanner fails', async () => {
+    const adapter = new ClaudeCodeRuntimeAdapter(async () => {
+      throw new Error('legacy scanner failed');
+    });
+
+    const result = await adapter.scanSessions();
+
+    expect(result.sessions).toEqual([]);
+    expect(result.errors).toEqual([
+      {
+        runtimeId: 'claude-code',
+        code: 'unknown',
+        message: 'legacy scanner failed',
+        recoverable: true,
+      },
+    ]);
+  });
+
+  test('keeps healthy sessions visible when Claude per-file parsing fails', async () => {
+    const parsed: ParsedSessionData = {
+      sessionId: 'claude-session-123',
+      directory: '/tmp/project',
+      firstMessage: 'Healthy session',
+      messageCount: 1,
+      toolCount: 0,
+      lastActiveAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+    const adapter = new ClaudeCodeRuntimeAdapter(async () => ({
+      sessions: [parsed],
+      failures: [{
+        filePath: '/tmp/project/bad-session.jsonl',
+        message: 'Invalid JSONL at line 3',
+      }],
+    }));
+
+    const result = await adapter.scanSessions();
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.errors).toEqual([
+      {
+        runtimeId: 'claude-code',
+        code: 'parse-failed',
+        message: 'Invalid JSONL at line 3',
+        sourcePath: '/tmp/project/bad-session.jsonl',
+        recoverable: true,
+      },
+    ]);
+  });
+});
+
+describe('CodexRuntimeAdapter', () => {
+  test('maps parsed sessions to raw runtime session IDs', async () => {
+    const rawSessionId = '019ed4a3-2186-7e51-9aa1-ca1e376549b8';
+    const parsed: CodexParsedSessionData = {
+      client: 'codex',
+      rawSessionId,
+      sessionId: scopeCodexSessionId(rawSessionId),
+      directory: '/tmp/project',
+      firstMessage: 'Codex task',
+      lastMessage: 'Codex done',
+      messageCount: 2,
+      toolCount: 0,
+      startedAt: new Date('2026-01-01T00:00:00.000Z'),
+      lastActiveAt: new Date('2026-01-01T00:05:00.000Z'),
+    };
+
+    const adapter = new CodexRuntimeAdapter(async () => [parsed]);
+    const result = await adapter.scanSessions();
+
+    expect(result.sessions[0]).toMatchObject({
+      runtimeId: 'codex',
+      sessionId: rawSessionId,
+      cwd: '/tmp/project',
+      runtimeMetadata: {
+        legacyClient: 'codex',
+        scopedSessionId: scopeCodexSessionId(rawSessionId),
+      },
+    });
+  });
+
+  test('builds structured recovery commands with raw session IDs', () => {
+    const rawSessionId = '019ed4a3-2186-7e51-9aa1-ca1e376549b8';
+    const adapter = new CodexRuntimeAdapter(async () => []);
+    const session = runtimeSession({
+      runtimeId: 'codex',
+      sessionId: rawSessionId,
+      cwd: '/tmp/project',
+      initialPrompt: 'Start codex work',
+    });
+
+    expect(adapter.buildRecoveryCommand?.(session, { method: 'resume' })).toEqual({
+      executable: 'codex',
+      args: ['resume', rawSessionId],
+      cwd: '/tmp/project',
+    });
+    expect(adapter.buildRecoveryCommand?.(session, {
+      method: 'continue',
+      skipPermissions: true,
+    })).toEqual({
+      executable: 'codex',
+      args: ['resume', '--dangerously-bypass-approvals-and-sandbox', '--last'],
+      cwd: '/tmp/project',
+    });
+    expect(adapter.buildRecoveryCommand?.(session, { method: 'new' })).toEqual({
+      executable: 'codex',
+      args: ['Start codex work'],
+      cwd: '/tmp/project',
+    });
+  });
+
+  test('keeps healthy sessions visible when Codex per-file parsing fails', async () => {
+    const rawSessionId = '019ed4a3-2186-7e51-9aa1-ca1e376549b8';
+    const parsed: CodexParsedSessionData = {
+      client: 'codex',
+      rawSessionId,
+      sessionId: scopeCodexSessionId(rawSessionId),
+      directory: '/tmp/project',
+      firstMessage: 'Healthy Codex session',
+      messageCount: 1,
+      toolCount: 0,
+      lastActiveAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+    const adapter = new CodexRuntimeAdapter(async () => ({
+      sessions: [parsed],
+      failures: [{
+        filePath: '/tmp/codex/bad-rollout.jsonl',
+        message: 'Invalid JSONL at line 7',
+      }],
+    }));
+
+    const result = await adapter.scanSessions();
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.errors).toEqual([
+      {
+        runtimeId: 'codex',
+        code: 'parse-failed',
+        message: 'Invalid JSONL at line 7',
+        sourcePath: '/tmp/codex/bad-rollout.jsonl',
+        recoverable: true,
+      },
+    ]);
+  });
+});

--- a/src/adapters/claude/scanner.ts
+++ b/src/adapters/claude/scanner.ts
@@ -27,12 +27,14 @@ interface SessionCache {
   data: ParsedSessionData | null;
   modifiedAt: number; // File modification time in ms
   includeToolCalls: boolean;
+  failureMessage?: string;
 }
 const sessionSummaryCache = new Map<string, SessionCache>();
 const sessionDetailCache = new Map<string, SessionCache>();
 const persistedParseFailures = new Map<string, number>();
 let persistedParseFailuresLoaded = false;
 let persistedParseFailuresDirty = false;
+const PERSISTED_PARSE_FAILURE_MESSAGE = 'Previously failed to parse session file';
 
 function loadPersistedParseFailures(): void {
   if (persistedParseFailuresLoaded) {
@@ -116,6 +118,16 @@ export interface ScanOptions {
   includeSubAgents?: boolean; // Include agent- prefixed files (default: false for backward compatibility)
   includeToolCalls?: boolean; // Include full tool call details in bulk parsed results (default: false)
   maxAgeDays?: number; // Only include files modified within this many days (default: all)
+}
+
+export interface ClaudeSessionScanFailure {
+  filePath: string;
+  message: string;
+}
+
+export interface ClaudeSessionScanResult {
+  sessions: ParsedSessionData[];
+  failures: ClaudeSessionScanFailure[];
 }
 
 /** Scan projects directory for session files */
@@ -220,14 +232,16 @@ function requireValidParsedSession(
   return parsed;
 }
 
-/** Get all sessions with parsed data (optimized with caching) */
-export async function getAllSessions(options: ScanOptions = {}): Promise<ParsedSessionData[]> {
+async function scanAllSessionsWithFailures(
+  options: ScanOptions = {}
+): Promise<ClaudeSessionScanResult> {
   const sessionFiles = scanProjectsDirectory(options);
   const includeToolCalls = options.includeToolCalls ?? false;
   const sessions: ParsedSessionData[] = [];
   let cacheHits = 0;
   let cacheMisses = 0;
-  const parseFailures: string[] = [];
+  const failures: ClaudeSessionScanFailure[] = [];
+  const freshFailures: ClaudeSessionScanFailure[] = [];
 
   // Track which files we've seen to clean up stale cache entries
   const seenFilePaths = new Set<string>();
@@ -244,6 +258,11 @@ export async function getAllSessions(options: ScanOptions = {}): Promise<ParsedS
         if (!includeToolCalls || cached.includeToolCalls) {
           if (cached.data) {
             sessions.push(cached.data);
+          } else if (cached.failureMessage) {
+            failures.push({
+              filePath: file.filePath,
+              message: cached.failureMessage,
+            });
           }
           cacheHits++;
           continue;
@@ -255,6 +274,11 @@ export async function getAllSessions(options: ScanOptions = {}): Promise<ParsedS
           data: null,
           modifiedAt: fileModTime,
           includeToolCalls,
+          failureMessage: PERSISTED_PARSE_FAILURE_MESSAGE,
+        });
+        failures.push({
+          filePath: file.filePath,
+          message: PERSISTED_PARSE_FAILURE_MESSAGE,
         });
         cacheHits++;
         continue;
@@ -280,9 +304,15 @@ export async function getAllSessions(options: ScanOptions = {}): Promise<ParsedS
         data: null,
         modifiedAt: file.modifiedAt.getTime(),
         includeToolCalls,
+        failureMessage: error instanceof Error ? error.message : String(error),
       });
       recordPersistedParseFailure(file.filePath, file.modifiedAt.getTime());
-      parseFailures.push(file.filePath);
+      const failure = {
+        filePath: file.filePath,
+        message: error instanceof Error ? error.message : String(error),
+      };
+      failures.push(failure);
+      freshFailures.push(failure);
     }
   }
 
@@ -305,15 +335,29 @@ export async function getAllSessions(options: ScanOptions = {}): Promise<ParsedS
   }
   flushPersistedParseFailures();
 
-  if (parseFailures.length > 0) {
+  if (freshFailures.length > 0) {
     logger.warn('Skipped invalid session files during scan', {
-      count: parseFailures.length,
-      sample: parseFailures.slice(0, 5),
+      count: freshFailures.length,
+      sample: freshFailures.slice(0, 5).map((failure) => failure.filePath),
     });
   }
 
   logger.debug(`Session scan: ${cacheHits} cache hits, ${cacheMisses} misses`);
-  return sessions;
+  return { sessions, failures };
+}
+
+/** Get all sessions with parsed data (optimized with caching) */
+export async function getAllSessions(options: ScanOptions = {}): Promise<ParsedSessionData[]> {
+  const result = await scanAllSessionsWithFailures(options);
+  return result.sessions;
+}
+
+/** Get all sessions and per-file failures for runtime adapters. */
+export async function getAllSessionsWithFailures(
+  options: ScanOptions = {}
+): Promise<ClaudeSessionScanResult> {
+  const result = await scanAllSessionsWithFailures(options);
+  return result;
 }
 
 /** Helper to get or parse session with caching */
@@ -330,6 +374,7 @@ async function getOrParseSession(file: ClaudeSessionFile): Promise<ParsedSession
       data: null,
       modifiedAt: fileModTime,
       includeToolCalls: true,
+      failureMessage: PERSISTED_PARSE_FAILURE_MESSAGE,
     });
     return null;
   }
@@ -352,6 +397,7 @@ async function getOrParseSession(file: ClaudeSessionFile): Promise<ParsedSession
       data: null,
       modifiedAt: fileModTime,
       includeToolCalls: true,
+      failureMessage: error instanceof Error ? error.message : String(error),
     });
     recordPersistedParseFailure(file.filePath, fileModTime);
     flushPersistedParseFailures();
@@ -372,6 +418,7 @@ async function getOrParseSessionSummary(file: ClaudeSessionFile): Promise<Parsed
       data: null,
       modifiedAt: fileModTime,
       includeToolCalls: false,
+      failureMessage: PERSISTED_PARSE_FAILURE_MESSAGE,
     });
     return null;
   }
@@ -394,6 +441,7 @@ async function getOrParseSessionSummary(file: ClaudeSessionFile): Promise<Parsed
       data: null,
       modifiedAt: fileModTime,
       includeToolCalls: false,
+      failureMessage: error instanceof Error ? error.message : String(error),
     });
     recordPersistedParseFailure(file.filePath, fileModTime);
     flushPersistedParseFailures();

--- a/src/adapters/codex/scanner.ts
+++ b/src/adapters/codex/scanner.ts
@@ -15,10 +15,21 @@ export interface CodexScanOptions {
   maxAgeDays?: number;
 }
 
+export interface CodexSessionScanFailure {
+  filePath: string;
+  message: string;
+}
+
+export interface CodexSessionScanResult {
+  sessions: CodexParsedSessionData[];
+  failures: CodexSessionScanFailure[];
+}
+
 interface CodexSessionCache {
   data: CodexParsedSessionData | null;
   modifiedAt: number;
   includeToolCalls: boolean;
+  failureMessage?: string;
 }
 
 const sessionSummaryCache = new Map<string, CodexSessionCache>();
@@ -107,28 +118,50 @@ async function getOrParseCodexSession(
   return parsed;
 }
 
-export async function getAllCodexSessions(
+async function scanAllCodexSessionsWithFailures(
   options: CodexScanOptions = {}
-): Promise<CodexParsedSessionData[]> {
+): Promise<CodexSessionScanResult> {
   const sessionFiles = scanCodexSessionsDirectory(options);
   const includeToolCalls = options.includeToolCalls ?? false;
   const sessions: CodexParsedSessionData[] = [];
-  const parseFailures: string[] = [];
+  const failures: CodexSessionScanFailure[] = [];
+  const freshFailures: CodexSessionScanFailure[] = [];
   const seenFilePaths = new Set<string>();
 
   for (const file of sessionFiles) {
     seenFilePaths.add(file.filePath);
     try {
+      const cached = sessionSummaryCache.get(file.filePath);
+      const fileModTime = file.modifiedAt.getTime();
+      if (cached && cached.modifiedAt === fileModTime) {
+        if (!includeToolCalls || cached.includeToolCalls) {
+          if (cached.failureMessage) {
+            failures.push({
+              filePath: file.filePath,
+              message: cached.failureMessage,
+            });
+            continue;
+          }
+        }
+      }
+
       const parsed = await getOrParseCodexSession(file, sessionSummaryCache, includeToolCalls);
       if (parsed) {
         sessions.push(parsed);
       }
-    } catch {
-      parseFailures.push(file.filePath);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const failure = {
+        filePath: file.filePath,
+        message,
+      };
+      failures.push(failure);
+      freshFailures.push(failure);
       sessionSummaryCache.set(file.filePath, {
         data: null,
         modifiedAt: file.modifiedAt.getTime(),
         includeToolCalls,
+        failureMessage: message,
       });
     }
   }
@@ -141,14 +174,28 @@ export async function getAllCodexSessions(
     }
   }
 
-  if (parseFailures.length > 0) {
+  if (freshFailures.length > 0) {
     logger.warn('Skipped invalid Codex session files during scan', {
-      count: parseFailures.length,
-      sample: parseFailures.slice(0, 5),
+      count: freshFailures.length,
+      sample: freshFailures.slice(0, 5).map((failure) => failure.filePath),
     });
   }
 
-  return sessions;
+  return { sessions, failures };
+}
+
+export async function getAllCodexSessions(
+  options: CodexScanOptions = {}
+): Promise<CodexParsedSessionData[]> {
+  const result = await scanAllCodexSessionsWithFailures(options);
+  return result.sessions;
+}
+
+export async function getAllCodexSessionsWithFailures(
+  options: CodexScanOptions = {}
+): Promise<CodexSessionScanResult> {
+  const result = await scanAllCodexSessionsWithFailures(options);
+  return result;
 }
 
 export async function getCodexSessionById(

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -4,4 +4,6 @@
 
 export * from './process/index.js';
 export * from './claude/index.js';
+export * from './codex/index.js';
 export * from './hook/index.js';
+export * from './runtimes/index.js';

--- a/src/adapters/runtimes/claude-code.ts
+++ b/src/adapters/runtimes/claude-code.ts
@@ -1,0 +1,110 @@
+/**
+ * Claude Code runtime adapter.
+ */
+
+import type { ParsedSessionData } from '../../domain/session/index.js';
+import type {
+  AgentRuntimeAdapter,
+  RuntimeDescriptor,
+  RuntimeRecoveryOptions,
+  RuntimeScanError,
+  RuntimeScanOptions,
+  RuntimeScanResult,
+  RuntimeSession,
+} from '../../domain/runtime/index.js';
+import { buildClaudeCommandArgs } from '../../services/recovery.service.js';
+import {
+  getAllSessionsWithFailures as getAllClaudeSessionsWithFailures,
+  type ClaudeSessionScanFailure,
+  type ScanOptions,
+} from '../claude/scanner.js';
+import { parsedSessionToRuntimeSession, structuredCommand } from './session-mapper.js';
+
+interface ClaudeRuntimeScanSourceResult {
+  sessions: ParsedSessionData[];
+  failures?: ClaudeSessionScanFailure[];
+}
+
+export type ClaudeCodeSessionScanner = (
+  options?: ScanOptions
+) => Promise<ParsedSessionData[] | ClaudeRuntimeScanSourceResult>;
+
+export const CLAUDE_CODE_DESCRIPTOR: RuntimeDescriptor = {
+  id: 'claude-code',
+  displayName: 'Claude Code',
+  kind: 'cli',
+  executableNames: ['claude', 'claude-code'],
+  sessionPathHints: [
+    '~/.claude/projects/<project>/<session>.jsonl',
+    '~/.claude-work/projects/<project>/<session>.jsonl',
+  ],
+  capabilities: ['session-history', 'process-scan', 'resume', 'quota', 'plans', 'hooks'],
+  compatibilityRoutes: {
+    quota: ['/api/quota'],
+    plans: ['/api/plans'],
+    hooks: ['/api/hooks', 'keepline hooks install', 'keepline hooks status'],
+  },
+};
+
+export class ClaudeCodeRuntimeAdapter implements AgentRuntimeAdapter {
+  readonly descriptor = CLAUDE_CODE_DESCRIPTOR;
+
+  constructor(
+    private readonly scanClaudeSessions: ClaudeCodeSessionScanner = getAllClaudeSessionsWithFailures
+  ) {}
+
+  async scanSessions(options: RuntimeScanOptions = {}): Promise<RuntimeScanResult> {
+    try {
+      const scanResult = await this.scanClaudeSessions({
+        includeSubAgents: options.includeSubAgents,
+        includeToolCalls: options.mode === 'full',
+        maxAgeDays: options.maxAgeDays,
+      });
+      const sessions = Array.isArray(scanResult) ? scanResult : scanResult.sessions;
+      const failures = Array.isArray(scanResult) ? [] : scanResult.failures ?? [];
+
+      return {
+        runtime: this.descriptor,
+        sessions: sessions.map((session) =>
+          parsedSessionToRuntimeSession(this.descriptor.id, session, {
+            legacyClient: 'claude',
+          })
+        ),
+        errors: failures.map((failure) => ({
+          runtimeId: this.descriptor.id,
+          code: 'parse-failed',
+          message: failure.message,
+          sourcePath: failure.filePath,
+          recoverable: true,
+        })),
+      };
+    } catch (error) {
+      const scanError: RuntimeScanError = {
+        runtimeId: this.descriptor.id,
+        code: 'unknown',
+        message: error instanceof Error ? error.message : String(error),
+        recoverable: true,
+      };
+      return {
+        runtime: this.descriptor,
+        sessions: [],
+        errors: [scanError],
+      };
+    }
+  }
+
+  buildRecoveryCommand(
+    session: RuntimeSession,
+    options: RuntimeRecoveryOptions
+  ) {
+    return structuredCommand(
+      buildClaudeCommandArgs(
+        options.method,
+        session.sessionId,
+        options.initialPrompt ?? session.initialPrompt,
+        options.skipPermissions ?? false
+      ),
+      session.cwd
+    );
+  }
+}

--- a/src/adapters/runtimes/claude-code.ts
+++ b/src/adapters/runtimes/claude-code.ts
@@ -18,6 +18,10 @@ import {
   type ClaudeSessionScanFailure,
   type ScanOptions,
 } from '../claude/scanner.js';
+import {
+  attributeRuntimeProcesses,
+  type RuntimeProcessAttributor,
+} from './process-attribution.js';
 import { parsedSessionToRuntimeSession, structuredCommand } from './session-mapper.js';
 
 interface ClaudeRuntimeScanSourceResult {
@@ -42,7 +46,7 @@ export const CLAUDE_CODE_DESCRIPTOR: RuntimeDescriptor = {
   compatibilityRoutes: {
     quota: ['/api/quota'],
     plans: ['/api/plans'],
-    hooks: ['/api/hooks', 'keepline hooks install', 'keepline hooks status'],
+    hooks: ['keepline hooks install', 'keepline hooks status'],
   },
 };
 
@@ -50,7 +54,9 @@ export class ClaudeCodeRuntimeAdapter implements AgentRuntimeAdapter {
   readonly descriptor = CLAUDE_CODE_DESCRIPTOR;
 
   constructor(
-    private readonly scanClaudeSessions: ClaudeCodeSessionScanner = getAllClaudeSessionsWithFailures
+    private readonly scanClaudeSessions: ClaudeCodeSessionScanner = getAllClaudeSessionsWithFailures,
+    private readonly attributeProcesses: RuntimeProcessAttributor = (sessions) =>
+      attributeRuntimeProcesses('claude-code', sessions)
   ) {}
 
   async scanSessions(options: RuntimeScanOptions = {}): Promise<RuntimeScanResult> {
@@ -62,21 +68,26 @@ export class ClaudeCodeRuntimeAdapter implements AgentRuntimeAdapter {
       });
       const sessions = Array.isArray(scanResult) ? scanResult : scanResult.sessions;
       const failures = Array.isArray(scanResult) ? [] : scanResult.failures ?? [];
+      const mappedSessions = sessions.map((session) =>
+        parsedSessionToRuntimeSession(this.descriptor.id, session, {
+          legacyClient: 'claude',
+        })
+      );
+      const processAttribution = this.attributeProcesses(mappedSessions);
 
       return {
         runtime: this.descriptor,
-        sessions: sessions.map((session) =>
-          parsedSessionToRuntimeSession(this.descriptor.id, session, {
-            legacyClient: 'claude',
-          })
-        ),
-        errors: failures.map((failure) => ({
-          runtimeId: this.descriptor.id,
-          code: 'parse-failed',
-          message: failure.message,
-          sourcePath: failure.filePath,
-          recoverable: true,
-        })),
+        sessions: processAttribution.sessions,
+        errors: [
+          ...failures.map((failure) => ({
+            runtimeId: this.descriptor.id,
+            code: 'parse-failed' as const,
+            message: failure.message,
+            sourcePath: failure.filePath,
+            recoverable: true,
+          })),
+          ...processAttribution.errors,
+        ],
       };
     } catch (error) {
       const scanError: RuntimeScanError = {

--- a/src/adapters/runtimes/codex.ts
+++ b/src/adapters/runtimes/codex.ts
@@ -1,0 +1,104 @@
+/**
+ * Codex runtime adapter.
+ */
+
+import type {
+  AgentRuntimeAdapter,
+  RuntimeDescriptor,
+  RuntimeRecoveryOptions,
+  RuntimeScanError,
+  RuntimeScanOptions,
+  RuntimeScanResult,
+  RuntimeSession,
+} from '../../domain/runtime/index.js';
+import { buildCodexCommandArgs } from '../../services/recovery.service.js';
+import { scopeCodexSessionId } from '../codex/parser.js';
+import {
+  getAllCodexSessionsWithFailures,
+  type CodexScanOptions,
+  type CodexSessionScanFailure,
+} from '../codex/scanner.js';
+import type { CodexParsedSessionData } from '../codex/types.js';
+import { parsedSessionToRuntimeSession, structuredCommand } from './session-mapper.js';
+
+interface CodexRuntimeScanSourceResult {
+  sessions: CodexParsedSessionData[];
+  failures?: CodexSessionScanFailure[];
+}
+
+export type CodexSessionScanner = (
+  options?: CodexScanOptions
+) => Promise<CodexParsedSessionData[] | CodexRuntimeScanSourceResult>;
+
+export const CODEX_DESCRIPTOR: RuntimeDescriptor = {
+  id: 'codex',
+  displayName: 'Codex',
+  kind: 'cli',
+  executableNames: ['codex'],
+  sessionPathHints: ['~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl'],
+  capabilities: ['session-history', 'process-scan', 'resume', 'quota'],
+  compatibilityRoutes: {
+    quota: ['/api/codex/quota'],
+  },
+};
+
+export class CodexRuntimeAdapter implements AgentRuntimeAdapter {
+  readonly descriptor = CODEX_DESCRIPTOR;
+
+  constructor(private readonly scanCodexSessions: CodexSessionScanner = getAllCodexSessionsWithFailures) {}
+
+  async scanSessions(options: RuntimeScanOptions = {}): Promise<RuntimeScanResult> {
+    try {
+      const scanResult = await this.scanCodexSessions({
+        includeToolCalls: options.mode === 'full',
+        maxAgeDays: options.maxAgeDays,
+      });
+      const sessions = Array.isArray(scanResult) ? scanResult : scanResult.sessions;
+      const failures = Array.isArray(scanResult) ? [] : scanResult.failures ?? [];
+
+      return {
+        runtime: this.descriptor,
+        sessions: sessions.map((session) =>
+          parsedSessionToRuntimeSession(this.descriptor.id, session, {
+            legacyClient: 'codex',
+            scopedSessionId: session.sessionId,
+          })
+        ),
+        errors: failures.map((failure) => ({
+          runtimeId: this.descriptor.id,
+          code: 'parse-failed',
+          message: failure.message,
+          sourcePath: failure.filePath,
+          recoverable: true,
+        })),
+      };
+    } catch (error) {
+      const scanError: RuntimeScanError = {
+        runtimeId: this.descriptor.id,
+        code: 'unknown',
+        message: error instanceof Error ? error.message : String(error),
+        recoverable: true,
+      };
+      return {
+        runtime: this.descriptor,
+        sessions: [],
+        errors: [scanError],
+      };
+    }
+  }
+
+  buildRecoveryCommand(
+    session: RuntimeSession,
+    options: RuntimeRecoveryOptions
+  ) {
+    return structuredCommand(
+      buildCodexCommandArgs(
+        options.method,
+        scopeCodexSessionId(session.sessionId),
+        options.initialPrompt ?? session.initialPrompt,
+        options.skipPermissions ?? false
+      ),
+      session.cwd
+    );
+  }
+}

--- a/src/adapters/runtimes/codex.ts
+++ b/src/adapters/runtimes/codex.ts
@@ -19,6 +19,10 @@ import {
   type CodexSessionScanFailure,
 } from '../codex/scanner.js';
 import type { CodexParsedSessionData } from '../codex/types.js';
+import {
+  attributeRuntimeProcesses,
+  type RuntimeProcessAttributor,
+} from './process-attribution.js';
 import { parsedSessionToRuntimeSession, structuredCommand } from './session-mapper.js';
 
 interface CodexRuntimeScanSourceResult {
@@ -45,7 +49,11 @@ export const CODEX_DESCRIPTOR: RuntimeDescriptor = {
 export class CodexRuntimeAdapter implements AgentRuntimeAdapter {
   readonly descriptor = CODEX_DESCRIPTOR;
 
-  constructor(private readonly scanCodexSessions: CodexSessionScanner = getAllCodexSessionsWithFailures) {}
+  constructor(
+    private readonly scanCodexSessions: CodexSessionScanner = getAllCodexSessionsWithFailures,
+    private readonly attributeProcesses: RuntimeProcessAttributor = (sessions) =>
+      attributeRuntimeProcesses('codex', sessions)
+  ) {}
 
   async scanSessions(options: RuntimeScanOptions = {}): Promise<RuntimeScanResult> {
     try {
@@ -55,22 +63,27 @@ export class CodexRuntimeAdapter implements AgentRuntimeAdapter {
       });
       const sessions = Array.isArray(scanResult) ? scanResult : scanResult.sessions;
       const failures = Array.isArray(scanResult) ? [] : scanResult.failures ?? [];
+      const mappedSessions = sessions.map((session) =>
+        parsedSessionToRuntimeSession(this.descriptor.id, session, {
+          legacyClient: 'codex',
+          scopedSessionId: session.sessionId,
+        })
+      );
+      const processAttribution = this.attributeProcesses(mappedSessions);
 
       return {
         runtime: this.descriptor,
-        sessions: sessions.map((session) =>
-          parsedSessionToRuntimeSession(this.descriptor.id, session, {
-            legacyClient: 'codex',
-            scopedSessionId: session.sessionId,
-          })
-        ),
-        errors: failures.map((failure) => ({
-          runtimeId: this.descriptor.id,
-          code: 'parse-failed',
-          message: failure.message,
-          sourcePath: failure.filePath,
-          recoverable: true,
-        })),
+        sessions: processAttribution.sessions,
+        errors: [
+          ...failures.map((failure) => ({
+            runtimeId: this.descriptor.id,
+            code: 'parse-failed' as const,
+            message: failure.message,
+            sourcePath: failure.filePath,
+            recoverable: true,
+          })),
+          ...processAttribution.errors,
+        ],
       };
     } catch (error) {
       const scanError: RuntimeScanError = {

--- a/src/adapters/runtimes/index.ts
+++ b/src/adapters/runtimes/index.ts
@@ -4,5 +4,7 @@
 
 export * from './claude-code.js';
 export * from './codex.js';
+export * from './process-attribution.js';
+export * from './project-root.js';
 export * from './registry.js';
 export * from './session-mapper.js';

--- a/src/adapters/runtimes/index.ts
+++ b/src/adapters/runtimes/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Runtime adapter exports.
+ */
+
+export * from './claude-code.js';
+export * from './codex.js';
+export * from './registry.js';
+export * from './session-mapper.js';

--- a/src/adapters/runtimes/process-attribution.ts
+++ b/src/adapters/runtimes/process-attribution.ts
@@ -1,0 +1,106 @@
+/**
+ * Runtime process attribution built on the legacy process matcher.
+ */
+
+import type { AgentClient } from '../../domain/session/index.js';
+import type {
+  RuntimeId,
+  RuntimeScanError,
+  RuntimeSession,
+} from '../../domain/runtime/index.js';
+import { detectSessionStatus } from '../process/detector.js';
+import { getCachedProcesses } from '../process/scanner.js';
+import type { ClaudeProcessInfo } from '../process/types.js';
+import { matchProcessesToSessions } from '../../services/session.process-matcher.js';
+
+export interface RuntimeProcessAttributionResult {
+  sessions: RuntimeSession[];
+  errors: RuntimeScanError[];
+}
+
+export type RuntimeProcessAttributor = (
+  sessions: RuntimeSession[]
+) => RuntimeProcessAttributionResult;
+
+function clientForRuntime(runtimeId: RuntimeId): AgentClient | undefined {
+  switch (runtimeId) {
+    case 'claude-code':
+      return 'claude';
+    case 'codex':
+      return 'codex';
+    default:
+      return undefined;
+  }
+}
+
+function scanError(runtimeId: RuntimeId, error: unknown): RuntimeScanError {
+  return {
+    runtimeId,
+    code: 'unknown',
+    message: error instanceof Error ? error.message : String(error),
+    recoverable: true,
+  };
+}
+
+export function attributeRuntimeProcesses(
+  runtimeId: RuntimeId,
+  sessions: RuntimeSession[],
+  processSource: () => ClaudeProcessInfo[] = getCachedProcesses
+): RuntimeProcessAttributionResult {
+  if (sessions.length === 0) {
+    return { sessions, errors: [] };
+  }
+
+  const client = clientForRuntime(runtimeId);
+  if (!client) {
+    return { sessions, errors: [] };
+  }
+
+  let processes: ClaudeProcessInfo[];
+  try {
+    processes = processSource();
+  } catch (error) {
+    return {
+      sessions,
+      errors: [scanError(runtimeId, error)],
+    };
+  }
+
+  const matches = matchProcessesToSessions(
+    sessions.map((session) => ({
+      sessionId: session.sessionId,
+      client,
+      directory: session.cwd,
+      startedAt: session.startedAt,
+      lastActiveAt: session.lastActiveAt,
+      pid: session.pid,
+    })),
+    processes
+  );
+
+  return {
+    sessions: sessions.map((session) => {
+      const process = matches.get(session.sessionId);
+      if (!process) {
+        return {
+          ...session,
+          status: session.status === 'completed' ? session.status : 'lost',
+          processRunning: false,
+        };
+      }
+
+      return {
+        ...session,
+        pid: process.pid,
+        tty: process.tty,
+        processRunning: true,
+        cpuUsage: process.cpu,
+        memoryUsage: process.memory,
+        status: session.status === 'completed'
+          ? session.status
+          : detectSessionStatus(process, session.lastActiveAt),
+      };
+    }),
+    errors: [],
+  };
+}

--- a/src/adapters/runtimes/project-root.ts
+++ b/src/adapters/runtimes/project-root.ts
@@ -1,0 +1,75 @@
+/**
+ * Project root normalization for runtime-neutral scans.
+ */
+
+import { existsSync, realpathSync, statSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { homedir } from 'os';
+import type { RuntimeSession } from '../../domain/runtime/index.js';
+
+function expandHome(inputPath: string): string {
+  if (inputPath === '~') return homedir();
+  if (inputPath.startsWith('~/')) return join(homedir(), inputPath.slice(2));
+  return inputPath;
+}
+
+function safeRealpath(inputPath: string): string {
+  const resolved = resolve(expandHome(inputPath));
+  try {
+    return realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function safeIsDirectory(inputPath: string): boolean | undefined {
+  try {
+    return statSync(inputPath).isDirectory();
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveProjectRoot(inputPath: string): string {
+  const resolved = safeRealpath(inputPath);
+  const isDirectory = safeIsDirectory(resolved);
+  if (isDirectory === undefined) {
+    return resolved;
+  }
+
+  let current = isDirectory ? resolved : dirname(resolved);
+  while (true) {
+    if (existsSync(join(current, '.git'))) {
+      return current;
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      return resolved;
+    }
+    current = parent;
+  }
+}
+
+export function withResolvedProjectRoots(sessions: RuntimeSession[]): RuntimeSession[] {
+  const rootByPath = new Map<string, string>();
+
+  return sessions.map((session) => {
+    const sourcePath = session.projectRoot ?? session.cwd;
+    let projectRoot = rootByPath.get(sourcePath);
+    if (!projectRoot) {
+      projectRoot = resolveProjectRoot(sourcePath);
+      rootByPath.set(sourcePath, projectRoot);
+    }
+
+    return { ...session, projectRoot };
+  });
+}
+
+export function filterSessionsByProjectRoot(
+  sessions: RuntimeSession[],
+  projectRoot: string
+): RuntimeSession[] {
+  const normalizedProjectRoot = resolveProjectRoot(projectRoot);
+  return sessions.filter((session) => session.projectRoot === normalizedProjectRoot);
+}

--- a/src/adapters/runtimes/registry.ts
+++ b/src/adapters/runtimes/registry.ts
@@ -12,6 +12,7 @@ import type {
 } from '../../domain/runtime/index.js';
 import { ClaudeCodeRuntimeAdapter } from './claude-code.js';
 import { CodexRuntimeAdapter } from './codex.js';
+import { filterSessionsByProjectRoot, withResolvedProjectRoots } from './project-root.js';
 
 const FEATURE_CAPABILITIES: readonly RuntimeFeatureCapability[] = ['quota', 'plans', 'hooks'];
 
@@ -76,7 +77,14 @@ export class RuntimeRegistry {
     return Promise.all(
       this.list().map(async (adapter) => {
         try {
-          return await adapter.scanSessions(options);
+          const result = await adapter.scanSessions(options);
+          const sessions = withResolvedProjectRoots(result.sessions);
+          return {
+            ...result,
+            sessions: options.projectRoot
+              ? filterSessionsByProjectRoot(sessions, options.projectRoot)
+              : sessions,
+          };
         } catch (error) {
           const scanError: RuntimeScanError = {
             runtimeId: adapter.descriptor.id,

--- a/src/adapters/runtimes/registry.ts
+++ b/src/adapters/runtimes/registry.ts
@@ -1,0 +1,103 @@
+/**
+ * Runtime adapter registry.
+ */
+
+import type {
+  AgentRuntimeAdapter,
+  RuntimeFeatureCapability,
+  RuntimeId,
+  RuntimeScanError,
+  RuntimeScanOptions,
+  RuntimeScanResult,
+} from '../../domain/runtime/index.js';
+import { ClaudeCodeRuntimeAdapter } from './claude-code.js';
+import { CodexRuntimeAdapter } from './codex.js';
+
+const FEATURE_CAPABILITIES: readonly RuntimeFeatureCapability[] = ['quota', 'plans', 'hooks'];
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function hasFeatureContract(
+  adapter: AgentRuntimeAdapter,
+  capability: RuntimeFeatureCapability
+): boolean {
+  const provider = adapter.descriptor.featureProviders?.[capability];
+  const routes = adapter.descriptor.compatibilityRoutes?.[capability];
+  return provider !== undefined || (routes !== undefined && routes.length > 0);
+}
+
+function validateAdapter(adapter: AgentRuntimeAdapter): void {
+  if (adapter.descriptor.capabilities.includes('resume') && !adapter.buildRecoveryCommand) {
+    throw new Error(
+      `Runtime adapter ${adapter.descriptor.id} declares resume without buildRecoveryCommand`
+    );
+  }
+
+  for (const capability of FEATURE_CAPABILITIES) {
+    if (
+      adapter.descriptor.capabilities.includes(capability) &&
+      !hasFeatureContract(adapter, capability)
+    ) {
+      throw new Error(
+        `Runtime adapter ${adapter.descriptor.id} declares ${capability} without a provider or compatibility route`
+      );
+    }
+  }
+}
+
+export class RuntimeRegistry {
+  private readonly adapters = new Map<RuntimeId, AgentRuntimeAdapter>();
+
+  constructor(adapters: AgentRuntimeAdapter[] = []) {
+    for (const adapter of adapters) {
+      this.register(adapter);
+    }
+  }
+
+  register(adapter: AgentRuntimeAdapter): void {
+    validateAdapter(adapter);
+    if (this.adapters.has(adapter.descriptor.id)) {
+      throw new Error(`Runtime adapter already registered: ${adapter.descriptor.id}`);
+    }
+    this.adapters.set(adapter.descriptor.id, adapter);
+  }
+
+  list(): AgentRuntimeAdapter[] {
+    return [...this.adapters.values()];
+  }
+
+  get(runtimeId: RuntimeId): AgentRuntimeAdapter | undefined {
+    return this.adapters.get(runtimeId);
+  }
+
+  async scanAll(options: RuntimeScanOptions = {}): Promise<RuntimeScanResult[]> {
+    return Promise.all(
+      this.list().map(async (adapter) => {
+        try {
+          return await adapter.scanSessions(options);
+        } catch (error) {
+          const scanError: RuntimeScanError = {
+            runtimeId: adapter.descriptor.id,
+            code: 'unknown',
+            message: errorMessage(error),
+            recoverable: true,
+          };
+          return {
+            runtime: adapter.descriptor,
+            sessions: [],
+            errors: [scanError],
+          };
+        }
+      })
+    );
+  }
+}
+
+export function createDefaultRuntimeRegistry(): RuntimeRegistry {
+  return new RuntimeRegistry([
+    new ClaudeCodeRuntimeAdapter(),
+    new CodexRuntimeAdapter(),
+  ]);
+}

--- a/src/adapters/runtimes/session-mapper.ts
+++ b/src/adapters/runtimes/session-mapper.ts
@@ -1,0 +1,109 @@
+/**
+ * Helpers shared by runtime adapter wrappers.
+ */
+
+import type { ParsedSessionData, ToolCallInfo } from '../../domain/session/index.js';
+import type {
+  JsonValue,
+  RuntimeCommand,
+  RuntimeId,
+  RuntimeSession,
+  RuntimeUsageStats,
+} from '../../domain/runtime/index.js';
+import type { CodexParsedSessionData } from '../codex/types.js';
+
+type ParsedRuntimeSource = ParsedSessionData | CodexParsedSessionData;
+
+export function structuredCommand(argv: string[], cwd?: string): RuntimeCommand {
+  const [executable, ...args] = argv;
+  if (!executable) {
+    throw new Error('Runtime command executable is required');
+  }
+  return { executable, args, cwd };
+}
+
+export function titleFromPrompt(prompt: string | undefined, fallback: string): string {
+  if (!prompt) return fallback;
+  if (prompt.length <= 80) return prompt;
+
+  const truncated = prompt.slice(0, 80);
+  const lastSpace = truncated.lastIndexOf(' ');
+  return lastSpace > 40 ? `${truncated.slice(0, lastSpace)}...` : `${truncated}...`;
+}
+
+function stringFromInput(input: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+export function filesTouchedFromSession(
+  session: Pick<ParsedSessionData, 'currentFile' | 'toolCalls'>
+): string[] {
+  const files = new Set<string>();
+  if (session.currentFile) {
+    files.add(session.currentFile);
+  }
+
+  for (const call of session.toolCalls ?? []) {
+    const filePath = stringFromInput(call.input, [
+      'path',
+      'file_path',
+      'filePath',
+      'notebook_path',
+    ]);
+    if (filePath) {
+      files.add(filePath);
+    }
+  }
+
+  return [...files];
+}
+
+function toRuntimeUsageStats(
+  usageStats: ParsedRuntimeSource['usageStats']
+): RuntimeUsageStats | undefined {
+  if (!usageStats) return undefined;
+  return {
+    totalInputTokens: usageStats.totalInputTokens,
+    totalOutputTokens: usageStats.totalOutputTokens,
+    totalTokens: usageStats.totalTokens,
+    totalCost: usageStats.totalCost,
+    apiCalls: usageStats.apiCalls,
+  };
+}
+
+export function parsedSessionToRuntimeSession(
+  runtimeId: RuntimeId,
+  session: ParsedRuntimeSource,
+  metadata: Record<string, JsonValue> = {}
+): RuntimeSession {
+  return {
+    runtimeId,
+    sessionId: 'rawSessionId' in session ? session.rawSessionId : session.sessionId,
+    cwd: session.directory,
+    agentId: session.agentId,
+    parentSessionId: session.parentSessionId,
+    parentRuntimeSessionId: session.parentSessionId,
+    isSubAgent: session.isSubAgent,
+    status: 'unknown',
+    title: titleFromPrompt(session.firstMessage, session.sessionId),
+    initialPrompt: session.firstMessage,
+    lastMessage: session.lastMessage,
+    lastTool: session.lastTool,
+    lastToolInput: session.lastToolInput,
+    currentFile: session.currentFile,
+    filesTouched: filesTouchedFromSession(session),
+    toolCalls: session.toolCalls as ToolCallInfo[] | undefined,
+    toolCount: session.toolCount,
+    messageCount: session.messageCount,
+    startedAt: session.startedAt,
+    lastActiveAt: session.lastActiveAt,
+    usageStats: toRuntimeUsageStats(session.usageStats),
+    runtimeMetadata: metadata,
+  };
+}

--- a/src/adapters/runtimes/session-mapper.ts
+++ b/src/adapters/runtimes/session-mapper.ts
@@ -87,7 +87,6 @@ export function parsedSessionToRuntimeSession(
     sessionId: 'rawSessionId' in session ? session.rawSessionId : session.sessionId,
     cwd: session.directory,
     agentId: session.agentId,
-    parentSessionId: session.parentSessionId,
     parentRuntimeSessionId: session.parentSessionId,
     isSubAgent: session.isSubAgent,
     status: 'unknown',

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -16,3 +16,6 @@ export * from './recovery/index.js';
 
 // Memory domain
 export * from './memory/index.js';
+
+// Runtime domain
+export * from './runtime/index.js';

--- a/src/domain/runtime/index.ts
+++ b/src/domain/runtime/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Runtime domain exports.
+ */
+
+export * from './types.js';

--- a/src/domain/runtime/types.ts
+++ b/src/domain/runtime/types.ts
@@ -1,0 +1,165 @@
+/**
+ * Runtime-neutral agent session contracts.
+ */
+
+import type { SessionStatus, ToolCallInfo } from '../session/index.js';
+
+export type RuntimeId = 'claude-code' | 'codex' | 'cursor' | (string & {});
+
+export type RuntimeKind = 'cli' | 'ide' | 'cloud' | 'unknown';
+
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export type RuntimeCapability =
+  | 'session-history'
+  | 'process-scan'
+  | 'resume'
+  | 'quota'
+  | 'plans'
+  | 'hooks';
+
+export type RuntimeFeatureCapability = Extract<
+  RuntimeCapability,
+  'quota' | 'plans' | 'hooks'
+>;
+
+export interface RuntimeQuotaProvider {
+  getQuota(): Promise<JsonValue>;
+}
+
+export interface RuntimePlansProvider {
+  scanPlans(options?: Record<string, JsonValue>): Promise<JsonValue[]>;
+}
+
+export interface RuntimeHooksProvider {
+  installHooks?(): Promise<JsonValue>;
+  getHookStatus?(): Promise<JsonValue>;
+}
+
+export interface RuntimeFeatureProviders {
+  quota: RuntimeQuotaProvider;
+  plans: RuntimePlansProvider;
+  hooks: RuntimeHooksProvider;
+}
+
+export type RuntimeCompatibilityRoutes = Partial<
+  Record<RuntimeFeatureCapability, readonly string[]>
+>;
+
+export interface RuntimeDescriptor {
+  id: RuntimeId;
+  displayName: string;
+  kind: RuntimeKind;
+  executableNames: string[];
+  sessionPathHints: string[];
+  capabilities: RuntimeCapability[];
+  featureProviders?: Partial<RuntimeFeatureProviders>;
+  compatibilityRoutes?: RuntimeCompatibilityRoutes;
+}
+
+export interface RuntimeUsageStats {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalTokens: number;
+  totalCost: number;
+  apiCalls: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  model?: string;
+  modelBreakdown?: JsonValue[];
+}
+
+export interface RuntimeSession {
+  runtimeId: RuntimeId;
+  sessionId: string;
+  sourcePath?: string;
+  cwd: string;
+  projectRoot?: string;
+
+  agentId?: string;
+  parentSessionId?: string;
+  parentRuntimeSessionId?: string;
+  isSubAgent?: boolean;
+
+  pid?: number;
+  tty?: string;
+  processRunning?: boolean;
+  cpuUsage?: number;
+  memoryUsage?: number;
+
+  status: SessionStatus | 'unknown';
+  title: string;
+  initialPrompt?: string;
+  lastMessage?: string;
+  lastTool?: string;
+  lastToolInput?: Record<string, unknown>;
+  currentFile?: string;
+  filesTouched: string[];
+  toolCalls?: ToolCallInfo[];
+  toolCount: number;
+  messageCount: number;
+
+  startedAt?: Date;
+  lastActiveAt: Date;
+  completedAt?: Date;
+
+  usageStats?: RuntimeUsageStats;
+  runtimeMetadata?: Record<string, JsonValue>;
+}
+
+export interface RuntimeCommand {
+  executable: string;
+  args: string[];
+  cwd?: string;
+}
+
+export type RuntimeRecoveryMethod = 'resume' | 'continue' | 'new';
+
+export interface RuntimeRecoveryOptions {
+  method: RuntimeRecoveryMethod;
+  initialPrompt?: string;
+  skipPermissions?: boolean;
+}
+
+export interface RuntimeScanOptions {
+  maxAgeDays?: number;
+  mode?: 'basic' | 'full';
+  includeSubAgents?: boolean;
+  projectRoot?: string;
+}
+
+export type RuntimeScanErrorCode =
+  | 'missing-root'
+  | 'read-failed'
+  | 'parse-failed'
+  | 'unsupported-schema'
+  | 'unknown';
+
+export interface RuntimeScanError {
+  runtimeId: RuntimeId;
+  code: RuntimeScanErrorCode;
+  message: string;
+  sourcePath?: string;
+  recoverable: boolean;
+}
+
+export interface RuntimeScanResult {
+  runtime: RuntimeDescriptor;
+  sessions: RuntimeSession[];
+  errors: RuntimeScanError[];
+}
+
+export interface AgentRuntimeAdapter {
+  descriptor: RuntimeDescriptor;
+  scanSessions(options?: RuntimeScanOptions): Promise<RuntimeScanResult>;
+  buildRecoveryCommand?: (
+    session: RuntimeSession,
+    options: RuntimeRecoveryOptions
+  ) => RuntimeCommand | undefined;
+}


### PR DESCRIPTION
## 摘要

- 新增 runtime-neutral domain contract：RuntimeDescriptor、RuntimeSession、RuntimeCommand、RuntimeScanResult、AgentRuntimeAdapter。
- 新增 Claude Code 与 Codex runtime adapter wrapper，并提供 default RuntimeRegistry。
- registry 现在会拒绝重复 runtimeId、拒绝缺少 recovery/provider contract 的 capability 声明，并隔离单 adapter scan 失败。
- recovery command 输出为结构化 executable/args/cwd，不返回 shell command string。

## SpecRail

- Parent: #44
- Spec: specs/GH44/tech.md
- Closes #47

## 验证

- bun test ./src/__tests__/runtime.registry.test.ts
- bun run typecheck
- bun test
- bun run build
