### PR TITLE
feat: add deterministic attention overview

### DIFF
--- a/specs/GH62/product.md
+++ b/specs/GH62/product.md
@@ -1,0 +1,77 @@
+# Agent Orchestrator Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/62
+
+## Summary
+
+Agent Orchestrator 让 Keepline 从“会话列表”升级为本地 agent runtime 的指挥视图。用户同时运行多个 Claude Code、Codex、未来 Cursor 或其他 agent session 时，应该能先看到“现在最该处理什么”，再进入具体 session、memory、work item 或 recovery 流程。
+
+第一阶段不把 LLM 摘要作为必要条件。MVP 先用现有 session、usage、memory、workboard 和 activity 数据生成 deterministic Attention Queue，避免因为模型不可用、隐私未授权或 transcript 缺失而让核心体验失效。
+
+## User Problem
+
+1. 用户同时运行 3-10 个以上本地 agent sessions 时，终端和 dashboard 只能告诉用户“有哪些会话”，不能告诉用户“哪个最该看”。
+2. waiting、lost、高成本、长时间 idle、blocked work item 等信号分散在不同界面，用户需要手动综合判断。
+3. 直接引入云模型摘要会带来隐私和可靠性风险；本地模型不可用时不能让 Orchestrator 视图空白或误导。
+4. 现有 Memory 和 Workboard 已经包含进度、handoff 和 blocked 信号，但缺少统一的 prioritization 层。
+
+## Product Behavior
+
+1. `keepline overview` 显示一个全局 Attention Queue，默认隐藏 completed sessions，按需要人工处理的优先级排序。
+2. 排序必须 deterministic。相同输入产生相同 ranking、score、reason 列表和 recommended action。
+3. Queue item 必须清楚标注来源：session status、usage/cost、memory、workboard、activity freshness 或 digest。
+4. 没有数据就显示空白或低置信度，不得编造进度、阻塞点或完成状态。
+5. waiting session 优先级高于 lost/recoverable session；lost/recoverable 高于高成本 session；高成本高于 stale/idle session。
+6. 高成本信号只来自 persisted usage data。没有 usage data 时不能猜测成本。
+7. Memory 增强字段可以提供 `summary`、`nextActions`、`blockers`，但这些字段缺失时 Overview 仍可工作。
+8. Session Digest 的第一版必须可区分 deterministic digest 和 model-generated digest。模型摘要不可覆盖用户手动 memory 数据。
+9. 本地模型摘要默认本地优先；云模型必须显式配置，且 transcript 内容默认不离开本机。
+10. 摘要生成失败必须显示 stale/error 状态或保留旧摘要，不得 warning 后静默显示假新摘要。
+11. Web Orchestrator 视图应复用同一 Attention Queue API，不在前端重新实现排序规则。
+12. 所有新 API 和 CLI 行为必须保持 runtime-neutral：Codex、Claude Code、未来 Cursor 都是 runtime/client 数据源，不是产品边界。
+
+## MVP Scope
+
+- 新增 deterministic Attention Queue 服务。
+- 新增 `keepline overview` CLI。
+- 新增只读 `GET /api/orchestrator/overview` API。
+- 使用现有 sessions、usage stats、memory summaries 和 activity timestamps。
+- 添加 SpecRail artifacts：`specs/GH62/product.md`、`tech.md`、`tasks.md`。
+- 新增 focused tests 覆盖排序、reason、CLI/API contract。
+
+## Follow-Up Scope
+
+- Session Digest persistence and deterministic generator.
+- Local model summarizer provider for Ollama / LM Studio.
+- Web Orchestrator tab or Workboard integration.
+- Semantic search and timeline playback.
+- Cursor runtime adapter only after stable source contract is selected.
+
+## Non-Goals
+
+- 不在第一阶段调用云模型或上传 transcript。
+- 不实现 Cursor adapter。
+- 不重写现有 Sessions、Memory、WorkItems 或 Projects UI。
+- 不让 agent 自动改变 WorkItem status。
+- 不自动 resume、stop、merge、close 或删除任何 session。
+- 不把 Overview ranking 作为 billing 或 hard enforcement 机制。
+
+## Acceptance Criteria
+
+1. `keepline overview` 在本地数据库有 sessions 时输出 Attention Queue。
+2. `GET /api/orchestrator/overview` 返回 `{ success, data: { generatedAt, items, stats } }`。
+3. 每个 item 至少包含 `sessionId`、`client`、`status`、`title`、`directory`、`score`、`rank`、`reasons`、`recommendedAction`、`lastActiveAt`。
+4. waiting session 的 rank 高于 lost、high-cost、idle 和 completed session。
+5. completed sessions 默认不进入 queue，除非调用方显式包含。
+6. usage cost 只在 `usageStats.totalCost` 存在时产生 reason。
+7. idle/stale reason 只根据 `lastActiveAt` 和配置阈值产生。
+8. 输出 reason 不解析 free-text 来推断 done 或 blocked。
+9. API route 需要沿用现有 auth middleware。
+10. 新增代码不破坏 `list`、`watch`、`recover`、`memory`、`work-items`、`projects` 流程。
+11. 验证命令通过：`bun run typecheck`、targeted tests、`bun test`、`bun run build`。
+
+## Open Questions
+
+- P0 后是否把 `overview` 作为默认 dashboard 的第一屏，还是保持独立命令/API？
+- 高成本阈值是否需要配置项，还是先固定默认值后续再开放？
+- Session Digest 的模型 provider 配置是否放入现有 config，还是单独 `orchestrator` config section？

