### PR TITLE
Project work items into Workboard buckets

### DIFF
--- a/src/__tests__/work-items.route.test.ts
+++ b/src/__tests__/work-items.route.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import workItems from '../web/api/routes/work-items.js';
+import workItemEvidence from '../web/api/routes/work-item-evidence.js';
 import { setupUser } from '../services/auth.service.js';
 import { resetDatabase } from '../db/migrations.js';
 import { closeDatabase } from '../infrastructure/database/sqlite.js';
@@ -15,6 +16,22 @@ async function authedRequest(
     headers.set('Content-Type', 'application/json');
   }
   return workItems.fetch(new Request(`http://localhost${path}`, {
+    ...options,
+    headers,
+  }));
+}
+
+async function workboardEvidenceRequest(
+  token: string,
+  path: string,
+  options: RequestInit = {}
+): Promise<Response> {
+  const headers = new Headers(options.headers);
+  headers.set('Authorization', `Bearer ${token}`);
+  if (options.body && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+  return workItemEvidence.fetch(new Request(`http://localhost${path}`, {
     ...options,
     headers,
   }));
@@ -186,5 +203,118 @@ describe('Work item routes', () => {
       data: { items: Array<{ title: string }> };
     };
     expect(afterDeleteBody.data.items.map((item) => item.title)).not.toContain('Todo item');
+  });
+
+  test('returns deterministic Workboard buckets and marks pending suggestions', async () => {
+    const { token } = await setupUser('workboard-user', 'password123');
+    const oldDate = '2026-06-20T12:00:00.000Z';
+    const recentDate = '2026-06-23T11:00:00.000Z';
+
+    const staleResponse = await authedRequest(token, '/', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'Stale planned', kind: 'todo', status: 'planned' }),
+    });
+    const runningResponse = await authedRequest(token, '/', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'Suggested running', kind: 'todo', status: 'planned' }),
+    });
+    const doneResponse = await authedRequest(token, '/', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'Completed by user', kind: 'todo', status: 'done' }),
+    });
+    const staleBody = await staleResponse.json() as { data: { item: { id: string } } };
+    const runningBody = await runningResponse.json() as { data: { item: { id: string } } };
+    const doneBody = await doneResponse.json() as { data: { item: { id: string } } };
+
+    const staleSessionResponse = await workboardEvidenceRequest(token, '/agent-sessions', {
+      method: 'POST',
+      body: JSON.stringify({
+        runtimeId: 'codex',
+        runtimeSessionId: 'stale-session',
+        cwd: '/tmp/project',
+        status: 'completed',
+        title: 'Old session',
+        lastActiveAt: oldDate,
+      }),
+    });
+    const runningSessionResponse = await workboardEvidenceRequest(token, '/agent-sessions', {
+      method: 'POST',
+      body: JSON.stringify({
+        runtimeId: 'codex',
+        runtimeSessionId: 'running-session',
+        cwd: '/tmp/project',
+        status: 'running',
+        title: 'Running session',
+        lastActiveAt: recentDate,
+      }),
+    });
+    const staleSessionBody = await staleSessionResponse.json() as {
+      data: { agentSession: { id: string } };
+    };
+    const runningSessionBody = await runningSessionResponse.json() as {
+      data: { agentSession: { id: string } };
+    };
+
+    await workboardEvidenceRequest(token, `/${staleBody.data.item.id}/session-links`, {
+      method: 'POST',
+      body: JSON.stringify({
+        agentSessionId: staleSessionBody.data.agentSession.id,
+        linkSource: 'user',
+      }),
+    });
+    await workboardEvidenceRequest(token, `/${runningBody.data.item.id}/session-links`, {
+      method: 'POST',
+      body: JSON.stringify({
+        agentSessionId: runningSessionBody.data.agentSession.id,
+        linkSource: 'heuristic_suggestion',
+      }),
+    });
+
+    const listWithPending = await authedRequest(token, '/?staleWindowHours=24');
+    expect(listWithPending.status).toBe(200);
+    const pendingBody = await listWithPending.json() as {
+      data: {
+        workboard: {
+          now: Array<{ item: { id: string } }>;
+          stale: Array<{ item: { id: string } }>;
+          done: Array<{ item: { id: string } }>;
+          suggestions: Array<{
+            item: { id: string };
+            suggestions: Array<{ agentSession: { status: string } }>;
+          }>;
+        };
+      };
+    };
+
+    expect(pendingBody.data.workboard.stale.map((entry) => entry.item.id))
+      .toEqual([staleBody.data.item.id]);
+    expect(pendingBody.data.workboard.done.map((entry) => entry.item.id))
+      .toEqual([doneBody.data.item.id]);
+    expect(pendingBody.data.workboard.now).toHaveLength(0);
+    expect(pendingBody.data.workboard.suggestions.map((entry) => entry.item.id))
+      .toEqual([runningBody.data.item.id]);
+    expect(pendingBody.data.workboard.suggestions[0].suggestions[0].agentSession.status)
+      .toBe('running');
+
+    await workboardEvidenceRequest(token, `/${runningBody.data.item.id}/session-links`, {
+      method: 'POST',
+      body: JSON.stringify({
+        agentSessionId: runningSessionBody.data.agentSession.id,
+        linkSource: 'user',
+      }),
+    });
+
+    const listAfterAccept = await authedRequest(token, '/?staleWindowHours=24');
+    const acceptedBody = await listAfterAccept.json() as {
+      data: {
+        workboard: {
+          now: Array<{ item: { id: string } }>;
+          suggestions: Array<{ item: { id: string } }>;
+        };
+      };
+    };
+    expect(acceptedBody.data.workboard.now.map((entry) => entry.item.id))
+      .toEqual([runningBody.data.item.id]);
+    expect(acceptedBody.data.workboard.suggestions).toHaveLength(0);
   });
 });

