### PR TITLE
Use runtime-neutral product copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Keepline
 
-### Never lose your Codex or Claude Code work again.
+### Never lose your local agent runtime work again.
 
 **The command center for agent CLI power users**
 
@@ -25,7 +25,7 @@
 
 ## The Problem
 
-You're deep in a coding session with Codex or Claude Code. Everything is going great. Then...
+You're deep in a coding session with one or more local agent runtimes. Everything is going great. Then...
 
 - **Terminal crashes** — hours of context, gone
 - **Multiple sessions** — which one was working on the auth bug?
@@ -34,7 +34,7 @@ You're deep in a coding session with Codex or Claude Code. Everything is going g
 
 ## The Solution
 
-**Keepline** monitors your Codex and Claude Code sessions in real-time, automatically recovers crashed sessions, tracks costs where supported, and preserves context across iterations.
+**Keepline** monitors local agent runtime sessions in real time, automatically recovers crashed work where supported, tracks costs where supported, and preserves context across iterations. Codex and Claude Code are the first supported runtime adapters.
 
 For the implementation details behind the rename and Codex detection, see [Keepline Rebrand and Codex Detection Spec](docs/KEEPLINE_REBRAND_AND_CODEX_DETECTION_SPEC.md).
 
@@ -122,7 +122,7 @@ This removes the quarantine attribute that macOS adds to downloaded files.
 
 ### Real-time Session Monitoring
 
-Monitor Codex and Claude Code sessions across your system. See status, current file, last tool, and activity at a glance.
+Monitor local agent runtime sessions across your system. See runtime, status, current file, last tool, and activity at a glance.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -380,7 +380,7 @@ bun test             # Run tests
 
 <div align="center">
 