--- a/specs/GH62/tasks.md
+++ b/specs/GH62/tasks.md
@@ -1,0 +1,180 @@
+# Agent Orchestrator Task Plan
+
+Issue: https://github.com/majiayu000/keepline/issues/62
+
+## Thread Lane Map
+
+- `GH62-L1`: Spec planner, read-only. Owns product/tech/task artifact review.
+- `GH62-L2`: PR1 worker. Owns deterministic Attention Queue service, CLI overview, API route, route registration, and tests.
+- `GH62-L3`: Reviewer, read-only. Owns post-implementation diff review and verification risk check.
+
+No two writable lanes may edit the same file. `AGENTS.md`, `.claude/*`, hooks, settings, and global config are forbidden files unless explicitly requested.
+
+## Tasks
+
+### SP62-T1: Create SpecRail artifacts
+
+Owner: coordinator
+
+Dependencies: #62 issue body
+
+Done when:
+
+- `specs/GH62/product.md` exists.
+- `specs/GH62/tech.md` exists.
+- `specs/GH62/tasks.md` exists.
+- Product scope separates P0 deterministic queue from digest/model/web follow-ups.
+
+Verify:
+
+```sh
+test -f specs/GH62/product.md
+test -f specs/GH62/tech.md
+test -f specs/GH62/tasks.md
+```
+
+### SP62-T2: Create child GitHub issues
+
+Owner: coordinator
+
+Dependencies: SP62-T1
+
+Done when:
+
+- Parent #62 is linked from all child issue bodies.
+- At least these child issues exist:
+  - #63 PR1 deterministic Attention Queue + `keepline overview`
+  - #65 Session Digest schema and deterministic digest generator
+  - #64 Local model summarizer provider
+  - #66 Web Orchestrator view
+- Issue-to-PR map is recorded before PR creation.
+
+Verify:
+
+```sh
+gh issue list --repo majiayu000/keepline --state open --limit 20
+```
+
+### SP62-T3: Implement deterministic Attention Queue service
+
+Owner: PR1 worker
+
+Writable files:
+
+- `src/services/attention.prioritizer.ts`
+- `src/services/index.ts`
+- `src/__tests__/attention.prioritizer.test.ts`
+
+Done when:
+
+- `buildAttentionOverview()` ranks waiting above lost above high-cost above stale/idle/running.
+- Reasons include stable codes, severity, messages, and score contribution.
+- Completed sessions are excluded by default.
+- No model calls or transcript reads occur.
+
+Verify:
+
+```sh
+bun test src/__tests__/attention.prioritizer.test.ts
+```
+
+### SP62-T4: Add CLI overview
+
+Owner: PR1 worker
+
+Writable files:
+
+- `src/cli/overview.ts`
+- `src/cli/index.ts`
+
+Done when:
+
+- `keepline overview` is registered.
+- `--all`, `--limit`, and `--json` are supported.
+- CLI initializes migrations and syncs sessions before reading data.
+
+Verify:
+
+```sh
+bun run typecheck
+```
+
+### SP62-T5: Add Orchestrator overview API
+
+Owner: PR1 worker
+
+Writable files:
+
+- `src/web/api/routes/orchestrator.ts`
+- `src/web/api/routes/index.ts`
+- `src/web/api/server.ts`
+- `src/__tests__/orchestrator.route.test.ts`
+
+Done when:
+
+- `GET /api/orchestrator/overview` returns serialized overview payload.
+- Route uses existing auth middleware.
+- Invalid numeric query values return 400.
+
+Verify:
+
+```sh
+bun test src/__tests__/orchestrator.route.test.ts
+```
+
+### SP62-T6: Full local verification
+
+Owner: verification owner
+
+Dependencies: SP62-T3, SP62-T4, SP62-T5
+
+Done when:
+
+- Targeted tests pass.
+- Typecheck passes.
+- Full test suite passes.
+- Build passes.
+
+Verify:
+
+```sh
+bun test src/__tests__/attention.prioritizer.test.ts src/__tests__/orchestrator.route.test.ts
+bun run typecheck
+bun test
+bun run build
+```
+
+### SP62-T7: Open PR1
+
+Owner: coordinator
+
+Dependencies: SP62-T6
+
+Done when:
+
+- Branch is pushed.
+- PR body links parent #62 and PR1 child issue.
+- PR body includes SpecRail artifact paths and verification commands.
+- PR is not merged without explicit human authorization.
+
+Verify:
+
+```sh
+gh pr view --json number,title,state,headRefName,baseRefName,url
+```
+
+## Issue-To-PR Map
+
+| Issue | Scope | PR status |
+|---|---|---|
+| #63 | Deterministic Attention Queue + `keepline overview` | This tranche opens PR1 |
+| #65 | Session Digest persistence and deterministic digest generation | Follow-up |
+| #64 | Ollama / LM Studio local summarizer provider | Follow-up |
+| #66 | Web Orchestrator view using shared API | Follow-up |
+
+## Follow-Up Issues
+
+- #65 Session Digest persistence and deterministic digest generation.
+- #64 Ollama / LM Studio local summarizer provider.
+- #66 Web Orchestrator view using the same API.
+- Optional semantic search/timeline after digest data is stable.