--- a/src/__tests__/workboard.projection.test.ts
+++ b/src/__tests__/workboard.projection.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildWorkboardProjection,
+  type AgentSession,
+  type ProgressEvidence,
+  type WorkItem,
+  type WorkItemSessionLink,
+} from '../domain/work-item/index.js';
+
+const NOW = new Date('2026-06-23T12:00:00.000Z');
+const RECENT = new Date('2026-06-23T11:00:00.000Z');
+const OLD = new Date('2026-06-20T12:00:00.000Z');
+
+function workItem(id: string, status: WorkItem['status']): WorkItem {
+  return {
+    id,
+    title: id,
+    kind: 'todo',
+    status,
+    statusSource: 'user',
+    createdAt: OLD,
+    updatedAt: RECENT,
+    completedAt: status === 'done' ? RECENT : undefined,
+  };
+}
+
+function agentSession(
+  id: string,
+  status: AgentSession['status'],
+  lastActiveAt: Date
+): AgentSession {
+  return {
+    id,
+    runtimeId: 'codex',
+    runtimeSessionId: id,
+    cwd: '/tmp/project',
+    status,
+    title: id,
+    lastActiveAt,
+    createdAt: OLD,
+    updatedAt: lastActiveAt,
+  };
+}
+
+function sessionLink(
+  workItemId: string,
+  agentSessionId: string,
+  acceptanceStatus: WorkItemSessionLink['acceptanceStatus'] = 'accepted'
+): WorkItemSessionLink {
+  return {
+    id: `${workItemId}-${agentSessionId}`,
+    workItemId,
+    agentSessionId,
+    linkSource: acceptanceStatus === 'accepted' ? 'user' : 'heuristic_suggestion',
+    acceptanceStatus,
+    acceptedAt: acceptanceStatus === 'accepted' ? RECENT : undefined,
+    createdAt: RECENT,
+    updatedAt: RECENT,
+  };
+}
+
+function progressEvidence(input: {
+  id: string;
+  workItemId?: string;
+  agentSessionId?: string;
+  outcome?: ProgressEvidence['outcome'];
+  confidence?: ProgressEvidence['confidence'];
+  occurredAt: Date;
+}): ProgressEvidence {
+  return {
+    id: input.id,
+    workItemId: input.workItemId,
+    agentSessionId: input.agentSessionId,
+    runtimeId: 'codex',
+    kind: 'message',
+    outcome: input.outcome,
+    summary: input.id,
+    occurredAt: input.occurredAt,
+    confidence: input.confidence ?? 'explicit',
+    createdAt: input.occurredAt,
+  };
+}
+
+describe('buildWorkboardProjection', () => {
+  test('applies bucket precedence without mutating work item state', () => {
+    const items = [
+      workItem('done-item', 'done'),
+      workItem('blocked-item', 'blocked'),
+      workItem('waiting-item', 'planned'),
+      workItem('completed-waiting-item', 'planned'),
+      workItem('stale-active-item', 'active'),
+      workItem('active-item', 'active'),
+      workItem('planned-running-item', 'planned'),
+      workItem('pending-running-item', 'planned'),
+      workItem('active-no-evidence-item', 'active'),
+      workItem('blank-planned-item', 'planned'),
+    ];
+    const sessions = [
+      agentSession('waiting-session', 'waiting', RECENT),
+      agentSession('completed-waiting-session', 'waiting', OLD),
+      agentSession('stale-session', 'completed', OLD),
+      agentSession('running-session', 'running', RECENT),
+      agentSession('pending-running-session', 'running', RECENT),
+    ];
+    const links = [
+      sessionLink('waiting-item', 'waiting-session'),
+      sessionLink('completed-waiting-item', 'completed-waiting-session'),
+      sessionLink('stale-active-item', 'stale-session'),
+      sessionLink('planned-running-item', 'running-session'),
+      sessionLink('pending-running-item', 'pending-running-session', 'pending'),
+    ];
+    const evidence = [
+      progressEvidence({
+        id: 'explicit-completed-after-waiting',
+        workItemId: 'completed-waiting-item',
+        agentSessionId: 'completed-waiting-session',
+        outcome: 'completed',
+        confidence: 'explicit',
+        occurredAt: RECENT,
+      }),
+      progressEvidence({
+        id: 'recent-active-progress',
+        workItemId: 'active-item',
+        outcome: 'progress',
+        occurredAt: RECENT,
+      }),
+      progressEvidence({
+        id: 'pending-session-progress',
+        workItemId: 'pending-running-item',
+        agentSessionId: 'pending-running-session',
+        outcome: 'progress',
+        occurredAt: RECENT,
+      }),
+    ];
+
+    const projection = buildWorkboardProjection({
+      items,
+      links,
+      agentSessions: sessions,
+      evidence,
+      now: NOW,
+      staleWindowHours: 24,
+    });
+
+    expect(projection.done.map((entry) => entry.item.id)).toEqual(['done-item']);
+    expect(projection.waiting.map((entry) => entry.item.id)).toEqual([
+      'blocked-item',
+      'waiting-item',
+    ]);
+    expect(projection.stale.map((entry) => entry.item.id)).toEqual(['stale-active-item']);
+    expect(projection.now.map((entry) => entry.item.id)).toEqual([
+      'active-item',
+      'active-no-evidence-item',
+      'planned-running-item',
+    ]);
+    expect(projection.suggestions.map((entry) => entry.item.id)).toEqual(['pending-running-item']);
+    expect(projection.now.find((entry) => entry.item.id === 'active-no-evidence-item')?.progressSummary)
+      .toBeUndefined();
+    expect(items.find((item) => item.id === 'completed-waiting-item')?.status).toBe('planned');
+    expect([
+      ...projection.now,
+      ...projection.waiting,
+      ...projection.stale,
+      ...projection.done,
+    ].some((entry) => entry.item.id === 'pending-running-item')).toBe(false);
+  });
+
+  test('does not treat inferred completion as a waiting-clear signal', () => {
+    const items = [workItem('inferred-completed-item', 'planned')];
+    const sessions = [agentSession('waiting-session', 'waiting', OLD)];
+    const links = [sessionLink('inferred-completed-item', 'waiting-session')];
+    const evidence = [
+      progressEvidence({
+        id: 'inferred-completed-after-waiting',
+        workItemId: 'inferred-completed-item',
+        agentSessionId: 'waiting-session',
+        outcome: 'completed',
+        confidence: 'inferred',
+        occurredAt: RECENT,
+      }),
+    ];
+
+    const projection = buildWorkboardProjection({
+      items,
+      links,
+      agentSessions: sessions,
+      evidence,
+      now: NOW,
+      staleWindowHours: 24,
+    });
+
+    expect(projection.waiting.map((entry) => entry.item.id)).toEqual(['inferred-completed-item']);
+    expect(items[0].status).toBe('planned');
+  });
+});

