### PR TITLE
Link WorkItems to agent evidence

### DIFF
--- a/src/__tests__/work-item-evidence.route.test.ts
+++ b/src/__tests__/work-item-evidence.route.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import workItemEvidence from '../web/api/routes/work-item-evidence.js';
+import workItems from '../web/api/routes/work-items.js';
+import { setupUser } from '../services/auth.service.js';
+import { resetDatabase } from '../db/migrations.js';
+import { closeDatabase } from '../infrastructure/database/sqlite.js';
+import { encodeAgentSessionId } from '../domain/work-item/index.js';
+import { isValidSessionId } from '../lib/session-id.js';
+
+async function authedWorkItemsRequest(
+  token: string,
+  path: string,
+  options: RequestInit = {}
+): Promise<Response> {
+  const headers = new Headers(options.headers);
+  headers.set('Authorization', `Bearer ${token}`);
+  if (options.body && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+  return workItems.fetch(new Request(`http://localhost${path}`, {
+    ...options,
+    headers,
+  }));
+}
+
+async function authedEvidenceRequest(
+  token: string,
+  path: string,
+  options: RequestInit = {}
+): Promise<Response> {
+  const headers = new Headers(options.headers);
+  headers.set('Authorization', `Bearer ${token}`);
+  if (options.body && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+  return workItemEvidence.fetch(new Request(`http://localhost${path}`, {
+    ...options,
+    headers,
+  }));
+}
+
+async function captureTestWorkItem(token: string, title: string): Promise<string> {
+  const response = await authedWorkItemsRequest(token, '/', {
+    method: 'POST',
+    body: JSON.stringify({ title, kind: 'todo' }),
+  });
+  expect(response.status).toBe(201);
+  const body = await response.json() as {
+    data: { item: { id: string } };
+  };
+  return body.data.item.id;
+}
+
+async function upsertAgentSession(
+  token: string,
+  runtimeId: string,
+  runtimeSessionId: string
+): Promise<string> {
+  const response = await authedEvidenceRequest(token, '/agent-sessions', {
+    method: 'POST',
+    body: JSON.stringify({
+      runtimeId,
+      runtimeSessionId,
+      cwd: '/tmp/project',
+      status: 'running',
+      title: `${runtimeId} session`,
+    }),
+  });
+  expect(response.status).toBe(201);
+  const body = await response.json() as {
+    data: { agentSession: { id: string } };
+  };
+  return body.data.agentSession.id;
+}
+
+describe('Work item evidence routes', () => {
+  beforeEach(() => {
+    resetDatabase();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test('encodes agent session IDs globally and validator-compatibly', async () => {
+    const codexId = encodeAgentSessionId('codex', 'same-runtime-session');
+    const claudeId = encodeAgentSessionId('claude-code', 'same-runtime-session');
+
+    expect(codexId).not.toBe(claudeId);
+    expect(isValidSessionId(codexId)).toBe(true);
+    expect(isValidSessionId(claudeId)).toBe(true);
+
+    const { token } = await setupUser('evidence-agent-id-user', 'password123');
+    const savedCodexId = await upsertAgentSession(token, 'codex', 'same-runtime-session');
+    const savedClaudeId = await upsertAgentSession(token, 'claude-code', 'same-runtime-session');
+
+    expect(savedCodexId).toBe(codexId);
+    expect(savedClaudeId).toBe(claudeId);
+  });
+
+  test('separates accepted user links from pending heuristic links', async () => {
+    const { token } = await setupUser('evidence-link-user', 'password123');
+    const workItemId = await captureTestWorkItem(token, 'Trace a runtime session');
+    const userSessionId = await upsertAgentSession(token, 'codex', 'user-link-session');
+    const heuristicSessionId = await upsertAgentSession(token, 'claude-code', 'heuristic-link-session');
+
+    const userLinkResponse = await authedEvidenceRequest(token, `/${workItemId}/session-links`, {
+      method: 'POST',
+      body: JSON.stringify({ agentSessionId: userSessionId, linkSource: 'user' }),
+    });
+    expect(userLinkResponse.status).toBe(201);
+    const userLinkBody = await userLinkResponse.json() as {
+      data: { link: { linkSource: string; acceptanceStatus: string; acceptedAt?: string } };
+    };
+    expect(userLinkBody.data.link).toMatchObject({
+      linkSource: 'user',
+      acceptanceStatus: 'accepted',
+    });
+    expect(userLinkBody.data.link.acceptedAt).toBeDefined();
+
+    const heuristicLinkResponse = await authedEvidenceRequest(token, `/${workItemId}/session-links`, {
+      method: 'POST',
+      body: JSON.stringify({
+        agentSessionId: heuristicSessionId,
+        linkSource: 'heuristic_suggestion',
+      }),
+    });
+    expect(heuristicLinkResponse.status).toBe(201);
+    const heuristicLinkBody = await heuristicLinkResponse.json() as {
+      data: { link: { id: string; linkSource: string; acceptanceStatus: string; acceptedAt?: string } };
+    };
+    expect(heuristicLinkBody.data.link).toMatchObject({
+      linkSource: 'heuristic_suggestion',
+      acceptanceStatus: 'pending',
+    });
+    expect(heuristicLinkBody.data.link.acceptedAt).toBeUndefined();
+
+    const duplicateHeuristicResponse = await authedEvidenceRequest(token, `/${workItemId}/session-links`, {
+      method: 'POST',
+      body: JSON.stringify({
+        agentSessionId: heuristicSessionId,
+        linkSource: 'heuristic_suggestion',
+      }),
+    });
+    expect(duplicateHeuristicResponse.status).toBe(201);
+    const duplicateHeuristicBody = await duplicateHeuristicResponse.json() as {
+      data: { link: { id: string; acceptanceStatus: string; acceptedAt?: string } };
+    };
+    expect(duplicateHeuristicBody.data.link).toMatchObject({
+      id: heuristicLinkBody.data.link.id,
+      acceptanceStatus: 'pending',
+    });
+    expect(duplicateHeuristicBody.data.link.acceptedAt).toBeUndefined();
+
+    const rejectedDirectAccept = await authedEvidenceRequest(token, `/${workItemId}/session-links`, {
+      method: 'POST',
+      body: JSON.stringify({
+        agentSessionId: heuristicSessionId,
+        linkSource: 'accepted_agent_suggestion',
+      }),
+    });
+    expect(rejectedDirectAccept.status).toBe(400);
+
+    const promotedUserLinkResponse = await authedEvidenceRequest(token, `/${workItemId}/session-links`, {
+      method: 'POST',
+      body: JSON.stringify({
+        agentSessionId: heuristicSessionId,
+        linkSource: 'user',
+      }),
+    });
+    expect(promotedUserLinkResponse.status).toBe(201);
+    const promotedUserLinkBody = await promotedUserLinkResponse.json() as {
+      data: { link: { id: string; linkSource: string; acceptanceStatus: string; acceptedAt?: string } };
+    };
+    expect(promotedUserLinkBody.data.link).toMatchObject({
+      id: heuristicLinkBody.data.link.id,
+      linkSource: 'user',
+      acceptanceStatus: 'accepted',
+    });
+    expect(promotedUserLinkBody.data.link.acceptedAt).toBeDefined();
+
+    const pendingSessionId = await upsertAgentSession(token, 'codex', 'pending-link-session');
+    const pendingLinkResponse = await authedEvidenceRequest(token, `/${workItemId}/session-links`, {
+      method: 'POST',
+      body: JSON.stringify({
+        agentSessionId: pendingSessionId,
+        linkSource: 'heuristic_suggestion',
+      }),
+    });
+    expect(pendingLinkResponse.status).toBe(201);
+    const pendingLinkBody = await pendingLinkResponse.json() as {
+      data: { link: { id: string } };
+    };
+
+    const acceptedResponse = await authedEvidenceRequest(
+      token,
+      `/session-links/${pendingLinkBody.data.link.id}/accept`,
+      { method: 'POST' }
+    );
+    expect(acceptedResponse.status).toBe(200);
+    const acceptedBody = await acceptedResponse.json() as {
+      data: { link: { linkSource: string; acceptanceStatus: string; acceptedAt?: string } };
+    };
+    expect(acceptedBody.data.link).toMatchObject({
+      linkSource: 'accepted_agent_suggestion',
+      acceptanceStatus: 'accepted',
+    });
+    expect(acceptedBody.data.link.acceptedAt).toBeDefined();
+  });
+
+  test('rejects orphan evidence and keeps inferred completion out of WorkItem state', async () => {
+    const { token } = await setupUser('evidence-orphan-user', 'password123');
+    const orphanResponse = await authedEvidenceRequest(token, '/evidence', {
+      method: 'POST',
+      body: JSON.stringify({
+        kind: 'message',
+        summary: 'No anchors',
+      }),
+    });
+    expect(orphanResponse.status).toBe(400);
+
+    const workItemId = await captureTestWorkItem(token, 'Do not silently complete');
+    const evidenceResponse = await authedEvidenceRequest(token, '/evidence', {
+      method: 'POST',
+      body: JSON.stringify({
+        workItemId,
+        kind: 'message',
+        outcome: 'completed',
+        confidence: 'inferred',
+        summary: 'Agent sounds done, but user did not accept it',
+      }),
+    });
+    expect(evidenceResponse.status).toBe(201);
+
+    const itemResponse = await authedWorkItemsRequest(token, `/${workItemId}`);
+    const itemBody = await itemResponse.json() as {
+      data: { item: { status: string; statusSource: string; completedAt?: string } };
+    };
+    expect(itemBody.data.item).toMatchObject({
+      status: 'inbox',
+      statusSource: 'user',
+    });
+    expect(itemBody.data.item.completedAt).toBeUndefined();
+  });
+
+  test('records all progress evidence kinds against an agent session', async () => {
+    const { token } = await setupUser('evidence-kinds-user', 'password123');
+    const agentSessionId = await upsertAgentSession(token, 'codex', 'all-evidence-kinds');
+
+    for (const kind of ['message', 'tool_call', 'file_change', 'plan_event', 'test_result']) {
+      const response = await authedEvidenceRequest(token, '/evidence', {
+        method: 'POST',
+        body: JSON.stringify({
+          agentSessionId,
+          kind,
+          outcome: kind === 'test_result' ? 'completed' : 'progress',
+          summary: `Recorded ${kind}`,
+          metadata: { kind },
+        }),
+      });
+      expect(response.status).toBe(201);
+      const body = await response.json() as {
+        data: { evidence: { kind: string; agentSessionId: string; metadata: { kind: string } } };
+      };
+      expect(body.data.evidence).toMatchObject({
+        kind,
+        agentSessionId,
+        metadata: { kind },
+      });
+    }
+  });
+});

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -12,6 +12,9 @@ export function runMigrations(): void {
 export function resetDatabase(): void {
   const db = getDatabase();
   db.exec(`
+    DROP TABLE IF EXISTS progress_evidence;
+    DROP TABLE IF EXISTS work_item_session_links;
+    DROP TABLE IF EXISTS agent_sessions;
     DROP TABLE IF EXISTS work_items;
     DROP TABLE IF EXISTS areas;
     DROP TABLE IF EXISTS terminal_sessions;

--- a/src/domain/work-item/types.ts
+++ b/src/domain/work-item/types.ts
@@ -1,3 +1,7 @@
+import { createHash } from 'crypto';
+import type { RuntimeId } from '../runtime/index.js';
+import type { SessionStatus } from '../session/index.js';
+
 export const WORK_ITEM_STATUSES = [
   'inbox',
   'planned',
@@ -19,9 +23,47 @@ export const WORK_ITEM_STATUS_SOURCES = [
   'accepted_agent_suggestion',
 ] as const;
 
+export const WORK_ITEM_LINK_SOURCES = [
+  'user',
+  'accepted_agent_suggestion',
+  'heuristic_suggestion',
+] as const;
+
+export const WORK_ITEM_LINK_ACCEPTANCE_STATUSES = [
+  'accepted',
+  'pending',
+  'rejected',
+] as const;
+
+export const PROGRESS_EVIDENCE_KINDS = [
+  'message',
+  'tool_call',
+  'file_change',
+  'plan_event',
+  'test_result',
+] as const;
+
+export const PROGRESS_EVIDENCE_OUTCOMES = [
+  'progress',
+  'blocked',
+  'completed',
+  'failed',
+] as const;
+
+export const PROGRESS_EVIDENCE_CONFIDENCE = [
+  'explicit',
+  'inferred',
+] as const;
+
 export type WorkItemStatus = typeof WORK_ITEM_STATUSES[number];
 export type WorkItemKind = typeof WORK_ITEM_KINDS[number];
 export type WorkItemStatusSource = typeof WORK_ITEM_STATUS_SOURCES[number];
+export type WorkItemSessionLinkSource = typeof WORK_ITEM_LINK_SOURCES[number];
+export type WorkItemSessionLinkAcceptanceStatus =
+  typeof WORK_ITEM_LINK_ACCEPTANCE_STATUSES[number];
+export type ProgressEvidenceKind = typeof PROGRESS_EVIDENCE_KINDS[number];
+export type ProgressEvidenceOutcome = typeof PROGRESS_EVIDENCE_OUTCOMES[number];
+export type ProgressEvidenceConfidence = typeof PROGRESS_EVIDENCE_CONFIDENCE[number];
 
 export interface Area {
   id: string;
@@ -87,6 +129,76 @@ export interface WorkItemOverviewStats {
   projectTask: number;
 }
 
+export interface AgentSession {
+  id: string;
+  runtimeId: RuntimeId;
+  runtimeSessionId: string;
+  projectRoot?: string;
+  cwd: string;
+  status: SessionStatus | 'unknown';
+  title: string;
+  lastActiveAt: Date;
+  evidenceSummary?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface AgentSessionUpsertInput {
+  runtimeId: RuntimeId;
+  runtimeSessionId: string;
+  projectRoot?: string;
+  cwd: string;
+  status: SessionStatus | 'unknown';
+  title: string;
+  lastActiveAt?: Date;
+  evidenceSummary?: string;
+}
+
+export interface WorkItemSessionLink {
+  id: string;
+  workItemId: string;
+  agentSessionId: string;
+  linkSource: WorkItemSessionLinkSource;
+  acceptanceStatus: WorkItemSessionLinkAcceptanceStatus;
+  acceptedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface WorkItemSessionLinkCreateInput {
+  workItemId: string;
+  agentSessionId: string;
+  linkSource?: WorkItemSessionLinkSource;
+}
+
+export interface ProgressEvidence {
+  id: string;
+  workItemId?: string;
+  agentSessionId?: string;
+  runtimeId?: RuntimeId;
+  kind: ProgressEvidenceKind;
+  outcome?: ProgressEvidenceOutcome;
+  summary: string;
+  sourcePath?: string;
+  occurredAt: Date;
+  confidence: ProgressEvidenceConfidence;
+  metadata?: Record<string, unknown>;
+  createdAt: Date;
+}
+
+export interface ProgressEvidenceCreateInput {
+  workItemId?: string;
+  agentSessionId?: string;
+  runtimeId?: RuntimeId;
+  kind: ProgressEvidenceKind;
+  outcome?: ProgressEvidenceOutcome;
+  summary: string;
+  sourcePath?: string;
+  occurredAt?: Date;
+  confidence?: ProgressEvidenceConfidence;
+  metadata?: Record<string, unknown>;
+}
+
 export function isWorkItemStatus(value: unknown): value is WorkItemStatus {
   return typeof value === 'string' && WORK_ITEM_STATUSES.includes(value as WorkItemStatus);
 }
@@ -98,4 +210,38 @@ export function isWorkItemKind(value: unknown): value is WorkItemKind {
 export function isWorkItemStatusSource(value: unknown): value is WorkItemStatusSource {
   return typeof value === 'string' &&
     WORK_ITEM_STATUS_SOURCES.includes(value as WorkItemStatusSource);
+}
+
+export function isWorkItemSessionLinkSource(
+  value: unknown
+): value is WorkItemSessionLinkSource {
+  return typeof value === 'string' &&
+    WORK_ITEM_LINK_SOURCES.includes(value as WorkItemSessionLinkSource);
+}
+
+export function isProgressEvidenceKind(value: unknown): value is ProgressEvidenceKind {
+  return typeof value === 'string' &&
+    PROGRESS_EVIDENCE_KINDS.includes(value as ProgressEvidenceKind);
+}
+
+export function isProgressEvidenceOutcome(value: unknown): value is ProgressEvidenceOutcome {
+  return typeof value === 'string' &&
+    PROGRESS_EVIDENCE_OUTCOMES.includes(value as ProgressEvidenceOutcome);
+}
+
+export function isProgressEvidenceConfidence(
+  value: unknown
+): value is ProgressEvidenceConfidence {
+  return typeof value === 'string' &&
+    PROGRESS_EVIDENCE_CONFIDENCE.includes(value as ProgressEvidenceConfidence);
+}
+
+export function encodeAgentSessionId(runtimeId: RuntimeId, runtimeSessionId: string): string {
+  const safeRuntimeId = String(runtimeId).replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 24) ||
+    'runtime';
+  const hash = createHash('sha256')
+    .update(`${runtimeId}\0${runtimeSessionId}`)
+    .digest('hex')
+    .slice(0, 32);
+  return `${safeRuntimeId}_${hash}`;
 }

--- a/src/infrastructure/database/index.ts
+++ b/src/infrastructure/database/index.ts
@@ -34,3 +34,7 @@ export { memoryRepository } from './repositories/memory.repository.js';
 export type { IMemoryRepository } from './repositories/memory.repository.js';
 export { workItemRepository } from './repositories/work-item.repository.js';
 export type { IWorkItemRepository } from './repositories/work-item.repository.js';
+export { workItemEvidenceRepository } from './repositories/work-item-evidence.repository.js';
+export type {
+  IWorkItemEvidenceRepository,
+} from './repositories/work-item-evidence.repository.js';

--- a/src/infrastructure/database/migrations/008_work_item_evidence.ts
+++ b/src/infrastructure/database/migrations/008_work_item_evidence.ts
@@ -1,0 +1,84 @@
+/**
+ * Migration 008: Work item agent-session evidence layer.
+ */
+
+import type { Migration } from './index.js';
+import { execSql } from '../sqlite.js';
+
+export const migration008: Migration = {
+  version: 8,
+  name: 'work_item_evidence',
+
+  up: () => {
+    execSql(`
+      CREATE TABLE IF NOT EXISTS agent_sessions (
+        id TEXT PRIMARY KEY,
+        runtime_id TEXT NOT NULL,
+        runtime_session_id TEXT NOT NULL,
+        project_root TEXT,
+        cwd TEXT NOT NULL,
+        status TEXT NOT NULL,
+        title TEXT NOT NULL,
+        last_active_at TEXT NOT NULL,
+        evidence_summary TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(runtime_id, runtime_session_id)
+      )
+    `);
+
+    execSql(`
+      CREATE TABLE IF NOT EXISTS work_item_session_links (
+        id TEXT PRIMARY KEY,
+        work_item_id TEXT NOT NULL,
+        agent_session_id TEXT NOT NULL,
+        link_source TEXT NOT NULL CHECK (link_source IN ('user', 'accepted_agent_suggestion', 'heuristic_suggestion')),
+        acceptance_status TEXT NOT NULL CHECK (acceptance_status IN ('accepted', 'pending', 'rejected')),
+        accepted_at TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (work_item_id) REFERENCES work_items(id) ON DELETE CASCADE,
+        FOREIGN KEY (agent_session_id) REFERENCES agent_sessions(id) ON DELETE CASCADE,
+        UNIQUE(work_item_id, agent_session_id)
+      )
+    `);
+
+    execSql(`
+      CREATE TABLE IF NOT EXISTS progress_evidence (
+        id TEXT PRIMARY KEY,
+        work_item_id TEXT,
+        agent_session_id TEXT,
+        runtime_id TEXT,
+        kind TEXT NOT NULL CHECK (kind IN ('message', 'tool_call', 'file_change', 'plan_event', 'test_result')),
+        outcome TEXT CHECK (outcome IS NULL OR outcome IN ('progress', 'blocked', 'completed', 'failed')),
+        summary TEXT NOT NULL,
+        source_path TEXT,
+        occurred_at TEXT NOT NULL,
+        confidence TEXT NOT NULL CHECK (confidence IN ('explicit', 'inferred')),
+        metadata TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (work_item_id) REFERENCES work_items(id) ON DELETE CASCADE,
+        FOREIGN KEY (agent_session_id) REFERENCES agent_sessions(id) ON DELETE CASCADE,
+        CHECK (work_item_id IS NOT NULL OR agent_session_id IS NOT NULL)
+      )
+    `);
+
+    execSql(`
+      CREATE INDEX IF NOT EXISTS idx_agent_sessions_runtime ON agent_sessions(runtime_id, runtime_session_id);
+      CREATE INDEX IF NOT EXISTS idx_agent_sessions_project_root ON agent_sessions(project_root);
+      CREATE INDEX IF NOT EXISTS idx_work_item_session_links_work_item ON work_item_session_links(work_item_id);
+      CREATE INDEX IF NOT EXISTS idx_work_item_session_links_agent_session ON work_item_session_links(agent_session_id);
+      CREATE INDEX IF NOT EXISTS idx_work_item_session_links_acceptance ON work_item_session_links(acceptance_status);
+      CREATE INDEX IF NOT EXISTS idx_progress_evidence_work_item ON progress_evidence(work_item_id);
+      CREATE INDEX IF NOT EXISTS idx_progress_evidence_agent_session ON progress_evidence(agent_session_id);
+      CREATE INDEX IF NOT EXISTS idx_progress_evidence_kind ON progress_evidence(kind);
+      CREATE INDEX IF NOT EXISTS idx_progress_evidence_occurred_at ON progress_evidence(occurred_at);
+    `);
+  },
+
+  down: () => {
+    execSql('DROP TABLE IF EXISTS progress_evidence');
+    execSql('DROP TABLE IF EXISTS work_item_session_links');
+    execSql('DROP TABLE IF EXISTS agent_sessions');
+  },
+};

--- a/src/infrastructure/database/migrations/all.ts
+++ b/src/infrastructure/database/migrations/all.ts
@@ -12,6 +12,7 @@ import { migration004 } from './004_sessions_last_message.js';
 import { migration005 } from './005_session_metadata.js';
 import { migration006 } from './006_session_client.js';
 import { migration007 } from './007_work_items.js';
+import { migration008 } from './008_work_item_evidence.js';
 
 /** All available migrations */
 export const allMigrations: Migration[] = [
@@ -22,4 +23,5 @@ export const allMigrations: Migration[] = [
   migration005,
   migration006,
   migration007,
+  migration008,
 ];

--- a/src/infrastructure/database/repositories/work-item-evidence.repository.ts
+++ b/src/infrastructure/database/repositories/work-item-evidence.repository.ts
@@ -1,0 +1,297 @@
+/**
+ * Repository for AgentSession, WorkItemSessionLink, and ProgressEvidence records.
+ */
+
+import { randomUUID } from 'crypto';
+import { getDatabase, transaction } from '../sqlite.js';
+import type {
+  AgentSession,
+  AgentSessionUpsertInput,
+  ProgressEvidence,
+  ProgressEvidenceCreateInput,
+  ProgressEvidenceConfidence,
+  ProgressEvidenceKind,
+  ProgressEvidenceOutcome,
+  WorkItemSessionLink,
+  WorkItemSessionLinkAcceptanceStatus,
+  WorkItemSessionLinkCreateInput,
+  WorkItemSessionLinkSource,
+} from '../../../domain/work-item/index.js';
+import { encodeAgentSessionId } from '../../../domain/work-item/index.js';
+import type { RuntimeId } from '../../../domain/runtime/index.js';
+
+interface AgentSessionRow {
+  id: string;
+  runtime_id: string;
+  runtime_session_id: string;
+  project_root: string | null;
+  cwd: string;
+  status: string;
+  title: string;
+  last_active_at: string;
+  evidence_summary: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface WorkItemSessionLinkRow {
+  id: string;
+  work_item_id: string;
+  agent_session_id: string;
+  link_source: string;
+  acceptance_status: string;
+  accepted_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ProgressEvidenceRow {
+  id: string;
+  work_item_id: string | null;
+  agent_session_id: string | null;
+  runtime_id: string | null;
+  kind: string;
+  outcome: string | null;
+  summary: string;
+  source_path: string | null;
+  occurred_at: string;
+  confidence: string;
+  metadata: string | null;
+  created_at: string;
+}
+
+function rowToAgentSession(row: AgentSessionRow): AgentSession {
+  return {
+    id: row.id,
+    runtimeId: row.runtime_id as RuntimeId,
+    runtimeSessionId: row.runtime_session_id,
+    projectRoot: row.project_root || undefined,
+    cwd: row.cwd,
+    status: row.status as AgentSession['status'],
+    title: row.title,
+    lastActiveAt: new Date(row.last_active_at),
+    evidenceSummary: row.evidence_summary || undefined,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  };
+}
+
+function rowToWorkItemSessionLink(row: WorkItemSessionLinkRow): WorkItemSessionLink {
+  return {
+    id: row.id,
+    workItemId: row.work_item_id,
+    agentSessionId: row.agent_session_id,
+    linkSource: row.link_source as WorkItemSessionLinkSource,
+    acceptanceStatus: row.acceptance_status as WorkItemSessionLinkAcceptanceStatus,
+    acceptedAt: row.accepted_at ? new Date(row.accepted_at) : undefined,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  };
+}
+
+function parseMetadata(raw: string | null): Record<string, unknown> | undefined {
+  if (!raw) return undefined;
+  const parsed = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Invalid progress evidence metadata payload');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function rowToProgressEvidence(row: ProgressEvidenceRow): ProgressEvidence {
+  return {
+    id: row.id,
+    workItemId: row.work_item_id || undefined,
+    agentSessionId: row.agent_session_id || undefined,
+    runtimeId: row.runtime_id as RuntimeId | undefined,
+    kind: row.kind as ProgressEvidenceKind,
+    outcome: row.outcome as ProgressEvidenceOutcome | undefined,
+    summary: row.summary,
+    sourcePath: row.source_path || undefined,
+    occurredAt: new Date(row.occurred_at),
+    confidence: row.confidence as ProgressEvidenceConfidence,
+    metadata: parseMetadata(row.metadata),
+    createdAt: new Date(row.created_at),
+  };
+}
+
+export interface IWorkItemEvidenceRepository {
+  upsertAgentSession(input: AgentSessionUpsertInput): AgentSession;
+  findAgentSessionById(id: string): AgentSession | null;
+  createSessionLink(input: WorkItemSessionLinkCreateInput): WorkItemSessionLink;
+  acceptSessionLink(id: string): WorkItemSessionLink | null;
+  findSessionLinkById(id: string): WorkItemSessionLink | null;
+  createProgressEvidence(input: ProgressEvidenceCreateInput): ProgressEvidence;
+  findEvidenceById(id: string): ProgressEvidence | null;
+}
+
+class WorkItemEvidenceRepository implements IWorkItemEvidenceRepository {
+  upsertAgentSession(input: AgentSessionUpsertInput): AgentSession {
+    const db = getDatabase();
+    const now = new Date().toISOString();
+    const id = encodeAgentSessionId(input.runtimeId, input.runtimeSessionId);
+    const lastActiveAt = (input.lastActiveAt ?? new Date()).toISOString();
+
+    db.prepare(`
+      INSERT INTO agent_sessions (
+        id, runtime_id, runtime_session_id, project_root, cwd, status, title,
+        last_active_at, evidence_summary, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        project_root = excluded.project_root,
+        cwd = excluded.cwd,
+        status = excluded.status,
+        title = excluded.title,
+        last_active_at = excluded.last_active_at,
+        evidence_summary = excluded.evidence_summary,
+        updated_at = excluded.updated_at
+    `).run(
+      id,
+      input.runtimeId,
+      input.runtimeSessionId,
+      input.projectRoot ?? null,
+      input.cwd,
+      input.status,
+      input.title,
+      lastActiveAt,
+      input.evidenceSummary ?? null,
+      now,
+      now
+    );
+
+    return this.findAgentSessionById(id)!;
+  }
+
+  findAgentSessionById(id: string): AgentSession | null {
+    const db = getDatabase();
+    const row = db.prepare('SELECT * FROM agent_sessions WHERE id = ?')
+      .get(id) as AgentSessionRow | undefined;
+    return row ? rowToAgentSession(row) : null;
+  }
+
+  createSessionLink(input: WorkItemSessionLinkCreateInput): WorkItemSessionLink {
+    const db = getDatabase();
+    const now = new Date().toISOString();
+    const id = randomUUID();
+    const linkSource = input.linkSource ?? 'user';
+    const acceptanceStatus = linkSource === 'heuristic_suggestion' ? 'pending' : 'accepted';
+    const acceptedAt = acceptanceStatus === 'accepted' ? now : null;
+
+    return transaction(() => {
+      const existing = this.findSessionLinkForPair(input.workItemId, input.agentSessionId);
+      if (existing) {
+        if (existing.acceptanceStatus === 'pending' && linkSource === 'user') {
+          db.prepare(`
+            UPDATE work_item_session_links
+            SET link_source = 'user',
+                acceptance_status = 'accepted',
+                accepted_at = ?,
+                updated_at = ?
+            WHERE id = ?
+          `).run(now, now, existing.id);
+
+          return this.findSessionLinkById(existing.id)!;
+        }
+        return existing;
+      }
+
+      db.prepare(`
+        INSERT INTO work_item_session_links (
+          id, work_item_id, agent_session_id, link_source, acceptance_status,
+          accepted_at, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        id,
+        input.workItemId,
+        input.agentSessionId,
+        linkSource,
+        acceptanceStatus,
+        acceptedAt,
+        now,
+        now
+      );
+
+      return this.findSessionLinkById(id)!;
+    });
+  }
+
+  acceptSessionLink(id: string): WorkItemSessionLink | null {
+    const existing = this.findSessionLinkById(id);
+    if (!existing) return null;
+    if (existing.acceptanceStatus === 'accepted') return existing;
+
+    const db = getDatabase();
+    const now = new Date().toISOString();
+    db.prepare(`
+      UPDATE work_item_session_links
+      SET link_source = 'accepted_agent_suggestion',
+          acceptance_status = 'accepted',
+          accepted_at = ?,
+          updated_at = ?
+      WHERE id = ?
+    `).run(now, now, id);
+
+    return this.findSessionLinkById(id);
+  }
+
+  findSessionLinkById(id: string): WorkItemSessionLink | null {
+    const db = getDatabase();
+    const row = db.prepare('SELECT * FROM work_item_session_links WHERE id = ?')
+      .get(id) as WorkItemSessionLinkRow | undefined;
+    return row ? rowToWorkItemSessionLink(row) : null;
+  }
+
+  private findSessionLinkForPair(
+    workItemId: string,
+    agentSessionId: string
+  ): WorkItemSessionLink | null {
+    const db = getDatabase();
+    const row = db.prepare(`
+      SELECT * FROM work_item_session_links
+      WHERE work_item_id = ? AND agent_session_id = ?
+    `).get(workItemId, agentSessionId) as WorkItemSessionLinkRow | undefined;
+    return row ? rowToWorkItemSessionLink(row) : null;
+  }
+
+  createProgressEvidence(input: ProgressEvidenceCreateInput): ProgressEvidence {
+    if (!input.workItemId && !input.agentSessionId) {
+      throw new Error('ProgressEvidence requires workItemId or agentSessionId');
+    }
+
+    const db = getDatabase();
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    const occurredAt = (input.occurredAt ?? new Date()).toISOString();
+
+    db.prepare(`
+      INSERT INTO progress_evidence (
+        id, work_item_id, agent_session_id, runtime_id, kind, outcome, summary,
+        source_path, occurred_at, confidence, metadata, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      id,
+      input.workItemId ?? null,
+      input.agentSessionId ?? null,
+      input.runtimeId ?? null,
+      input.kind,
+      input.outcome ?? null,
+      input.summary,
+      input.sourcePath ?? null,
+      occurredAt,
+      input.confidence ?? 'explicit',
+      input.metadata ? JSON.stringify(input.metadata) : null,
+      now
+    );
+
+    return this.findEvidenceById(id)!;
+  }
+
+  findEvidenceById(id: string): ProgressEvidence | null {
+    const db = getDatabase();
+    const row = db.prepare('SELECT * FROM progress_evidence WHERE id = ?')
+      .get(id) as ProgressEvidenceRow | undefined;
+    return row ? rowToProgressEvidence(row) : null;
+  }
+}
+
+export const workItemEvidenceRepository = new WorkItemEvidenceRepository();

--- a/src/web/api/routes/index.ts
+++ b/src/web/api/routes/index.ts
@@ -12,5 +12,16 @@ import plans from './plans.js';
 import auth from './auth.js';
 import projects from './projects.js';
 import workItems from './work-items.js';
+import workItemEvidence from './work-item-evidence.js';
 
-export { sessions, recovery, usage, memory, plans, auth, projects, workItems };
+export {
+  sessions,
+  recovery,
+  usage,
+  memory,
+  plans,
+  auth,
+  projects,
+  workItems,
+  workItemEvidence,
+};

--- a/src/web/api/routes/work-item-evidence.ts
+++ b/src/web/api/routes/work-item-evidence.ts
@@ -1,0 +1,291 @@
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import {
+  workItemEvidenceRepository,
+  workItemRepository,
+} from '../../../infrastructure/database/index.js';
+import {
+  isProgressEvidenceConfidence,
+  isProgressEvidenceKind,
+  isProgressEvidenceOutcome,
+  isWorkItemSessionLinkSource,
+  type AgentSessionUpsertInput,
+  type ProgressEvidenceCreateInput,
+  type WorkItemSessionLinkCreateInput,
+} from '../../../domain/work-item/index.js';
+import type { SessionStatus } from '../../../domain/session/index.js';
+import type { RuntimeId } from '../../../domain/runtime/index.js';
+import { isValidSessionId } from '../../../lib/session-id.js';
+import { logger } from '../../../lib/logger.js';
+import { authMiddleware } from '../middleware/auth.js';
+import { readJsonObject } from './work-items.js';
+
+const app = new Hono();
+app.use('*', authMiddleware);
+
+const AGENT_SESSION_STATUSES = [
+  'running',
+  'waiting',
+  'idle',
+  'lost',
+  'completed',
+  'unknown',
+] as const;
+
+function serializeDate(date: Date | undefined): string | undefined {
+  return date?.toISOString();
+}
+
+function serializeAgentSession(session: ReturnType<typeof workItemEvidenceRepository.findAgentSessionById>) {
+  if (!session) return undefined;
+  return {
+    ...session,
+    lastActiveAt: session.lastActiveAt.toISOString(),
+    createdAt: session.createdAt.toISOString(),
+    updatedAt: session.updatedAt.toISOString(),
+  };
+}
+
+function serializeLink(link: ReturnType<typeof workItemEvidenceRepository.findSessionLinkById>) {
+  if (!link) return undefined;
+  return {
+    ...link,
+    acceptedAt: serializeDate(link.acceptedAt),
+    createdAt: link.createdAt.toISOString(),
+    updatedAt: link.updatedAt.toISOString(),
+  };
+}
+
+function serializeEvidence(evidence: ReturnType<typeof workItemEvidenceRepository.findEvidenceById>) {
+  if (!evidence) return undefined;
+  return {
+    ...evidence,
+    occurredAt: evidence.occurredAt.toISOString(),
+    createdAt: evidence.createdAt.toISOString(),
+  };
+}
+
+function readRequiredString(
+  c: Context,
+  data: Record<string, unknown>,
+  key: string,
+  maxLength: number
+): { value?: string; response?: Response } {
+  const raw = data[key];
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return { response: c.json({ success: false, error: `${key} is required` }, 400) };
+  }
+  const value = raw.trim();
+  if (value.length > maxLength) {
+    return {
+      response: c.json({ success: false, error: `${key} must be ${maxLength} characters or fewer` }, 400),
+    };
+  }
+  return { value };
+}
+
+function readOptionalString(
+  c: Context,
+  data: Record<string, unknown>,
+  key: string,
+  maxLength: number
+): { value?: string; response?: Response } {
+  const raw = data[key];
+  if (raw == null) return {};
+  if (typeof raw !== 'string') {
+    return { response: c.json({ success: false, error: `${key} must be a string` }, 400) };
+  }
+  const value = raw.trim();
+  if (value.length > maxLength) {
+    return {
+      response: c.json({ success: false, error: `${key} must be ${maxLength} characters or fewer` }, 400),
+    };
+  }
+  return { value: value || undefined };
+}
+
+function isAgentSessionStatus(value: unknown): value is SessionStatus | 'unknown' {
+  return typeof value === 'string' &&
+    AGENT_SESSION_STATUSES.includes(value as typeof AGENT_SESSION_STATUSES[number]);
+}
+
+app.post('/agent-sessions', async (c) => {
+  const parsedBody = await readJsonObject(c);
+  if (parsedBody.response) return parsedBody.response;
+  const data = parsedBody.data!;
+
+  const runtimeId = readRequiredString(c, data, 'runtimeId', 64);
+  if (runtimeId.response) return runtimeId.response;
+  const runtimeSessionId = readRequiredString(c, data, 'runtimeSessionId', 512);
+  if (runtimeSessionId.response) return runtimeSessionId.response;
+  const cwd = readRequiredString(c, data, 'cwd', 2048);
+  if (cwd.response) return cwd.response;
+  const title = readRequiredString(c, data, 'title', 240);
+  if (title.response) return title.response;
+  const projectRoot = readOptionalString(c, data, 'projectRoot', 2048);
+  if (projectRoot.response) return projectRoot.response;
+  const evidenceSummary = readOptionalString(c, data, 'evidenceSummary', 1000);
+  if (evidenceSummary.response) return evidenceSummary.response;
+
+  if (!isAgentSessionStatus(data.status)) {
+    return c.json({ success: false, error: 'Invalid agent session status' }, 400);
+  }
+
+  const lastActiveAt = typeof data.lastActiveAt === 'string'
+    ? new Date(data.lastActiveAt)
+    : new Date();
+  if (Number.isNaN(lastActiveAt.getTime())) {
+    return c.json({ success: false, error: 'lastActiveAt must be an ISO date' }, 400);
+  }
+
+  try {
+    const session = workItemEvidenceRepository.upsertAgentSession({
+      runtimeId: runtimeId.value! as RuntimeId,
+      runtimeSessionId: runtimeSessionId.value!,
+      cwd: cwd.value!,
+      title: title.value!,
+      status: data.status,
+      projectRoot: projectRoot.value,
+      evidenceSummary: evidenceSummary.value,
+      lastActiveAt,
+    } satisfies AgentSessionUpsertInput);
+
+    return c.json({
+      success: true,
+      data: { agentSession: serializeAgentSession(session) },
+    }, 201);
+  } catch (error) {
+    logger.error('Failed to upsert agent session', error);
+    return c.json({ success: false, error: 'Failed to save agent session' }, 500);
+  }
+});
+
+app.post('/:id/session-links', async (c) => {
+  const workItemId = c.req.param('id');
+  if (!workItemRepository.findById(workItemId)) {
+    return c.json({ success: false, error: 'Work item not found' }, 404);
+  }
+
+  const parsedBody = await readJsonObject(c);
+  if (parsedBody.response) return parsedBody.response;
+  const data = parsedBody.data!;
+  const agentSessionId = readRequiredString(c, data, 'agentSessionId', 64);
+  if (agentSessionId.response) return agentSessionId.response;
+  if (!isValidSessionId(agentSessionId.value!)) {
+    return c.json({ success: false, error: 'Invalid agentSessionId format' }, 400);
+  }
+  if (!workItemEvidenceRepository.findAgentSessionById(agentSessionId.value!)) {
+    return c.json({ success: false, error: 'Agent session not found' }, 404);
+  }
+
+  const rawLinkSource = data.linkSource ?? 'user';
+  if (!isWorkItemSessionLinkSource(rawLinkSource)) {
+    return c.json({ success: false, error: 'Invalid linkSource' }, 400);
+  }
+  if (rawLinkSource === 'accepted_agent_suggestion') {
+    return c.json({
+      success: false,
+      error: 'accepted_agent_suggestion links must be created by accepting a pending link',
+    }, 400);
+  }
+
+  try {
+    const link = workItemEvidenceRepository.createSessionLink({
+      workItemId,
+      agentSessionId: agentSessionId.value!,
+      linkSource: rawLinkSource,
+    } satisfies WorkItemSessionLinkCreateInput);
+
+    return c.json({ success: true, data: { link: serializeLink(link) } }, 201);
+  } catch (error) {
+    logger.error('Failed to create work item session link', error);
+    return c.json({ success: false, error: 'Failed to create work item session link' }, 500);
+  }
+});
+
+app.post('/session-links/:id/accept', (c) => {
+  const link = workItemEvidenceRepository.acceptSessionLink(c.req.param('id'));
+  if (!link) {
+    return c.json({ success: false, error: 'Work item session link not found' }, 404);
+  }
+  return c.json({ success: true, data: { link: serializeLink(link) } });
+});
+
+app.post('/evidence', async (c) => {
+  const parsedBody = await readJsonObject(c);
+  if (parsedBody.response) return parsedBody.response;
+  const data = parsedBody.data!;
+
+  const summary = readRequiredString(c, data, 'summary', 1000);
+  if (summary.response) return summary.response;
+  const sourcePath = readOptionalString(c, data, 'sourcePath', 2048);
+  if (sourcePath.response) return sourcePath.response;
+  const runtimeId = readOptionalString(c, data, 'runtimeId', 64);
+  if (runtimeId.response) return runtimeId.response;
+
+  if (!isProgressEvidenceKind(data.kind)) {
+    return c.json({ success: false, error: 'Invalid evidence kind' }, 400);
+  }
+  if (data.outcome != null && !isProgressEvidenceOutcome(data.outcome)) {
+    return c.json({ success: false, error: 'Invalid evidence outcome' }, 400);
+  }
+  if (data.confidence != null && !isProgressEvidenceConfidence(data.confidence)) {
+    return c.json({ success: false, error: 'Invalid evidence confidence' }, 400);
+  }
+
+  const workItemId = typeof data.workItemId === 'string' && data.workItemId.trim()
+    ? data.workItemId.trim()
+    : undefined;
+  const agentSessionId = typeof data.agentSessionId === 'string' && data.agentSessionId.trim()
+    ? data.agentSessionId.trim()
+    : undefined;
+
+  if (!workItemId && !agentSessionId) {
+    return c.json({
+      success: false,
+      error: 'Progress evidence requires workItemId or agentSessionId',
+    }, 400);
+  }
+  if (workItemId && !workItemRepository.findById(workItemId)) {
+    return c.json({ success: false, error: 'Work item not found' }, 404);
+  }
+  if (agentSessionId && !workItemEvidenceRepository.findAgentSessionById(agentSessionId)) {
+    return c.json({ success: false, error: 'Agent session not found' }, 404);
+  }
+
+  const occurredAt = typeof data.occurredAt === 'string'
+    ? new Date(data.occurredAt)
+    : new Date();
+  if (Number.isNaN(occurredAt.getTime())) {
+    return c.json({ success: false, error: 'occurredAt must be an ISO date' }, 400);
+  }
+
+  if (data.metadata != null && (typeof data.metadata !== 'object' || Array.isArray(data.metadata))) {
+    return c.json({ success: false, error: 'metadata must be an object' }, 400);
+  }
+
+  const outcome = data.outcome ?? undefined;
+  const confidence = data.confidence ?? 'explicit';
+
+  try {
+    const evidence = workItemEvidenceRepository.createProgressEvidence({
+      workItemId,
+      agentSessionId,
+      runtimeId: runtimeId.value as RuntimeId | undefined,
+      kind: data.kind,
+      outcome,
+      summary: summary.value!,
+      sourcePath: sourcePath.value,
+      occurredAt,
+      confidence,
+      metadata: data.metadata as Record<string, unknown> | undefined,
+    } satisfies ProgressEvidenceCreateInput);
+
+    return c.json({ success: true, data: { evidence: serializeEvidence(evidence) } }, 201);
+  } catch (error) {
+    logger.error('Failed to create progress evidence', error);
+    return c.json({ success: false, error: 'Failed to create progress evidence' }, 500);
+  }
+});
+
+export default app;

--- a/src/web/api/routes/work-items.ts
+++ b/src/web/api/routes/work-items.ts
@@ -50,7 +50,7 @@ function readString(
   return { value: value || undefined };
 }
 
-async function readJsonObject(c: Context): Promise<{
+export async function readJsonObject(c: Context): Promise<{
   data?: Record<string, unknown>;
   response?: Response;
 }> {

--- a/src/web/api/server.ts
+++ b/src/web/api/server.ts
@@ -19,7 +19,17 @@ import { initPricing } from '../../services/usage.pricing.js';
 import { initializeMemoryService } from '../../services/memory.service.js';
 import { logger } from '../../lib/logger.js';
 import { rateLimit } from './middleware/rateLimit.js';
-import { sessions, recovery, usage, memory, plans, auth, projects, workItems } from './routes/index.js';
+import {
+  sessions,
+  recovery,
+  usage,
+  memory,
+  plans,
+  auth,
+  projects,
+  workItems,
+  workItemEvidence,
+} from './routes/index.js';
 import { broadcast, wsClients, websocketHandler } from './websocket.js';
 import { terminalWebsocketHandler } from './terminal-websocket.js';
 import { verifyToken } from '../../services/auth.service.js';
@@ -86,6 +96,7 @@ app.route('/api/auth', auth);
 app.route('/api/sessions', sessions);
 app.route('/api/sessions', recovery);
 app.route('/api/projects', projects);
+app.route('/api/work-items', workItemEvidence);
 app.route('/api/work-items', workItems);
 app.route('/api', usage);
 app.route('/api/memory', memory);


### PR DESCRIPTION
## Summary
- add AgentSession, WorkItemSessionLink, and ProgressEvidence persistence
- expose work item evidence routes with explicit accepted vs pending semantics
- keep inferred evidence out of formal WorkItem status changes

## Verification
- git diff --check
- bun test src/__tests__/work-item-evidence.route.test.ts
- bun run typecheck
- bun test
- bun run build

Closes #49