--- a/specs/GH62/tech.md
+++ b/specs/GH62/tech.md
@@ -1,0 +1,144 @@
+# Agent Orchestrator Tech Spec
+
+Product spec: `specs/GH62/product.md`
+
+Issue: https://github.com/majiayu000/keepline/issues/62
+
+## Context
+
+- `src/services/session.aggregator.ts` 已经提供 full/basic aggregated sessions 和 live process status。
+- `src/domain/session/value-objects.ts` 已经定义 `needsAttention(status)`，但只覆盖 waiting/lost，没有 ranking 或 reason。
+- `src/domain/memory/entity.ts` 和 `src/services/memory.service.ts` 已经有 relay-race memory 字段，可作为 digest 后续输入。
+- `src/domain/work-item/workboard.ts` 已经有 waiting/stale/now/done 投影规则，Orchestrator 不应复制 WorkItem 状态流转。
+- `src/web/api/routes/sessions.ts`、`projects.ts`、`work-items.ts` 已经采用 Hono route module + auth middleware 结构。
+- `src/cli/index.ts` 使用 Commander 注册命令；`list.tsx` 会先 run migrations + sync sessions。
+- `specs/GH44/product.md` 和 `tech.md` 要求 runtime-neutral orchestration，不允许把 Claude Code 或 Codex 写成系统边界。
+
+## Design
+
+新增一个只读 application service：
+
+```ts
+interface AttentionReason {
+  code: 'waiting_for_human' | 'recoverable_lost' | 'high_cost' | 'stale_activity' | 'idle_activity' | 'active_session'
+  severity: 'critical' | 'warning' | 'info'
+  message: string
+  score: number
+}
+
+interface AttentionQueueItem {
+  rank: number
+  sessionId: string
+  client: AgentClient
+  status: SessionStatus
+  title: string
+  directory: string
+  lastActiveAt: Date
+  score: number
+  reasons: AttentionReason[]
+  recommendedAction: 'review' | 'recover' | 'monitor' | 'resume' | 'none'
+  processRunning: boolean
+  usageCost?: number
+}
+```
+
+Suggested module: `src/services/attention.prioritizer.ts`.
+
+The service accepts sessions plus optional thresholds and returns:
+
+```ts
+interface AttentionOverview {
+  generatedAt: Date
+  items: AttentionQueueItem[]
+  stats: {
+    totalCandidates: number
+    needingAttention: number
+    critical: number
+    warning: number
+  }
+}
+```
+
+## Ranking Rules
+
+Rules are tiered and deterministic. A lower-priority reason must not stack with
+other lower-priority reasons to outrank a higher-priority primary reason:
+
+1. `waiting`: `waiting_for_human`, critical, base score 1000, action `review`.
+2. `lost`: `recoverable_lost`, critical, base score 850, action `recover`.
+3. `usageStats.totalCost >= highCostThreshold`: `high_cost`, warning, score 600 plus bounded cost bonus, action remains current higher-priority action or `review`.
+4. `lastActiveAt` older than stale threshold and status is `running` or `idle`: `stale_activity`, warning, score 350, action `review`.
+5. `idle`: `idle_activity`, info, score 150, action `monitor`.
+6. `running`: `active_session`, info, score 25, action `monitor`.
+
+Tie-breakers:
+
+1. higher primary reason score first
+2. more recent `lastActiveAt` first
+3. `sessionId` ascending
+
+Completed sessions are excluded by default.
+
+## API
+
+Add route module `src/web/api/routes/orchestrator.ts`:
+
+- `GET /api/orchestrator/overview`
+- query params:
+  - `includeCompleted=true|false`
+  - `limit=<number>` default 20, max 100
+  - `highCostThreshold=<number>` optional, default from service
+  - `staleHours=<number>` optional, default from service
+
+Mount it in `src/web/api/routes/index.ts` and `src/web/api/server.ts`.
+
+Serialize dates to ISO strings. Do not expose raw internal class instances.
+
+## CLI
+
+Add `src/cli/overview.ts` and register:
+
+```sh
+keepline overview
+keepline overview --all
+keepline overview --limit 10
+keepline overview --json
+```
+
+The CLI should:
+
+1. run migrations
+2. sync sessions
+3. build overview from `getAggregatedSessions()`
+4. output a compact table by default
+5. output JSON when `--json` is passed
+
+## Data Model
+
+PR1 does not require a migration.
+
+Future PR for Session Digest may add a dedicated `session_digests` table rather than overloading `session_memories`. That follow-up must preserve existing Memory fields and distinguish deterministic/model-generated summary sources.
+
+## Privacy and Failure Behavior
+
+- PR1 does not read transcript content directly and does not call models.
+- Missing usage data means no high-cost reason.
+- Bad query params return 400 rather than silently falling back when the value is invalid.
+- Any API failure returns 500 with a generic message and logs the error.
+
+## Verification Plan
+
+- Unit test `buildAttentionOverview()` ordering and reason generation.
+- Route test `/api/orchestrator/overview` auth + serialization + limit.
+- CLI smoke test can be covered by typecheck/build in PR1; a later CLI test harness can add subprocess coverage.
+- Run:
+  - `bun test src/__tests__/attention.prioritizer.test.ts src/__tests__/orchestrator.route.test.ts`
+  - `bun run typecheck`
+  - `bun test`
+  - `bun run build`
+
+## Rollback
+
+- Remove the new route mount and CLI command registration.
+- Remove `src/services/attention.prioritizer.ts`, `src/cli/overview.ts`, and related tests.
+- No database rollback is needed for PR1 because no migration is introduced.