-**Built for Codex and Claude Code power users**
+**Built for local agent runtime power users**
 
 [GitHub](https://github.com/majiayu000/claude-hub) | [npm](https://www.npmjs.com/package/keepline) | [Documentation](https://keepline.dev)
 

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -18,7 +18,7 @@
 
 | 功能 | 描述 | 状态 |
 |------|------|------|
-| 会话监控 | 扫描并追踪 Claude Code 进程状态 | ✅ |
+| 会话监控 | 扫描并追踪本地 agent runtime 进程和会话状态 | ✅ |
 | 状态分类 | running/waiting/idle/lost/completed | ✅ |
 | Web UI | React 前端实时监控界面 | ✅ |
 | 会话恢复 | 恢复丢失的会话 | ✅ |

--- a/docs/KEEPLINE_REBRAND_AND_CODEX_DETECTION_SPEC.md
+++ b/docs/KEEPLINE_REBRAND_AND_CODEX_DETECTION_SPEC.md
@@ -2,7 +2,7 @@
 
 ## 背景
 
-项目原名为 Claude Hub，核心能力是扫描 Claude Code 会话、进程、成本和恢复状态。当前目标是把产品主品牌升级为 Keepline，并新增 Codex CLI 会话检测与恢复。此版本不保留旧品牌兼容入口、旧品牌环境变量或旧品牌数据目录 fallback。
+项目原名为 Claude Hub，历史能力从 Claude Code 会话、进程、成本和恢复状态扫描起步。当前目标是把产品主品牌升级为 Keepline，并新增 Codex CLI 会话检测与恢复。此版本不保留旧品牌兼容入口、旧品牌环境变量或旧品牌数据目录 fallback。
 
 GitHub 跟踪 issue: https://github.com/majiayu000/claude-hub/issues/34
 

--- a/docs/PROJECTS_VIEW_DESIGN.md
+++ b/docs/PROJECTS_VIEW_DESIGN.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-Add a new "Projects" tab to display Claude Code sessions grouped by project/directory, providing a bird's-eye view of all active projects and their status.
+Add a new "Projects" tab to display local agent runtime sessions grouped by project/directory, providing a bird's-eye view of all active projects and their status.
 
 ## User Story
 
-As a developer using multiple Claude Code sessions across different projects, I want to see all my projects at a glance, understand which ones are active, and quickly identify what each project is currently working on.
+As a developer using multiple local agent runtime sessions across different projects, I want to see all my projects at a glance, understand which ones are active, and quickly identify what each project is currently working on.
 
 ## Design: Project Cards Grid + Stats Overview
 

--- a/docs/architecture/KEEPLINE_V2_ARCHITECTURE.md
+++ b/docs/architecture/KEEPLINE_V2_ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Keepline Architecture Design
 
-> **目标**: 从「会话监控工具」升级为「Claude Code 自动化平台」
+> **目标**: 从「会话监控工具」升级为「本地 Agent Runtime 总控层」
 > **设计原则**: 接力赛模式 | 容错优先 | 人类在循环中 | 渐进增强
 
 ---

--- a/docs/architecture/QUICK_REFERENCE.md
+++ b/docs/architecture/QUICK_REFERENCE.md
@@ -5,7 +5,7 @@
 ```
 ┌──────────────────────────────────────────────────────────────────┐
 │                      KEEPLINE V2                                   │
-│              Claude Code 自动化平台                               │
+│              本地 Agent Runtime 总控层                            │
 ├──────────────────────────────────────────────────────────────────┤
 │                                                                  │
 │    ┌──────┐  ┌──────┐  ┌──────┐  ┌──────┐  ┌──────┐            │
@@ -36,7 +36,7 @@
 │    ┌─────────────────────────────────────────────────────┐      │
 │    │            INFRASTRUCTURE LAYER                      │      │
 │    │                                                      │      │
-│    │  SQLite | EventBus | ProcessScanner | ClaudeParser  │      │
+│    │  SQLite | EventBus | ProcessScanner | RuntimeAdapter │      │
 │    │  HookServer | Terminal | Daemon | HTTP/WebSocket    │      │
 │    └─────────────────────────────────────────────────────┘      │
 │                                                                  │
@@ -66,7 +66,7 @@
 ```
 ps + lsof → ProcessScanner → SessionService → SQLite
      ↓
-Claude JSONL → ClaudeParser → SessionService → Events
+Runtime logs → RuntimeAdapter → SessionService → Events
 ```
 
 ### 2. Auto Recovery Flow

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "keepline",
   "version": "1.0.0",
-  "description": "The command center for Codex and Claude Code sessions - Never lose your work again",
+  "description": "The command center for local agent runtime sessions - Never lose your work again",
   "author": "Keepline Contributors",
   "license": "MIT",
   "type": "module",

--- a/specs/project-workspaces/PRODUCT.md
+++ b/specs/project-workspaces/PRODUCT.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Project Workspaces makes project identity a first-class way to monitor agent work. A user with many Warp panes, Claude Code sessions, and Codex sessions should be able to open Keepline and immediately see which projects are active, which agent client is running in each project, and what needs attention.
+Project Workspaces makes project identity a first-class way to monitor agent work. A user with many Warp panes and local agent runtime sessions should be able to open Keepline and immediately see which projects are active, which runtime adapter is represented in each project, and what needs attention.
 
 This extends the existing Projects tab from a directory card view into a reliable project workspace surface. It is inspired by stash's project-first workboard, but Keepline remains a session monitor and recovery dashboard, not a todo system.
 

--- a/specs/project-workspaces/TECH.md
+++ b/specs/project-workspaces/TECH.md
@@ -4,7 +4,7 @@ Product spec: `specs/project-workspaces/PRODUCT.md`
 
 ## Context
 
-- `README.md:37` - Keepline monitors Codex and Claude Code sessions in real time.
+- `README.md:37` - Keepline monitors local agent runtime sessions in real time, with Codex and Claude Code as supported runtime adapters.
 - `README.md:57` - The README already promises project overview as "Aggregated by project."
 - `docs/PROJECTS_VIEW_DESIGN.md:5` - The existing design introduces a Projects tab grouped by project/directory.
 - `docs/PROJECTS_VIEW_DESIGN.md:69` - The current project model is path, name, sessions, stats, currentTask, and lastActiveAt.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,7 +22,7 @@ export function registerCommands(program: Command): void {
   program
     .command('list')
     .alias('ls')
-    .description('List all Codex and Claude Code sessions')
+    .description('List all agent runtime sessions')
     .option('-s, --status <status>', 'Filter by status (running,waiting,idle,lost,completed)')
     .option('-d, --directory <dir>', 'Filter by directory')
     .option('-l, --limit <n>', 'Limit results')
@@ -34,7 +34,7 @@ export function registerCommands(program: Command): void {
   program
     .command('watch')
     .alias('w')
-    .description('Live monitor Codex and Claude Code sessions')
+    .description('Live monitor agent runtime sessions')
     .option('-i, --interval <seconds>', 'Refresh interval in seconds')
     .action(watchCommand);
 
@@ -101,7 +101,7 @@ export function registerCommands(program: Command): void {
   // Sync (manual trigger)
   program
     .command('sync')
-    .description('Manually sync Codex and Claude Code sessions')
+    .description('Manually sync agent runtime sessions')
     .action(async () => {
       const { runMigrations } = await import('../db/migrations.js');
       const { syncSessions } = await import('../services/session.service.js');

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 /**
  * Keepline - The command center for agent coding sessions
  *
- * Never lose your Codex or Claude Code work again.
+ * Never lose your local agent runtime work again.
  * Real-time monitoring, automatic recovery, cost tracking,
  * and cross-session memory for agent CLI power users.
  */
@@ -26,7 +26,7 @@ const program = new Command();
 program
   .name('keepline')
   .version('1.0.0')
-  .description('The command center for Codex and Claude Code sessions - Never lose your work again');
+  .description('The command center for local agent runtime sessions - Never lose your work again');
 
 // Register all commands
 registerCommands(program);

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -125,7 +125,7 @@ export class SessionService {
     return [...lost, ...waiting];
   }
 
-  /** Sync Codex and Claude Code sessions with running processes */
+  /** Sync runtime adapter sessions with running processes */
   async syncSessions(options: SyncOptions = {}): Promise<{
     discovered: number;
     updated: number;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -41,7 +41,7 @@ export function App({ sessions, stats }: AppProps): React.ReactElement {
         <Gradient name="pastel">
           <Text bold>◆ KEEPLINE</Text>
         </Gradient>
-        <Text color="gray"> — Codex and Claude session control center</Text>
+        <Text color="gray"> — agent runtime session control center</Text>
       </Box>
 
       {/* Stats bar */}

--- a/src/ui/views/DashboardView.tsx
+++ b/src/ui/views/DashboardView.tsx
@@ -76,7 +76,7 @@ export function DashboardView({ sessions, stats }: Props): React.ReactElement {
         <Text color="#bb9af7" bold>╭─ </Text>
         <Text color="#7dcfff" bold>KEEPLINE</Text>
         <Text color="#bb9af7" bold> ─╮</Text>
-        <Text color="#565f89"> Codex and Claude session control center</Text>
+        <Text color="#565f89"> agent runtime session control center</Text>
       </Box>
 
       {/* Stats Row */}

--- a/src/web/client/index.html
+++ b/src/web/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Monitor, recover, and manage Codex and Claude Code sessions" />
+    <meta name="description" content="Monitor, recover, and manage local agent runtime sessions" />
     <meta name="theme-color" content="#0a0a0f" />
     <title>Keepline</title>
     <!-- Preconnect to API -->

--- a/src/web/client/src/components/Header/Header.tsx
+++ b/src/web/client/src/components/Header/Header.tsx
@@ -35,7 +35,7 @@ export const Header = memo(function Header({
     <header className={styles.header} role="banner">
       <div className={styles.brand}>
         <h1 className={styles.title}>KEEPLINE</h1>
-        <span className={styles.subtitle}>Codex and Claude session control center</span>
+        <span className={styles.subtitle}>Agent runtime session control center</span>
       </div>
       <div className={styles.actions}>
         <ConnectionStatus status={connectionStatus} />

--- a/src/web/client/src/components/ProjectsGrid/ProjectsGrid.tsx
+++ b/src/web/client/src/components/ProjectsGrid/ProjectsGrid.tsx
@@ -18,7 +18,7 @@ export const ProjectsGrid = memo(function ProjectsGrid({
         <span className={styles.emptyIcon}>#</span>
         <span className={styles.emptyText}>No projects found</span>
         <span className={styles.emptyHint}>
-          Start a Codex or Claude Code session to see projects here
+          Start a local agent runtime session to see projects here
         </span>
       </div>
     )

--- a/src/web/client/src/utils/export.ts
+++ b/src/web/client/src/utils/export.ts
@@ -68,7 +68,7 @@ export function exportToCSV(sessions: Session[], filename = 'sessions'): void {
  */
 export function exportToMarkdown(sessions: Session[], filename = 'sessions'): void {
   const lines: string[] = [
-    '# Claude Code Sessions Report',
+    '# Agent Runtime Sessions Report',
     '',
     `> Exported at: ${new Date().toLocaleString()}`,
     `> Total sessions: ${sessions.length}`,


### PR DESCRIPTION
## Summary
- update README/package/CLI/UI copy to describe Keepline as a local agent runtime hub
- keep Codex and Claude Code as supported runtime adapters, not the product boundary
- clear the remaining #44 UI/docs boundary-copy acceptance item, including older docs/spec/export copy found during merge review

## Verification
- rg -n "Claude Code process state|核心能力是扫描 Claude Code|Claude Code Sessions Report|Claude Code sessions|Claude Code automation platform|Codex and Claude Code sessions|Codex or Claude Code|Claude session control center|Built for Codex|Start a Codex|monitors Codex and Claude" README.md package.json docs specs src || true
- git diff --check
- bun run typecheck
- bun test src/__tests__/runtime.registry.test.ts src/__tests__/recovery-security.test.ts src/__tests__/workboard.projection.test.ts src/__tests__/work-items.route.test.ts
- bun test
- bun run build

Closes #44