--- a/src/domain/work-item/index.ts
+++ b/src/domain/work-item/index.ts
@@ -1,1 +1,2 @@
 export * from './types.js';
+export * from './workboard.js';

--- a/src/domain/work-item/types.ts
+++ b/src/domain/work-item/types.ts
@@ -55,6 +55,13 @@ export const PROGRESS_EVIDENCE_CONFIDENCE = [
   'inferred',
 ] as const;
 
+export const WORKBOARD_BUCKETS = [
+  'now',
+  'waiting',
+  'stale',
+  'done',
+] as const;
+
 export type WorkItemStatus = typeof WORK_ITEM_STATUSES[number];
 export type WorkItemKind = typeof WORK_ITEM_KINDS[number];
 export type WorkItemStatusSource = typeof WORK_ITEM_STATUS_SOURCES[number];
@@ -64,6 +71,7 @@ export type WorkItemSessionLinkAcceptanceStatus =
 export type ProgressEvidenceKind = typeof PROGRESS_EVIDENCE_KINDS[number];
 export type ProgressEvidenceOutcome = typeof PROGRESS_EVIDENCE_OUTCOMES[number];
 export type ProgressEvidenceConfidence = typeof PROGRESS_EVIDENCE_CONFIDENCE[number];
+export type WorkboardBucketId = typeof WORKBOARD_BUCKETS[number];
 
 export interface Area {
   id: string;
@@ -197,6 +205,40 @@ export interface ProgressEvidenceCreateInput {
   occurredAt?: Date;
   confidence?: ProgressEvidenceConfidence;
   metadata?: Record<string, unknown>;
+}
+
+export interface WorkboardAgentSessionSummary {
+  id: string;
+  runtimeId: RuntimeId;
+  title: string;
+  status: AgentSession['status'];
+  lastActiveAt: Date;
+}
+
+export interface WorkboardSuggestion {
+  linkId: string;
+  agentSession: WorkboardAgentSessionSummary;
+  suggestedAt: Date;
+}
+
+export interface WorkboardItemProjection {
+  item: WorkItem;
+  bucket?: WorkboardBucketId;
+  progressSummary?: string;
+  lastActivityAt?: Date;
+  waitingOnSession?: WorkboardAgentSessionSummary;
+  acceptedSessions: WorkboardAgentSessionSummary[];
+  suggestions: WorkboardSuggestion[];
+}
+
+export interface WorkboardProjection {
+  now: WorkboardItemProjection[];
+  waiting: WorkboardItemProjection[];
+  stale: WorkboardItemProjection[];
+  done: WorkboardItemProjection[];
+  suggestions: WorkboardItemProjection[];
+  staleWindowHours: number;
+  generatedAt: Date;
 }
 
 export function isWorkItemStatus(value: unknown): value is WorkItemStatus {

--- a/src/domain/work-item/workboard.ts
+++ b/src/domain/work-item/workboard.ts
@@ -1,0 +1,235 @@
+import type {
+  AgentSession,
+  ProgressEvidence,
+  WorkboardAgentSessionSummary,
+  WorkboardBucketId,
+  WorkboardItemProjection,
+  WorkboardProjection,
+  WorkItem,
+  WorkItemSessionLink,
+} from './types.js';
+
+export const DEFAULT_WORKBOARD_STALE_WINDOW_HOURS = 72;
+
+export interface BuildWorkboardProjectionInput {
+  items: WorkItem[];
+  links: WorkItemSessionLink[];
+  agentSessions: AgentSession[];
+  evidence: ProgressEvidence[];
+  now?: Date;
+  staleWindowHours?: number;
+}
+
+interface WorkboardEvaluation {
+  projection: WorkboardItemProjection;
+  bucket?: WorkboardBucketId;
+}
+
+export function buildWorkboardProjection(
+  input: BuildWorkboardProjectionInput
+): WorkboardProjection {
+  const now = input.now ?? new Date();
+  const staleWindowHours = input.staleWindowHours ?? DEFAULT_WORKBOARD_STALE_WINDOW_HOURS;
+  const staleCutoffMs = now.getTime() - staleWindowHours * 60 * 60 * 1000;
+  const sessionsById = new Map(input.agentSessions.map((session) => [session.id, session]));
+  const linksByWorkItemId = groupBy(input.links, (link) => link.workItemId);
+  const evidenceById = new Map(input.evidence.map((record) => [record.id, record]));
+  const allEvidence = [...evidenceById.values()];
+
+  const projection: WorkboardProjection = {
+    now: [],
+    waiting: [],
+    stale: [],
+    done: [],
+    suggestions: [],
+    staleWindowHours,
+    generatedAt: now,
+  };
+
+  for (const item of input.items) {
+    if (item.status === 'archived') continue;
+
+    const evaluated = evaluateWorkItem({
+      item,
+      links: linksByWorkItemId.get(item.id) ?? [],
+      sessionsById,
+      evidence: allEvidence,
+      staleCutoffMs,
+    });
+
+    if (evaluated.bucket) {
+      projection[evaluated.bucket].push({
+        ...evaluated.projection,
+        bucket: evaluated.bucket,
+      });
+      continue;
+    }
+
+    if (evaluated.projection.suggestions.length > 0) {
+      projection.suggestions.push(evaluated.projection);
+    }
+  }
+
+  for (const bucket of ['now', 'waiting', 'stale', 'done', 'suggestions'] as const) {
+    projection[bucket].sort(compareProjectionItems);
+  }
+
+  return projection;
+}
+
+function evaluateWorkItem(input: {
+  item: WorkItem;
+  links: WorkItemSessionLink[];
+  sessionsById: Map<string, AgentSession>;
+  evidence: ProgressEvidence[];
+  staleCutoffMs: number;
+}): WorkboardEvaluation {
+  const acceptedLinks = input.links.filter((link) => link.acceptanceStatus === 'accepted');
+  const pendingLinks = input.links.filter((link) => link.acceptanceStatus === 'pending');
+  const acceptedSessions = acceptedLinks
+    .map((link) => input.sessionsById.get(link.agentSessionId))
+    .filter((session): session is AgentSession => !!session);
+  const acceptedSessionIds = new Set(acceptedSessions.map((session) => session.id));
+  const relevantEvidence = input.evidence.filter((record) =>
+    isEvidenceRelevantToItem(record, input.item.id, acceptedSessionIds)
+  );
+  const progressEvidence = [...relevantEvidence].sort(compareEvidenceByRecency)[0];
+  const activityDates = [
+    ...acceptedSessions.map((session) => session.lastActiveAt),
+    ...relevantEvidence.map((record) => record.occurredAt),
+  ];
+  const lastActivityAt = maxDate(activityDates);
+  const mostRecentSession = [...acceptedSessions].sort(compareSessionsByRecency)[0];
+  const suggestions = pendingLinks
+    .map((link) => {
+      const session = input.sessionsById.get(link.agentSessionId);
+      if (!session) return undefined;
+      return {
+        linkId: link.id,
+        agentSession: summarizeSession(session),
+        suggestedAt: link.createdAt,
+      };
+    })
+    .filter((suggestion): suggestion is NonNullable<typeof suggestion> => !!suggestion)
+    .sort((a, b) => b.suggestedAt.getTime() - a.suggestedAt.getTime());
+
+  const projection: WorkboardItemProjection = {
+    item: input.item,
+    progressSummary: progressEvidence?.summary,
+    lastActivityAt,
+    acceptedSessions: acceptedSessions.map(summarizeSession).sort(compareSessionSummaries),
+    suggestions,
+  };
+
+  if (input.item.status === 'done') {
+    return { projection, bucket: 'done' };
+  }
+
+  if (input.item.status === 'blocked') {
+    return { projection, bucket: 'waiting' };
+  }
+
+  if (mostRecentSession?.status === 'waiting' &&
+    !hasNewerExplicitCompletion(input.item.id, mostRecentSession.id, mostRecentSession.lastActiveAt, input.evidence)) {
+    return {
+      projection: {
+        ...projection,
+        waitingOnSession: summarizeSession(mostRecentSession),
+      },
+      bucket: 'waiting',
+    };
+  }
+
+  const canBeStale = input.item.status === 'planned' || input.item.status === 'active';
+  if (canBeStale && activityDates.length > 0 &&
+    activityDates.every((date) => date.getTime() < input.staleCutoffMs)) {
+    return { projection, bucket: 'stale' };
+  }
+
+  if (input.item.status === 'active' ||
+    (input.item.status === 'planned' && acceptedSessions.some((session) => session.status === 'running'))) {
+    return { projection, bucket: 'now' };
+  }
+
+  return { projection };
+}
+
+function isEvidenceRelevantToItem(
+  record: ProgressEvidence,
+  workItemId: string,
+  acceptedSessionIds: Set<string>
+): boolean {
+  if (record.workItemId && record.workItemId !== workItemId) return false;
+  if (record.agentSessionId && !acceptedSessionIds.has(record.agentSessionId)) return false;
+  return record.workItemId === workItemId ||
+    (!!record.agentSessionId && acceptedSessionIds.has(record.agentSessionId));
+}
+
+function hasNewerExplicitCompletion(
+  workItemId: string,
+  agentSessionId: string,
+  lastActiveAt: Date,
+  evidence: ProgressEvidence[]
+): boolean {
+  return evidence.some((record) => {
+    if (record.outcome !== 'completed' || record.confidence !== 'explicit') return false;
+    if (record.occurredAt.getTime() <= lastActiveAt.getTime()) return false;
+    if (record.workItemId && record.workItemId !== workItemId) return false;
+    if (record.agentSessionId && record.agentSessionId !== agentSessionId) return false;
+    return record.workItemId === workItemId || record.agentSessionId === agentSessionId;
+  });
+}
+
+function summarizeSession(session: AgentSession): WorkboardAgentSessionSummary {
+  return {
+    id: session.id,
+    runtimeId: session.runtimeId,
+    title: session.title,
+    status: session.status,
+    lastActiveAt: session.lastActiveAt,
+  };
+}
+
+function maxDate(dates: Date[]): Date | undefined {
+  if (dates.length === 0) return undefined;
+  return dates.reduce((latest, date) =>
+    date.getTime() > latest.getTime() ? date : latest
+  );
+}
+
+function groupBy<T>(values: T[], keyFor: (value: T) => string): Map<string, T[]> {
+  const grouped = new Map<string, T[]>();
+  for (const value of values) {
+    const key = keyFor(value);
+    const list = grouped.get(key) ?? [];
+    list.push(value);
+    grouped.set(key, list);
+  }
+  return grouped;
+}
+
+function compareProjectionItems(a: WorkboardItemProjection, b: WorkboardItemProjection): number {
+  const aTime = a.lastActivityAt?.getTime() ?? a.item.completedAt?.getTime() ?? a.item.updatedAt.getTime();
+  const bTime = b.lastActivityAt?.getTime() ?? b.item.completedAt?.getTime() ?? b.item.updatedAt.getTime();
+  if (aTime !== bTime) return bTime - aTime;
+  const titleComparison = a.item.title.localeCompare(b.item.title);
+  return titleComparison || a.item.id.localeCompare(b.item.id);
+}
+
+function compareEvidenceByRecency(a: ProgressEvidence, b: ProgressEvidence): number {
+  const timeComparison = b.occurredAt.getTime() - a.occurredAt.getTime();
+  return timeComparison || a.id.localeCompare(b.id);
+}
+
+function compareSessionsByRecency(a: AgentSession, b: AgentSession): number {
+  const timeComparison = b.lastActiveAt.getTime() - a.lastActiveAt.getTime();
+  return timeComparison || a.id.localeCompare(b.id);
+}
+
+function compareSessionSummaries(
+  a: WorkboardAgentSessionSummary,
+  b: WorkboardAgentSessionSummary
+): number {
+  const timeComparison = b.lastActiveAt.getTime() - a.lastActiveAt.getTime();
+  return timeComparison || a.id.localeCompare(b.id);
+}

--- a/src/infrastructure/database/repositories/work-item-evidence.repository.ts
+++ b/src/infrastructure/database/repositories/work-item-evidence.repository.ts
@@ -20,6 +20,12 @@ import type {
 import { encodeAgentSessionId } from '../../../domain/work-item/index.js';
 import type { RuntimeId } from '../../../domain/runtime/index.js';
 
+export interface WorkItemEvidenceProjectionData {
+  links: WorkItemSessionLink[];
+  agentSessions: AgentSession[];
+  evidence: ProgressEvidence[];
+}
+
 interface AgentSessionRow {
   id: string;
   runtime_id: string;
@@ -123,6 +129,7 @@ export interface IWorkItemEvidenceRepository {
   findSessionLinkById(id: string): WorkItemSessionLink | null;
   createProgressEvidence(input: ProgressEvidenceCreateInput): ProgressEvidence;
   findEvidenceById(id: string): ProgressEvidence | null;
+  findProjectionDataForWorkItems(workItemIds: string[]): WorkItemEvidenceProjectionData;
 }
 
 class WorkItemEvidenceRepository implements IWorkItemEvidenceRepository {
@@ -291,6 +298,54 @@ class WorkItemEvidenceRepository implements IWorkItemEvidenceRepository {
     const row = db.prepare('SELECT * FROM progress_evidence WHERE id = ?')
       .get(id) as ProgressEvidenceRow | undefined;
     return row ? rowToProgressEvidence(row) : null;
+  }
+
+  findProjectionDataForWorkItems(workItemIds: string[]): WorkItemEvidenceProjectionData {
+    const db = getDatabase();
+    const uniqueWorkItemIds = [...new Set(workItemIds)].filter(Boolean);
+    if (uniqueWorkItemIds.length === 0) {
+      return { links: [], agentSessions: [], evidence: [] };
+    }
+
+    const workItemPlaceholders = uniqueWorkItemIds.map(() => '?').join(', ');
+    const links = db.prepare(`
+      SELECT * FROM work_item_session_links
+      WHERE work_item_id IN (${workItemPlaceholders})
+    `).all(...uniqueWorkItemIds) as WorkItemSessionLinkRow[];
+    const mappedLinks = links.map(rowToWorkItemSessionLink);
+    const agentSessionIds = [
+      ...new Set(mappedLinks.map((link) => link.agentSessionId)),
+    ];
+    const agentSessions = this.findAgentSessionsByIds(agentSessionIds);
+
+    const evidenceClauses = [`work_item_id IN (${workItemPlaceholders})`];
+    const evidenceParams: string[] = [...uniqueWorkItemIds];
+    if (agentSessionIds.length > 0) {
+      evidenceClauses.push(`agent_session_id IN (${agentSessionIds.map(() => '?').join(', ')})`);
+      evidenceParams.push(...agentSessionIds);
+    }
+    const evidence = db.prepare(`
+      SELECT * FROM progress_evidence
+      WHERE ${evidenceClauses.join(' OR ')}
+    `).all(...evidenceParams) as ProgressEvidenceRow[];
+
+    return {
+      links: mappedLinks,
+      agentSessions,
+      evidence: evidence.map(rowToProgressEvidence),
+    };
+  }
+
+  private findAgentSessionsByIds(ids: string[]): AgentSession[] {
+    const uniqueIds = [...new Set(ids)].filter(Boolean);
+    if (uniqueIds.length === 0) return [];
+
+    const db = getDatabase();
+    const rows = db.prepare(`
+      SELECT * FROM agent_sessions
+      WHERE id IN (${uniqueIds.map(() => '?').join(', ')})
+    `).all(...uniqueIds) as AgentSessionRow[];
+    return rows.map(rowToAgentSession);
   }
 }
 

--- a/src/web/api/routes/work-items.ts
+++ b/src/web/api/routes/work-items.ts
@@ -1,10 +1,17 @@
 import { Hono } from 'hono';
 import type { Context } from 'hono';
-import { workItemRepository } from '../../../infrastructure/database/index.js';
 import {
+  workItemEvidenceRepository,
+  workItemRepository,
+} from '../../../infrastructure/database/index.js';
+import {
+  DEFAULT_WORKBOARD_STALE_WINDOW_HOURS,
+  buildWorkboardProjection,
   isWorkItemKind,
   isWorkItemStatus,
   isWorkItemStatusSource,
+  type WorkboardItemProjection,
+  type WorkboardProjection,
   type WorkItem,
   type WorkItemCreateInput,
   type WorkItemFilters,
@@ -25,6 +32,42 @@ function serializeWorkItem(item: WorkItem) {
     createdAt: item.createdAt.toISOString(),
     updatedAt: item.updatedAt.toISOString(),
     completedAt: item.completedAt?.toISOString(),
+  };
+}
+
+function serializeWorkboardProjection(projection: WorkboardProjection) {
+  return {
+    now: projection.now.map(serializeWorkboardItem),
+    waiting: projection.waiting.map(serializeWorkboardItem),
+    stale: projection.stale.map(serializeWorkboardItem),
+    done: projection.done.map(serializeWorkboardItem),
+    suggestions: projection.suggestions.map(serializeWorkboardItem),
+    staleWindowHours: projection.staleWindowHours,
+    generatedAt: projection.generatedAt.toISOString(),
+  };
+}
+
+function serializeWorkboardItem(projection: WorkboardItemProjection) {
+  return {
+    ...projection,
+    item: serializeWorkItem(projection.item),
+    lastActivityAt: projection.lastActivityAt?.toISOString(),
+    waitingOnSession: projection.waitingOnSession
+      ? serializeWorkboardSession(projection.waitingOnSession)
+      : undefined,
+    acceptedSessions: projection.acceptedSessions.map(serializeWorkboardSession),
+    suggestions: projection.suggestions.map((suggestion) => ({
+      ...suggestion,
+      agentSession: serializeWorkboardSession(suggestion.agentSession),
+      suggestedAt: suggestion.suggestedAt.toISOString(),
+    })),
+  };
+}
+
+function serializeWorkboardSession(session: WorkboardItemProjection['acceptedSessions'][number]) {
+  return {
+    ...session,
+    lastActiveAt: session.lastActiveAt.toISOString(),
   };
 }
 
@@ -101,6 +144,19 @@ function parseStatusSource(value: unknown, fallback?: WorkItemStatusSource): {
   return { value };
 }
 
+function parseStaleWindowHours(raw: string | undefined): { value?: number; error?: string } {
+  if (raw == null || raw.trim() === '') {
+    return { value: DEFAULT_WORKBOARD_STALE_WINDOW_HOURS };
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 24 * 365) {
+    return { error: 'staleWindowHours must be between 0 and 8760' };
+  }
+
+  return { value: parsed };
+}
+
 app.get('/', (c) => {
   try {
     const filters: WorkItemFilters = {};
@@ -129,13 +185,26 @@ app.get('/', (c) => {
       filters.projectRoot = projectRoot;
     }
     filters.includeArchived = c.req.query('includeArchived') === 'true';
+    const staleWindowHours = parseStaleWindowHours(c.req.query('staleWindowHours'));
+    if (staleWindowHours.error) {
+      return c.json({ success: false, error: staleWindowHours.error }, 400);
+    }
 
     const items = workItemRepository.findAll(filters);
+    const evidence = workItemEvidenceRepository.findProjectionDataForWorkItems(
+      items.map((item) => item.id)
+    );
+    const workboard = buildWorkboardProjection({
+      items,
+      ...evidence,
+      staleWindowHours: staleWindowHours.value,
+    });
     return c.json({
       success: true,
       data: {
         items: items.map(serializeWorkItem),
         stats: workItemRepository.getOverviewStats(),
+        workboard: serializeWorkboardProjection(workboard),
       },
     });
   } catch (error) {

--- a/src/web/client/src/components/WorkItemsPanel/WorkItemsPanel.module.css
+++ b/src/web/client/src/components/WorkItemsPanel/WorkItemsPanel.module.css
@@ -136,6 +136,71 @@
   gap: var(--space-md);
 }
 
+.workboard {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(220px, 1fr));
+  gap: var(--space-md);
+  align-items: start;
+}
+
+.boardSection,
+.suggestionSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  min-width: 0;
+}
+
+.suggestionSection {
+  grid-column: 1 / -1;
+}
+
+.sectionHeader {
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  color: var(--text-bright);
+}
+
+.sectionHeader h3 {
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+}
+
+.sectionHeader span {
+  min-width: 28px;
+  height: 24px;
+  padding: 0 var(--space-xs);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+}
+
+.boardItems {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.boardEmpty {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-md);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+}
+
 .itemCard {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -182,11 +247,19 @@
 .badge.active { color: var(--success); border-color: var(--success); }
 .badge.blocked { color: var(--warning); border-color: var(--warning); }
 .badge.done { color: var(--secondary); border-color: var(--secondary); }
+.bucketBadge { text-transform: uppercase; }
 
 .itemBody {
   margin-top: var(--space-sm);
   color: var(--text);
   font-size: var(--text-sm);
+  overflow-wrap: anywhere;
+}
+
+.progressLine {
+  margin-top: var(--space-sm);
+  color: var(--primary);
+  font-size: var(--text-xs);
   overflow-wrap: anywhere;
 }
 
@@ -201,6 +274,27 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.sessionRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin-top: var(--space-sm);
+}
+
+.sessionPill,
+.suggestionPill {
+  padding: 2px var(--space-sm);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+}
+
+.suggestionPill {
+  color: var(--warning);
+  border-color: var(--warning);
 }
 
 .actions {
@@ -251,7 +345,7 @@
 
   .segmented {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr);
     width: 100%;
   }
 
@@ -260,7 +354,8 @@
   }
 
   .captureForm,
-  .itemCard {
+  .itemCard,
+  .workboard {
     grid-template-columns: 1fr;
   }
 

--- a/src/web/client/src/components/WorkItemsPanel/WorkItemsPanel.tsx
+++ b/src/web/client/src/components/WorkItemsPanel/WorkItemsPanel.tsx
@@ -1,12 +1,19 @@
 import { FormEvent, useMemo, useState } from 'react'
 import { Button } from '@/components/Button'
 import { useWorkItems } from '@/hooks'
-import type { WorkItem, WorkItemKind, WorkItemStatus } from '@/types'
+import type {
+  WorkItem,
+  WorkItemKind,
+  WorkItemStatus,
+  WorkboardData,
+  WorkboardItemProjection,
+} from '@/types'
 import styles from './WorkItemsPanel.module.css'
 
-type WorkItemsView = 'overview' | 'todo' | 'inbox'
+type WorkItemsView = 'workboard' | 'overview' | 'todo' | 'inbox'
 
 const VIEW_LABELS: Array<{ id: WorkItemsView; label: string }> = [
+  { id: 'workboard', label: 'Workboard' },
   { id: 'overview', label: 'Overview' },
   { id: 'todo', label: 'Todo' },
   { id: 'inbox', label: 'Inbox' },
@@ -36,6 +43,7 @@ export function WorkItemsPanel({ token }: WorkItemsPanelProps) {
   const {
     items,
     stats,
+    workboard,
     loading,
     saving,
     error,
@@ -44,7 +52,7 @@ export function WorkItemsPanel({ token }: WorkItemsPanelProps) {
     updateItem,
     deleteItem,
   } = useWorkItems(token)
-  const [view, setView] = useState<WorkItemsView>('overview')
+  const [view, setView] = useState<WorkItemsView>('workboard')
   const [title, setTitle] = useState('')
   const [kind, setKind] = useState<WorkItemKind>('todo')
   const [status, setStatus] = useState<WorkItemStatus>('inbox')
@@ -187,64 +195,210 @@ export function WorkItemsPanel({ token }: WorkItemsPanelProps) {
         </Button>
       </form>
 
-      {visibleItems.length === 0 ? (
+      {view === 'workboard' ? (
+        <WorkboardView
+          workboard={workboard}
+          setItemStatus={setItemStatus}
+          deleteItem={deleteItem}
+        />
+      ) : visibleItems.length === 0 ? (
         <div className={styles.emptyState}>No work items</div>
       ) : (
         <div className={styles.itemList}>
           {visibleItems.map((item) => (
-            <article key={item.id} className={styles.itemCard}>
-              <div className={styles.itemMain}>
-                <div className={styles.itemHeader}>
-                  <h3 className={styles.itemTitle}>{item.title}</h3>
-                  <div className={styles.badges}>
-                    <span className={`${styles.badge} ${styles[item.status]}`}>
-                      {STATUS_LABELS[item.status]}
-                    </span>
-                    <span className={styles.badge}>{KIND_LABELS[item.kind]}</span>
-                  </div>
-                </div>
-                {item.body && <p className={styles.itemBody}>{item.body}</p>}
-                <div className={styles.metaRow}>
-                  {item.area && <span>{item.area}</span>}
-                  {item.projectRoot && <span className={styles.path}>{item.projectRoot}</span>}
-                  {item.statusSource === 'accepted_agent_suggestion' && <span>Accepted suggestion</span>}
-                </div>
-              </div>
-              <div className={styles.actions}>
-                {item.status !== 'planned' && item.status !== 'done' && item.status !== 'archived' && (
-                  <button type="button" onClick={() => setItemStatus(item, 'planned')} title="Plan">
-                    P
-                  </button>
-                )}
-                {item.status !== 'active' && item.status !== 'done' && item.status !== 'archived' && (
-                  <button type="button" onClick={() => setItemStatus(item, 'active')} title="Start">
-                    S
-                  </button>
-                )}
-                {item.status !== 'blocked' && item.status !== 'done' && item.status !== 'archived' && (
-                  <button type="button" onClick={() => setItemStatus(item, 'blocked')} title="Block">
-                    B
-                  </button>
-                )}
-                {item.status !== 'done' && item.status !== 'archived' && (
-                  <button type="button" onClick={() => setItemStatus(item, 'done')} title="Done">
-                    D
-                  </button>
-                )}
-                {item.status !== 'archived' && (
-                  <button type="button" onClick={() => setItemStatus(item, 'archived')} title="Archive">
-                    A
-                  </button>
-                )}
-                <button type="button" onClick={() => deleteItem(item.id)} title="Delete">
-                  X
-                </button>
-              </div>
-            </article>
+            <WorkItemCard
+              key={item.id}
+              item={item}
+              setItemStatus={setItemStatus}
+              deleteItem={deleteItem}
+            />
           ))}
         </div>
       )}
     </div>
+  )
+}
+
+function WorkboardView({
+  workboard,
+  setItemStatus,
+  deleteItem,
+}: {
+  workboard: WorkboardData;
+  setItemStatus: (item: WorkItem, nextStatus: WorkItemStatus) => void;
+  deleteItem: (id: string) => void;
+}) {
+  return (
+    <div className={styles.workboard}>
+      <WorkboardSection
+        title="Now"
+        items={workboard.now}
+        setItemStatus={setItemStatus}
+        deleteItem={deleteItem}
+      />
+      <WorkboardSection
+        title="Waiting"
+        items={workboard.waiting}
+        setItemStatus={setItemStatus}
+        deleteItem={deleteItem}
+      />
+      <WorkboardSection
+        title="Stale"
+        items={workboard.stale}
+        setItemStatus={setItemStatus}
+        deleteItem={deleteItem}
+      />
+      <WorkboardSection
+        title="Done"
+        items={workboard.done}
+        setItemStatus={setItemStatus}
+        deleteItem={deleteItem}
+      />
+      {workboard.suggestions.length > 0 && (
+        <section className={styles.suggestionSection}>
+          <div className={styles.sectionHeader}>
+            <h3>Suggestions</h3>
+            <span>{workboard.suggestions.length}</span>
+          </div>
+          <div className={styles.itemList}>
+            {workboard.suggestions.map((projection) => (
+              <WorkItemCard
+                key={projection.item.id}
+                item={projection.item}
+                projection={projection}
+                setItemStatus={setItemStatus}
+                deleteItem={deleteItem}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}
+
+function WorkboardSection({
+  title,
+  items,
+  setItemStatus,
+  deleteItem,
+}: {
+  title: string;
+  items: WorkboardItemProjection[];
+  setItemStatus: (item: WorkItem, nextStatus: WorkItemStatus) => void;
+  deleteItem: (id: string) => void;
+}) {
+  return (
+    <section className={styles.boardSection}>
+      <div className={styles.sectionHeader}>
+        <h3>{title}</h3>
+        <span>{items.length}</span>
+      </div>
+      {items.length === 0 ? (
+        <div className={styles.boardEmpty}>No items</div>
+      ) : (
+        <div className={styles.boardItems}>
+          {items.map((projection) => (
+            <WorkItemCard
+              key={projection.item.id}
+              item={projection.item}
+              projection={projection}
+              setItemStatus={setItemStatus}
+              deleteItem={deleteItem}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function WorkItemCard({
+  item,
+  projection,
+  setItemStatus,
+  deleteItem,
+}: {
+  item: WorkItem;
+  projection?: WorkboardItemProjection;
+  setItemStatus: (item: WorkItem, nextStatus: WorkItemStatus) => void;
+  deleteItem: (id: string) => void;
+}) {
+  return (
+    <article className={styles.itemCard}>
+      <div className={styles.itemMain}>
+        <div className={styles.itemHeader}>
+          <h3 className={styles.itemTitle}>{item.title}</h3>
+          <div className={styles.badges}>
+            <span className={`${styles.badge} ${styles[item.status]}`}>
+              {STATUS_LABELS[item.status]}
+            </span>
+            <span className={styles.badge}>{KIND_LABELS[item.kind]}</span>
+            {projection?.bucket && (
+              <span className={`${styles.badge} ${styles.bucketBadge}`}>
+                {projection.bucket}
+              </span>
+            )}
+          </div>
+        </div>
+        {item.body && <p className={styles.itemBody}>{item.body}</p>}
+        {projection?.progressSummary && (
+          <p className={styles.progressLine}>{projection.progressSummary}</p>
+        )}
+        <div className={styles.metaRow}>
+          {item.area && <span>{item.area}</span>}
+          {item.projectRoot && <span className={styles.path}>{item.projectRoot}</span>}
+          {projection?.lastActivityAt && (
+            <span>{new Date(projection.lastActivityAt).toLocaleString()}</span>
+          )}
+          {item.statusSource === 'accepted_agent_suggestion' && <span>Accepted suggestion</span>}
+        </div>
+        {projection && (projection.acceptedSessions.length > 0 || projection.suggestions.length > 0) && (
+          <div className={styles.sessionRow}>
+            {projection.acceptedSessions.map((session) => (
+              <span key={session.id} className={styles.sessionPill}>
+                {session.runtimeId} / {session.status}
+              </span>
+            ))}
+            {projection.suggestions.map((suggestion) => (
+              <span key={suggestion.linkId} className={styles.suggestionPill}>
+                Suggestion / {suggestion.agentSession.runtimeId} / {suggestion.agentSession.status}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className={styles.actions}>
+        {item.status !== 'planned' && item.status !== 'done' && item.status !== 'archived' && (
+          <button type="button" onClick={() => setItemStatus(item, 'planned')} title="Plan">
+            P
+          </button>
+        )}
+        {item.status !== 'active' && item.status !== 'done' && item.status !== 'archived' && (
+          <button type="button" onClick={() => setItemStatus(item, 'active')} title="Start">
+            S
+          </button>
+        )}
+        {item.status !== 'blocked' && item.status !== 'done' && item.status !== 'archived' && (
+          <button type="button" onClick={() => setItemStatus(item, 'blocked')} title="Block">
+            B
+          </button>
+        )}
+        {item.status !== 'done' && item.status !== 'archived' && (
+          <button type="button" onClick={() => setItemStatus(item, 'done')} title="Done">
+            D
+          </button>
+        )}
+        {item.status !== 'archived' && (
+          <button type="button" onClick={() => setItemStatus(item, 'archived')} title="Archive">
+            A
+          </button>
+        )}
+        <button type="button" onClick={() => deleteItem(item.id)} title="Delete">
+          X
+        </button>
+      </div>
+    </article>
   )
 }
 

--- a/src/web/client/src/hooks/useWorkItems.ts
+++ b/src/web/client/src/hooks/useWorkItems.ts
@@ -5,6 +5,7 @@ import type {
   WorkItemCreateInput,
   WorkItemOverviewStats,
   WorkItemUpdateInput,
+  WorkboardData,
 } from '@/types'
 
 const EMPTY_STATS: WorkItemOverviewStats = {
@@ -21,9 +22,20 @@ const EMPTY_STATS: WorkItemOverviewStats = {
   projectTask: 0,
 }
 
+const EMPTY_WORKBOARD: WorkboardData = {
+  now: [],
+  waiting: [],
+  stale: [],
+  done: [],
+  suggestions: [],
+  staleWindowHours: 72,
+  generatedAt: new Date(0).toISOString(),
+}
+
 export interface UseWorkItemsReturn {
   items: WorkItem[]
   stats: WorkItemOverviewStats
+  workboard: WorkboardData
   loading: boolean
   saving: boolean
   error: string | null
@@ -36,6 +48,7 @@ export interface UseWorkItemsReturn {
 export function useWorkItems(_token: string): UseWorkItemsReturn {
   const [items, setItems] = useState<WorkItem[]>([])
   const [stats, setStats] = useState<WorkItemOverviewStats>(EMPTY_STATS)
+  const [workboard, setWorkboard] = useState<WorkboardData>(EMPTY_WORKBOARD)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -47,6 +60,7 @@ export function useWorkItems(_token: string): UseWorkItemsReturn {
     if (response.success && response.data) {
       setItems(response.data.items)
       setStats(response.data.stats)
+      setWorkboard(response.data.workboard ?? EMPTY_WORKBOARD)
       setError(null)
     } else {
       setError(response.error || 'Failed to load work items')
@@ -104,6 +118,7 @@ export function useWorkItems(_token: string): UseWorkItemsReturn {
   return {
     items,
     stats,
+    workboard,
     loading,
     saving,
     error,

--- a/src/web/client/src/types/work-item.ts
+++ b/src/web/client/src/types/work-item.ts
@@ -1,6 +1,7 @@
 export type WorkItemStatus = 'inbox' | 'planned' | 'active' | 'blocked' | 'done' | 'archived'
 export type WorkItemKind = 'todo' | 'idea' | 'note' | 'project_task'
 export type WorkItemStatusSource = 'user' | 'accepted_agent_suggestion'
+export type WorkboardBucketId = 'now' | 'waiting' | 'stale' | 'done'
 
 export interface WorkItem {
   id: string
@@ -34,6 +35,41 @@ export interface WorkItemOverviewStats {
 export interface WorkItemsData {
   items: WorkItem[]
   stats: WorkItemOverviewStats
+  workboard: WorkboardData
+}
+
+export interface WorkboardAgentSessionSummary {
+  id: string
+  runtimeId: string
+  title: string
+  status: string
+  lastActiveAt: string
+}
+
+export interface WorkboardSuggestion {
+  linkId: string
+  agentSession: WorkboardAgentSessionSummary
+  suggestedAt: string
+}
+
+export interface WorkboardItemProjection {
+  item: WorkItem
+  bucket?: WorkboardBucketId
+  progressSummary?: string
+  lastActivityAt?: string
+  waitingOnSession?: WorkboardAgentSessionSummary
+  acceptedSessions: WorkboardAgentSessionSummary[]
+  suggestions: WorkboardSuggestion[]
+}
+
+export interface WorkboardData {
+  now: WorkboardItemProjection[]
+  waiting: WorkboardItemProjection[]
+  stale: WorkboardItemProjection[]
+  done: WorkboardItemProjection[]
+  suggestions: WorkboardItemProjection[]
+  staleWindowHours: number
+  generatedAt: string
 }
 
 export interface WorkItemCreateInput {


### PR DESCRIPTION
## Summary
- add deterministic Workboard projection for Now, Waiting, Stale, Done, and pending suggestions
- return Workboard data from the work items API without mutating WorkItem status
- render Workboard buckets and suggestion markers in the Work tab

## Verification
- git diff --check
- bun test src/__tests__/workboard.projection.test.ts src/__tests__/work-items.route.test.ts src/__tests__/work-item-evidence.route.test.ts
- bun run typecheck
- bun test
- bun run build
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH44 skipped: checks/check_workflow.py is missing in this checkout

Closes #50