--- a/src/__tests__/attention.prioritizer.test.ts
+++ b/src/__tests__/attention.prioritizer.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from 'bun:test';
+import type { AggregatedSession } from '../services/session.types.js';
+import { buildAttentionOverview } from '../services/attention.prioritizer.js';
+
+const NOW = new Date('2026-06-29T12:00:00.000Z');
+const RECENT = new Date('2026-06-29T11:55:00.000Z');
+const OLD = new Date('2026-06-27T12:00:00.000Z');
+
+function session(input: Partial<AggregatedSession> & {
+  sessionId: string;
+  status: AggregatedSession['status'];
+}): AggregatedSession {
+  return {
+    id: input.sessionId,
+    sessionId: input.sessionId,
+    client: input.client ?? 'codex',
+    directory: input.directory ?? '/tmp/keepline',
+    status: input.status,
+    title: input.title ?? input.sessionId,
+    initialPrompt: '',
+    startedAt: RECENT,
+    lastActiveAt: input.lastActiveAt ?? RECENT,
+    completedAt: input.completedAt,
+    pid: input.pid,
+    tty: input.tty,
+    toolCount: input.toolCount ?? 0,
+    messageCount: input.messageCount ?? 0,
+    usageStats: input.usageStats,
+    processRunning: input.processRunning ?? false,
+    cpuUsage: input.cpuUsage,
+    memoryUsage: input.memoryUsage,
+    createdAt: RECENT,
+    updatedAt: RECENT,
+  };
+}
+
+describe('buildAttentionOverview', () => {
+  test('ranks waiting above lost, high-cost, stale, idle, running, and completed', () => {
+    const overview = buildAttentionOverview([
+      session({ sessionId: 'running', status: 'running' }),
+      session({ sessionId: 'completed', status: 'completed' }),
+      session({ sessionId: 'idle', status: 'idle' }),
+      session({ sessionId: 'stale', status: 'running', lastActiveAt: OLD }),
+      session({
+        sessionId: 'high-cost',
+        status: 'running',
+        usageStats: {
+          totalInputTokens: 10,
+          totalOutputTokens: 20,
+          totalTokens: 30,
+          totalCost: 5,
+          apiCalls: 1,
+        },
+      }),
+      session({ sessionId: 'lost', status: 'lost' }),
+      session({ sessionId: 'waiting', status: 'waiting' }),
+    ], {
+      now: NOW,
+      highCostThreshold: 1,
+      staleHours: 24,
+    });
+
+    expect(overview.items.map((item) => item.sessionId)).toEqual([
+      'waiting',
+      'lost',
+      'high-cost',
+      'stale',
+      'idle',
+      'running',
+    ]);
+    expect(overview.items[0]).toMatchObject({
+      rank: 1,
+      recommendedAction: 'review',
+      reasons: [expect.objectContaining({ code: 'waiting_for_human' })],
+    });
+    expect(overview.items[1].recommendedAction).toBe('recover');
+    expect(overview.items.find((item) => item.sessionId === 'completed')).toBeUndefined();
+  });
+
+  test('keeps higher-priority states above lower-priority stacked reasons', () => {
+    const overview = buildAttentionOverview([
+      session({
+        sessionId: 'lost-high-cost',
+        status: 'lost',
+        usageStats: {
+          totalInputTokens: 100,
+          totalOutputTokens: 200,
+          totalTokens: 300,
+          totalCost: 100,
+          apiCalls: 5,
+        },
+      }),
+      session({
+        sessionId: 'running-high-cost-stale',
+        status: 'running',
+        lastActiveAt: OLD,
+        usageStats: {
+          totalInputTokens: 100,
+          totalOutputTokens: 200,
+          totalTokens: 300,
+          totalCost: 100,
+          apiCalls: 5,
+        },
+      }),
+      session({ sessionId: 'waiting-only', status: 'waiting' }),
+    ], {
+      now: NOW,
+      highCostThreshold: 1,
+      staleHours: 24,
+    });
+
+    expect(overview.items.map((item) => item.sessionId)).toEqual([
+      'waiting-only',
+      'lost-high-cost',
+      'running-high-cost-stale',
+    ]);
+  });
+
+  test('does not create cost reasons without persisted usage cost', () => {
+    const overview = buildAttentionOverview([
+      session({ sessionId: 'no-usage', status: 'running' }),
+      session({
+        sessionId: 'below-threshold',
+        status: 'running',
+        usageStats: {
+          totalInputTokens: 1,
+          totalOutputTokens: 1,
+          totalTokens: 2,
+          totalCost: 0.5,
+          apiCalls: 1,
+        },
+      }),
+    ], {
+      now: NOW,
+      highCostThreshold: 1,
+    });
+
+    for (const item of overview.items) {
+      expect(item.reasons.some((reason) => reason.code === 'high_cost')).toBe(false);
+    }
+  });
+
+  test('uses deterministic tie breakers for equal scores', () => {
+    const overview = buildAttentionOverview([
+      session({ sessionId: 'b-session', status: 'idle', lastActiveAt: RECENT }),
+      session({ sessionId: 'a-session', status: 'idle', lastActiveAt: RECENT }),
+      session({ sessionId: 'newer-session', status: 'idle', lastActiveAt: NOW }),
+    ], { now: NOW });
+
+    expect(overview.items.map((item) => item.sessionId)).toEqual([
+      'newer-session',
+      'a-session',
+      'b-session',
+    ]);
+  });
+
+  test('can include completed sessions explicitly', () => {
+    const overview = buildAttentionOverview([
+      session({ sessionId: 'completed', status: 'completed' }),
+    ], {
+      includeCompleted: true,
+      now: NOW,
+    });
+
+    expect(overview.items).toHaveLength(1);
+    expect(overview.items[0]).toMatchObject({
+      sessionId: 'completed',
+      recommendedAction: 'none',
+      score: 0,
+    });
+  });
+});

--- a/src/__tests__/orchestrator.route.test.ts
+++ b/src/__tests__/orchestrator.route.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import orchestrator from '../web/api/routes/orchestrator.js';
+import { app } from '../web/api/server.js';
+import { setupUser } from '../services/auth.service.js';
+import { resetDatabase } from '../db/migrations.js';
+import { closeDatabase } from '../infrastructure/database/sqlite.js';
+import { sessionRepository } from '../infrastructure/database/repositories/session.repository.js';
+
+describe('Orchestrator Route Contract', () => {
+  beforeEach(() => {
+    resetDatabase();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test('overview returns serialized attention queue with auth', async () => {
+    sessionRepository.upsert({
+      sessionId: 'orchestrator-route-cost',
+      client: 'codex',
+      directory: '/tmp/keepline-orchestrator',
+      status: 'running',
+      title: 'Expensive local run',
+      initialPrompt: 'Track cost',
+      lastActiveAt: new Date('2026-06-29T10:00:00.000Z'),
+      toolCount: 2,
+      messageCount: 4,
+      usageStats: {
+        totalInputTokens: 100,
+        totalOutputTokens: 50,
+        totalTokens: 150,
+        totalCost: 5,
+        apiCalls: 2,
+      },
+    });
+
+    const { token } = await setupUser('orchestrator-route-user', 'password123');
+    const response = await orchestrator.fetch(new Request(
+      'http://localhost/overview?limit=10&highCostThreshold=1',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json() as {
+      success: boolean;
+      data: {
+        generatedAt: string;
+        items: Array<{
+          sessionId: string;
+          lastActiveAt: string;
+          reasons: Array<{ code: string }>;
+        }>;
+        stats: { totalCandidates: number };
+      };
+    };
+
+    expect(body.success).toBe(true);
+    expect(body.data.generatedAt).toEqual(expect.any(String));
+    expect(body.data.stats.totalCandidates).toBe(1);
+    expect(body.data.items).toHaveLength(1);
+    expect(body.data.items[0]).toMatchObject({
+      sessionId: 'orchestrator-route-cost',
+      lastActiveAt: '2026-06-29T10:00:00.000Z',
+    });
+    expect(body.data.items[0].reasons.map((reason) => reason.code)).toContain('high_cost');
+  });
+
+  test('server mounts the orchestrator overview route', async () => {
+    sessionRepository.upsert({
+      sessionId: 'mounted-orchestrator-route',
+      client: 'claude',
+      directory: '/tmp/keepline-mounted-orchestrator',
+      status: 'running',
+      title: 'Mounted route',
+      initialPrompt: 'Mounted',
+      lastActiveAt: new Date('2026-06-29T10:00:00.000Z'),
+      toolCount: 1,
+      messageCount: 1,
+    });
+
+    const { token } = await setupUser('mounted-orchestrator-user', 'password123');
+    const response = await app.fetch(new Request(
+      'http://localhost/api/orchestrator/overview?limit=1',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as {
+      success: boolean;
+      data: { items: Array<{ sessionId: string }> };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.items).toHaveLength(1);
+    expect(body.data.items[0].sessionId).toBe('mounted-orchestrator-route');
+  });
+
+  test('rejects invalid numeric query values', async () => {
+    const { token } = await setupUser('orchestrator-invalid-user', 'password123');
+    const response = await orchestrator.fetch(new Request(
+      'http://localhost/overview?limit=abc',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(400);
+    const body = await response.json() as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('limit must be a positive number');
+  });
+
+  test('requires authentication', async () => {
+    const response = await orchestrator.fetch(new Request('http://localhost/overview'));
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/__tests__/overview.cli.test.ts
+++ b/src/__tests__/overview.cli.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import { parseOverviewOptions } from '../cli/overview.js';
+
+describe('overview CLI options', () => {
+  test('parses positive numeric options', () => {
+    expect(parseOverviewOptions({
+      all: true,
+      limit: '5',
+      highCostThreshold: '2.5',
+      staleHours: '12',
+    })).toEqual({
+      includeCompleted: true,
+      limit: 5,
+      highCostThreshold: 2.5,
+      staleHours: 12,
+    });
+  });
+
+  test('rejects invalid numeric options', () => {
+    expect(() => parseOverviewOptions({ limit: 'abc' })).toThrow(
+      'limit must be a positive number'
+    );
+    expect(() => parseOverviewOptions({ highCostThreshold: '-1' })).toThrow(
+      'high-cost-threshold must be a positive number'
+    );
+    expect(() => parseOverviewOptions({ staleHours: '0' })).toThrow(
+      'stale-hours must be a positive number'
+    );
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,7 @@ import { recoverCommand, recoverListCommand } from './recover.js';
 import { daemonCommand } from './daemon.js';
 import { statusCommand } from './status.js';
 import { webCommand } from './web.js';
+import { overviewCommand } from './overview.js';
 import {
   memoryListCommand,
   memoryShowCommand,
@@ -68,6 +69,17 @@ export function registerCommands(program: Command): void {
     .command('status')
     .description('Show system status')
     .action(statusCommand);
+
+  // Orchestrator overview
+  program
+    .command('overview')
+    .description('Show the global agent attention queue')
+    .option('-a, --all', 'Include completed sessions')
+    .option('-l, --limit <n>', 'Limit results (default: 20)')
+    .option('--json', 'Output JSON')
+    .option('--high-cost-threshold <amount>', 'Cost threshold for high-cost reason')
+    .option('--stale-hours <hours>', 'Hours without activity before stale reason')
+    .action(overviewCommand);
 
   // Hooks management
   program

--- a/src/cli/overview.ts
+++ b/src/cli/overview.ts
@@ -1,0 +1,147 @@
+import Table from 'cli-table3';
+import chalk from 'chalk';
+import { runMigrations } from '../db/migrations.js';
+import { syncSessions } from '../services/session.service.js';
+import { getAggregatedSessions } from '../services/session.aggregator.js';
+import {
+  buildAttentionOverview,
+  type AttentionOverview,
+  type AttentionQueueItem,
+} from '../services/attention.prioritizer.js';
+import { logger } from '../lib/logger.js';
+
+export interface OverviewOptions {
+  all?: boolean;
+  limit?: string;
+  json?: boolean;
+  highCostThreshold?: string;
+  staleHours?: string;
+}
+
+export async function overviewCommand(options: OverviewOptions): Promise<void> {
+  let parsedOptions: ParsedOverviewOptions;
+  try {
+    parsedOptions = parseOverviewOptions(options);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(chalk.red(message));
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.json) {
+    logger.configure({ console: false });
+  }
+
+  runMigrations();
+  if (!options.json) {
+    process.stdout.write('\x1b[90mScanning sessions...\x1b[0m\n');
+  }
+  await syncSessions();
+
+  const overview = buildAttentionOverview(getAggregatedSessions(), {
+    includeCompleted: parsedOptions.includeCompleted,
+    limit: parsedOptions.limit,
+    highCostThreshold: parsedOptions.highCostThreshold,
+    staleHours: parsedOptions.staleHours,
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(serializeOverview(overview), null, 2));
+    return;
+  }
+
+  process.stdout.write('\x1b[A\x1b[K');
+  printOverview(overview);
+}
+
+export interface ParsedOverviewOptions {
+  includeCompleted?: boolean;
+  limit?: number;
+  highCostThreshold?: number;
+  staleHours?: number;
+}
+
+export function parseOverviewOptions(options: OverviewOptions): ParsedOverviewOptions {
+  return {
+    includeCompleted: options.all,
+    limit: parseOptionalPositiveNumber(options.limit, 'limit'),
+    highCostThreshold: parseOptionalPositiveNumber(
+      options.highCostThreshold,
+      'high-cost-threshold'
+    ),
+    staleHours: parseOptionalPositiveNumber(options.staleHours, 'stale-hours'),
+  };
+}
+
+function parseOptionalPositiveNumber(value: string | undefined, name: string): number | undefined {
+  if (value == null || value.trim() === '') return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive number`);
+  }
+  return parsed;
+}
+
+function printOverview(overview: AttentionOverview): void {
+  console.log('');
+  console.log(chalk.bold('Keepline Attention Queue'));
+  console.log(chalk.gray(`Generated: ${overview.generatedAt.toISOString()}`));
+  console.log('');
+
+  if (overview.items.length === 0) {
+    console.log(chalk.gray('No sessions in the attention queue.'));
+    console.log('');
+    return;
+  }
+
+  const table = new Table({
+    head: ['#', 'Score', 'Status', 'Client', 'Action', 'Session', 'Reasons'],
+    style: { head: ['cyan'] },
+    wordWrap: true,
+    colWidths: [5, 8, 12, 10, 10, 32, 44],
+  });
+
+  for (const item of overview.items) {
+    table.push([
+      item.rank,
+      item.score,
+      item.status,
+      item.client,
+      item.recommendedAction,
+      formatSessionLabel(item),
+      item.reasons.map((reason) => reason.message).join('; ') || '-',
+    ]);
+  }
+
+  console.log(table.toString());
+  console.log('');
+  console.log(
+    chalk.gray(
+      `Candidates: ${overview.stats.totalCandidates} | ` +
+      `Needs attention: ${overview.stats.needingAttention} | ` +
+      `Critical: ${overview.stats.critical} | Warning: ${overview.stats.warning}`
+    )
+  );
+  console.log('');
+}
+
+function formatSessionLabel(item: AttentionQueueItem): string {
+  const title = item.title || item.sessionId;
+  return `${title}\n${chalk.gray(item.directory)}`;
+}
+
+function serializeOverview(overview: AttentionOverview) {
+  return {
+    generatedAt: overview.generatedAt.toISOString(),
+    items: overview.items.map(serializeItem),
+    stats: overview.stats,
+  };
+}
+
+function serializeItem(item: AttentionQueueItem) {
+  return {
+    ...item,
+    lastActiveAt: item.lastActiveAt.toISOString(),
+  };
+}

--- a/src/services/attention.prioritizer.ts
+++ b/src/services/attention.prioritizer.ts
@@ -1,0 +1,228 @@
+import type { AgentClient, SessionStatus } from '../domain/session/index.js';
+import type { AggregatedSession } from './session.types.js';
+
+export type AttentionReasonCode =
+  | 'waiting_for_human'
+  | 'recoverable_lost'
+  | 'high_cost'
+  | 'stale_activity'
+  | 'idle_activity'
+  | 'active_session';
+
+export type AttentionSeverity = 'critical' | 'warning' | 'info';
+
+export type RecommendedAction = 'review' | 'recover' | 'monitor' | 'resume' | 'none';
+
+export interface AttentionReason {
+  code: AttentionReasonCode;
+  severity: AttentionSeverity;
+  message: string;
+  score: number;
+}
+
+export interface AttentionQueueItem {
+  rank: number;
+  sessionId: string;
+  client: AgentClient;
+  status: SessionStatus;
+  title: string;
+  directory: string;
+  lastActiveAt: Date;
+  score: number;
+  reasons: AttentionReason[];
+  recommendedAction: RecommendedAction;
+  processRunning: boolean;
+  usageCost?: number;
+}
+
+export interface AttentionOverviewStats {
+  totalCandidates: number;
+  needingAttention: number;
+  critical: number;
+  warning: number;
+}
+
+export interface AttentionOverview {
+  generatedAt: Date;
+  items: AttentionQueueItem[];
+  stats: AttentionOverviewStats;
+}
+
+export interface AttentionOverviewOptions {
+  includeCompleted?: boolean;
+  limit?: number;
+  now?: Date;
+  highCostThreshold?: number;
+  staleHours?: number;
+}
+
+export const DEFAULT_ATTENTION_LIMIT = 20;
+export const MAX_ATTENTION_LIMIT = 100;
+export const DEFAULT_HIGH_COST_THRESHOLD = 1;
+export const DEFAULT_STALE_HOURS = 24;
+
+const WAITING_SCORE = 1000;
+const LOST_SCORE = 850;
+const HIGH_COST_SCORE = 600;
+const STALE_SCORE = 350;
+const IDLE_SCORE = 150;
+const RUNNING_SCORE = 25;
+
+export function buildAttentionOverview(
+  sessions: AggregatedSession[],
+  options: AttentionOverviewOptions = {}
+): AttentionOverview {
+  const now = options.now ?? new Date();
+  const limit = clampLimit(options.limit);
+  const highCostThreshold = options.highCostThreshold ?? DEFAULT_HIGH_COST_THRESHOLD;
+  const staleHours = options.staleHours ?? DEFAULT_STALE_HOURS;
+  const staleCutoffMs = now.getTime() - staleHours * 60 * 60 * 1000;
+  const candidates = sessions.filter(
+    (session) => options.includeCompleted || session.status !== 'completed'
+  );
+  const rankedItems = candidates
+    .map((session) => buildAttentionItem(session, {
+      highCostThreshold,
+      staleCutoffMs,
+    }))
+    .sort(compareAttentionItems)
+    .map((item, index) => ({ ...item, rank: index + 1 }));
+  const items = rankedItems.slice(0, limit);
+
+  return {
+    generatedAt: now,
+    items,
+    stats: {
+      totalCandidates: candidates.length,
+      needingAttention: rankedItems.filter(hasCriticalOrWarningReason).length,
+      critical: rankedItems.filter(hasCriticalReason).length,
+      warning: rankedItems.filter(hasWarningReason).length,
+    },
+  };
+}
+
+function buildAttentionItem(
+  session: AggregatedSession,
+  options: {
+    highCostThreshold: number;
+    staleCutoffMs: number;
+  }
+): AttentionQueueItem {
+  const reasons: AttentionReason[] = [];
+
+  if (session.status === 'waiting') {
+    reasons.push({
+      code: 'waiting_for_human',
+      severity: 'critical',
+      message: 'Waiting for human input',
+      score: WAITING_SCORE,
+    });
+  }
+
+  if (session.status === 'lost') {
+    reasons.push({
+      code: 'recoverable_lost',
+      severity: 'critical',
+      message: 'Session is lost and may be recoverable',
+      score: LOST_SCORE,
+    });
+  }
+
+  const usageCost = session.usageStats?.totalCost;
+  if (usageCost != null && usageCost >= options.highCostThreshold) {
+    const costBonus = Math.min(
+      Math.floor((usageCost / Math.max(options.highCostThreshold, 0.01)) * 50),
+      200
+    );
+    reasons.push({
+      code: 'high_cost',
+      severity: 'warning',
+      message: `Session cost is $${usageCost.toFixed(2)}`,
+      score: HIGH_COST_SCORE + costBonus,
+    });
+  }
+
+  const stale = session.lastActiveAt.getTime() < options.staleCutoffMs;
+  if ((session.status === 'running' || session.status === 'idle') && stale) {
+    reasons.push({
+      code: 'stale_activity',
+      severity: 'warning',
+      message: 'No recent activity',
+      score: STALE_SCORE,
+    });
+  }
+
+  if (session.status === 'idle') {
+    reasons.push({
+      code: 'idle_activity',
+      severity: 'info',
+      message: 'Session is idle',
+      score: IDLE_SCORE,
+    });
+  }
+
+  if (session.status === 'running') {
+    reasons.push({
+      code: 'active_session',
+      severity: 'info',
+      message: 'Session is running',
+      score: RUNNING_SCORE,
+    });
+  }
+
+  return {
+    rank: 0,
+    sessionId: session.sessionId,
+    client: session.client,
+    status: session.status,
+    title: session.title,
+    directory: session.directory,
+    lastActiveAt: session.lastActiveAt,
+    score: getPriorityScore(reasons),
+    reasons,
+    recommendedAction: getRecommendedAction(reasons),
+    processRunning: session.processRunning,
+    usageCost,
+  };
+}
+
+function getPriorityScore(reasons: AttentionReason[]): number {
+  if (reasons.length === 0) return 0;
+  return Math.max(...reasons.map((reason) => reason.score));
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (limit == null) return DEFAULT_ATTENTION_LIMIT;
+  if (!Number.isFinite(limit) || limit <= 0) return DEFAULT_ATTENTION_LIMIT;
+  return Math.min(Math.floor(limit), MAX_ATTENTION_LIMIT);
+}
+
+function getRecommendedAction(reasons: AttentionReason[]): RecommendedAction {
+  if (reasons.some((reason) => reason.code === 'waiting_for_human')) return 'review';
+  if (reasons.some((reason) => reason.code === 'recoverable_lost')) return 'recover';
+  if (reasons.some((reason) => reason.code === 'high_cost')) return 'review';
+  if (reasons.some((reason) => reason.code === 'stale_activity')) return 'review';
+  if (reasons.some((reason) => reason.code === 'idle_activity')) return 'monitor';
+  if (reasons.some((reason) => reason.code === 'active_session')) return 'monitor';
+  return 'none';
+}
+
+function compareAttentionItems(a: AttentionQueueItem, b: AttentionQueueItem): number {
+  const scoreComparison = b.score - a.score;
+  if (scoreComparison !== 0) return scoreComparison;
+  const activityComparison = b.lastActiveAt.getTime() - a.lastActiveAt.getTime();
+  if (activityComparison !== 0) return activityComparison;
+  return a.sessionId.localeCompare(b.sessionId);
+}
+
+function hasCriticalReason(item: AttentionQueueItem): boolean {
+  return item.reasons.some((reason) => reason.severity === 'critical');
+}
+
+function hasWarningReason(item: AttentionQueueItem): boolean {
+  return item.reasons.some((reason) => reason.severity === 'warning');
+}
+
+function hasCriticalOrWarningReason(item: AttentionQueueItem): boolean {
+  return item.reasons.some((reason) => reason.severity !== 'info');
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -2,6 +2,7 @@
 export * from './session.types.js';
 export * from './session.service.js';
 export * from './session.aggregator.js';
+export * from './attention.prioritizer.js';
 
 // Recovery
 export * from './recovery.types.js';

--- a/src/web/api/routes/index.ts
+++ b/src/web/api/routes/index.ts
@@ -13,6 +13,7 @@ import auth from './auth.js';
 import projects from './projects.js';
 import workItems from './work-items.js';
 import workItemEvidence from './work-item-evidence.js';
+import orchestrator from './orchestrator.js';
 
 export {
   sessions,
@@ -24,4 +25,5 @@ export {
   projects,
   workItems,
   workItemEvidence,
+  orchestrator,
 };

--- a/src/web/api/routes/orchestrator.ts
+++ b/src/web/api/routes/orchestrator.ts
@@ -1,0 +1,80 @@
+import { Hono } from 'hono';
+import { getAggregatedSessions } from '../../../services/session.aggregator.js';
+import {
+  buildAttentionOverview,
+  MAX_ATTENTION_LIMIT,
+  type AttentionOverview,
+  type AttentionQueueItem,
+} from '../../../services/attention.prioritizer.js';
+import { logger } from '../../../lib/logger.js';
+import { authMiddleware } from '../middleware/auth.js';
+
+const app = new Hono();
+app.use('*', authMiddleware);
+
+app.get('/overview', (c) => {
+  const limitResult = parsePositiveNumber(c.req.query('limit'), 'limit');
+  if (limitResult.error) {
+    return c.json({ success: false, error: limitResult.error }, 400);
+  }
+  const highCostResult = parsePositiveNumber(
+    c.req.query('highCostThreshold'),
+    'highCostThreshold'
+  );
+  if (highCostResult.error) {
+    return c.json({ success: false, error: highCostResult.error }, 400);
+  }
+  const staleHoursResult = parsePositiveNumber(c.req.query('staleHours'), 'staleHours');
+  if (staleHoursResult.error) {
+    return c.json({ success: false, error: staleHoursResult.error }, 400);
+  }
+
+  try {
+    const overview = buildAttentionOverview(getAggregatedSessions(), {
+      includeCompleted: c.req.query('includeCompleted') === 'true',
+      limit: limitResult.value,
+      highCostThreshold: highCostResult.value,
+      staleHours: staleHoursResult.value,
+    });
+
+    return c.json({
+      success: true,
+      data: serializeOverview(overview),
+    });
+  } catch (error) {
+    logger.error('Failed to build orchestrator overview', error);
+    return c.json({ success: false, error: 'Failed to build orchestrator overview' }, 500);
+  }
+});
+
+function parsePositiveNumber(
+  value: string | undefined,
+  name: string
+): { value?: number; error?: string } {
+  if (value == null || value.trim() === '') return {};
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return { error: `${name} must be a positive number` };
+  }
+  if (name === 'limit' && parsed > MAX_ATTENTION_LIMIT) {
+    return { error: `limit must be ${MAX_ATTENTION_LIMIT} or less` };
+  }
+  return { value: parsed };
+}
+
+function serializeOverview(overview: AttentionOverview) {
+  return {
+    generatedAt: overview.generatedAt.toISOString(),
+    items: overview.items.map(serializeItem),
+    stats: overview.stats,
+  };
+}
+
+function serializeItem(item: AttentionQueueItem) {
+  return {
+    ...item,
+    lastActiveAt: item.lastActiveAt.toISOString(),
+  };
+}
+
+export default app;

--- a/src/web/api/server.ts
+++ b/src/web/api/server.ts
@@ -29,6 +29,7 @@ import {
   projects,
   workItems,
   workItemEvidence,
+  orchestrator,
 } from './routes/index.js';
 import { broadcast, wsClients, websocketHandler } from './websocket.js';
 import { terminalWebsocketHandler } from './terminal-websocket.js';
@@ -103,6 +104,7 @@ app.route('/api/auth', auth);
 app.route('/api/sessions', sessions);
 app.route('/api/sessions', recovery);
 app.route('/api/projects', projects);
+app.route('/api/orchestrator', orchestrator);
 app.route('/api/work-items', workItemEvidence);
 app.route('/api/work-items', workItems);
 app.route('/api', usage);


### PR DESCRIPTION
## What does this PR do?

Adds the first Agent Orchestrator slice for #62: a deterministic Attention Queue that works without model calls or transcript upload.

Closes #63
Refs #62

## Scope

- Adds SpecRail artifacts for #62:
  - `specs/GH62/product.md`
  - `specs/GH62/tech.md`
  - `specs/GH62/tasks.md`
- Adds `buildAttentionOverview()` for deterministic session prioritization.
- Adds `keepline overview` with `--all`, `--limit`, `--json`, `--high-cost-threshold`, and `--stale-hours`.
- Adds `GET /api/orchestrator/overview` using existing auth middleware.
- Adds tests for ranking, overlapping priority reasons, CLI option validation, API serialization/auth, and mounted route coverage.

## Non-goals

- No Session Digest persistence.
- No local or cloud model summarizer.
- No Web Orchestrator UI.
- No DB migration.

## Verification

```sh
bun test src/__tests__/attention.prioritizer.test.ts src/__tests__/overview.cli.test.ts src/__tests__/orchestrator.route.test.ts
bun run typecheck
TMP_HOME=$(mktemp -d); KEEPLINE_HOME="$TMP_HOME" bun run src/index.ts overview --json --limit 1 > "$TMP_HOME/overview.json"; node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")); console.log("json-ok")' "$TMP_HOME/overview.json"; rm -rf "$TMP_HOME"
git diff --check
bun test
bun run build
```

Fresh local results: all passed. `bun run build` emits the existing Vite large chunk warning.
