### PR TITLE
fix(orchestrator): hide old lost sessions by default

### DIFF
--- a/src/__tests__/attention.prioritizer.test.ts
+++ b/src/__tests__/attention.prioritizer.test.ts
@@ -171,6 +171,39 @@ describe('buildAttentionOverview', () => {
     });
   });
 
+  test('hides old lost sessions from the default recovery queue', () => {
+    const overview = buildAttentionOverview([
+      session({ sessionId: 'recent-lost', status: 'lost', lastActiveAt: RECENT }),
+      session({ sessionId: 'old-lost', status: 'lost', lastActiveAt: OLD }),
+      session({ sessionId: 'waiting', status: 'waiting', lastActiveAt: OLD }),
+    ], { now: NOW });
+
+    expect(overview.items.map((item) => item.sessionId)).toEqual([
+      'waiting',
+      'recent-lost',
+    ]);
+    expect(overview.stats).toMatchObject({
+      totalCandidates: 2,
+      hiddenOldLost: 1,
+      lostWindowHours: 1,
+      critical: 2,
+    });
+  });
+
+  test('can include old lost sessions explicitly', () => {
+    const overview = buildAttentionOverview([
+      session({ sessionId: 'old-lost', status: 'lost', lastActiveAt: OLD }),
+    ], {
+      now: NOW,
+      includeOldLost: true,
+    });
+
+    expect(overview.items).toHaveLength(1);
+    expect(overview.items[0].sessionId).toBe('old-lost');
+    expect(overview.stats.hiddenOldLost).toBe(0);
+    expect(overview.stats.lostWindowHours).toBeUndefined();
+  });
+
   test('attaches serialized digest without changing queue order', () => {
     const digest: SessionDigest = {
       id: 'digest-id',

--- a/src/__tests__/orchestrator.route.test.ts
+++ b/src/__tests__/orchestrator.route.test.ts
@@ -223,6 +223,52 @@ describe('Orchestrator Route Contract', () => {
     expect(body.error).toBe('limit must be a positive number');
   });
 
+  test('hides old lost sessions by default and can include them explicitly', async () => {
+    sessionRepository.upsert({
+      sessionId: 'old-lost-route-session',
+      client: 'codex',
+      directory: '/tmp/keepline-old-lost',
+      status: 'lost',
+      title: 'Old lost',
+      lastActiveAt: new Date('2026-06-27T10:00:00.000Z'),
+    });
+
+    const { token } = await setupUser('orchestrator-old-lost-user', 'password123');
+    const defaultResponse = await orchestrator.fetch(new Request(
+      'http://localhost/overview?limit=10',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+    const defaultBody = await defaultResponse.json() as {
+      data: {
+        items: Array<{ sessionId: string }>;
+        stats: { hiddenOldLost: number; lostWindowHours?: number };
+      };
+    };
+
+    expect(defaultResponse.status).toBe(200);
+    expect(defaultBody.data.items).toHaveLength(0);
+    expect(defaultBody.data.stats).toMatchObject({
+      hiddenOldLost: 1,
+      lostWindowHours: 1,
+    });
+
+    const explicitResponse = await orchestrator.fetch(new Request(
+      'http://localhost/overview?limit=10&includeOldLost=true',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+    const explicitBody = await explicitResponse.json() as {
+      data: {
+        items: Array<{ sessionId: string }>;
+        stats: { hiddenOldLost: number; lostWindowHours?: number };
+      };
+    };
+
+    expect(explicitResponse.status).toBe(200);
+    expect(explicitBody.data.items[0].sessionId).toBe('old-lost-route-session');
+    expect(explicitBody.data.stats.hiddenOldLost).toBe(0);
+    expect(explicitBody.data.stats.lostWindowHours).toBeUndefined();
+  });
+
   test('requires authentication', async () => {
     const response = await orchestrator.fetch(new Request('http://localhost/overview'));
 

--- a/src/__tests__/overview.cli.test.ts
+++ b/src/__tests__/overview.cli.test.ts
@@ -8,11 +8,15 @@ describe('overview CLI options', () => {
       limit: '5',
       highCostThreshold: '2.5',
       staleHours: '12',
+      lostHours: '6',
+      includeOldLost: true,
     })).toEqual({
       includeCompleted: true,
       limit: 5,
       highCostThreshold: 2.5,
       staleHours: 12,
+      includeOldLost: true,
+      lostHours: 6,
     });
   });
 
@@ -25,6 +29,9 @@ describe('overview CLI options', () => {
     );
     expect(() => parseOverviewOptions({ staleHours: '0' })).toThrow(
       'stale-hours must be a positive number'
+    );
+    expect(() => parseOverviewOptions({ lostHours: '0' })).toThrow(
+      'lost-hours must be a positive number'
     );
   });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -79,6 +79,8 @@ export function registerCommands(program: Command): void {
     .option('--json', 'Output JSON')
     .option('--high-cost-threshold <amount>', 'Cost threshold for high-cost reason')
     .option('--stale-hours <hours>', 'Hours without activity before stale reason')
+    .option('--lost-hours <hours>', 'Hours a lost session remains in the default recovery queue')
+    .option('--include-old-lost', 'Include lost sessions outside the recovery window')
     .action(overviewCommand);
 
   // Hooks management

--- a/src/cli/overview.ts
+++ b/src/cli/overview.ts
@@ -16,6 +16,8 @@ export interface OverviewOptions {
   json?: boolean;
   highCostThreshold?: string;
   staleHours?: string;
+  includeOldLost?: boolean;
+  lostHours?: string;
 }
 
 export async function overviewCommand(options: OverviewOptions): Promise<void> {
@@ -44,6 +46,8 @@ export async function overviewCommand(options: OverviewOptions): Promise<void> {
     limit: parsedOptions.limit,
     highCostThreshold: parsedOptions.highCostThreshold,
     staleHours: parsedOptions.staleHours,
+    includeOldLost: parsedOptions.includeOldLost,
+    lostHours: parsedOptions.lostHours,
   });
 
   if (options.json) {
@@ -60,6 +64,8 @@ export interface ParsedOverviewOptions {
   limit?: number;
   highCostThreshold?: number;
   staleHours?: number;
+  includeOldLost?: boolean;
+  lostHours?: number;
 }
 
 export function parseOverviewOptions(options: OverviewOptions): ParsedOverviewOptions {
@@ -71,6 +77,8 @@ export function parseOverviewOptions(options: OverviewOptions): ParsedOverviewOp
       'high-cost-threshold'
     ),
     staleHours: parseOptionalPositiveNumber(options.staleHours, 'stale-hours'),
+    includeOldLost: options.includeOldLost,
+    lostHours: parseOptionalPositiveNumber(options.lostHours, 'lost-hours'),
   };
 }
 
@@ -120,10 +128,19 @@ function printOverview(overview: AttentionOverview): void {
     chalk.gray(
       `Candidates: ${overview.stats.totalCandidates} | ` +
       `Needs attention: ${overview.stats.needingAttention} | ` +
-      `Critical: ${overview.stats.critical} | Warning: ${overview.stats.warning}`
+      `Critical: ${overview.stats.critical} | Warning: ${overview.stats.warning}` +
+      formatHiddenOldLost(overview)
     )
   );
   console.log('');
+}
+
+function formatHiddenOldLost(overview: AttentionOverview): string {
+  if (overview.stats.hiddenOldLost === 0 || overview.stats.lostWindowHours == null) {
+    return '';
+  }
+  return ` | Hidden old lost: ${overview.stats.hiddenOldLost} ` +
+    `(>${overview.stats.lostWindowHours}h)`;
 }
 
 function formatSessionLabel(item: AttentionQueueItem): string {

--- a/src/services/attention.prioritizer.ts
+++ b/src/services/attention.prioritizer.ts
@@ -43,6 +43,8 @@ export interface AttentionOverviewStats {
   needingAttention: number;
   critical: number;
   warning: number;
+  hiddenOldLost: number;
+  lostWindowHours?: number;
 }
 
 export interface AttentionOverview {
@@ -57,6 +59,8 @@ export interface AttentionOverviewOptions {
   now?: Date;
   highCostThreshold?: number;
   staleHours?: number;
+  includeOldLost?: boolean;
+  lostHours?: number;
   digests?: Map<string, SessionDigest>;
 }
 
@@ -64,6 +68,7 @@ export const DEFAULT_ATTENTION_LIMIT = 20;
 export const MAX_ATTENTION_LIMIT = 100;
 export const DEFAULT_HIGH_COST_THRESHOLD = 1;
 export const DEFAULT_STALE_HOURS = 24;
+export const DEFAULT_LOST_HOURS = 1;
 
 const WAITING_SCORE = 1000;
 const LOST_SCORE = 850;
@@ -80,10 +85,20 @@ export function buildAttentionOverview(
   const limit = clampLimit(options.limit);
   const highCostThreshold = options.highCostThreshold ?? DEFAULT_HIGH_COST_THRESHOLD;
   const staleHours = options.staleHours ?? DEFAULT_STALE_HOURS;
+  const lostHours = options.includeOldLost ? undefined : options.lostHours ?? DEFAULT_LOST_HOURS;
   const staleCutoffMs = now.getTime() - staleHours * 60 * 60 * 1000;
-  const candidates = sessions.filter(
-    (session) => options.includeCompleted || session.status !== 'completed'
-  );
+  const lostCutoffMs = lostHours == null
+    ? Number.NEGATIVE_INFINITY
+    : now.getTime() - lostHours * 60 * 60 * 1000;
+  let hiddenOldLost = 0;
+  const candidates = sessions.filter((session) => {
+    if (!options.includeCompleted && session.status === 'completed') return false;
+    if (session.status === 'lost' && session.lastActiveAt.getTime() < lostCutoffMs) {
+      hiddenOldLost += 1;
+      return false;
+    }
+    return true;
+  });
   const rankedItems = candidates
     .map((session) => buildAttentionItem(session, {
       highCostThreshold,
@@ -102,6 +117,8 @@ export function buildAttentionOverview(
       needingAttention: rankedItems.filter(hasCriticalOrWarningReason).length,
       critical: rankedItems.filter(hasCriticalReason).length,
       warning: rankedItems.filter(hasWarningReason).length,
+      hiddenOldLost,
+      lostWindowHours: lostHours,
     },
   };
 }

--- a/src/web/api/routes/orchestrator.ts
+++ b/src/web/api/routes/orchestrator.ts
@@ -44,14 +44,20 @@ app.get('/overview', (c) => {
   if (staleHoursResult.error) {
     return c.json({ success: false, error: staleHoursResult.error }, 400);
   }
+  const lostHoursResult = parsePositiveNumber(c.req.query('lostHours'), 'lostHours');
+  if (lostHoursResult.error) {
+    return c.json({ success: false, error: lostHoursResult.error }, 400);
+  }
 
   try {
     const sessions = getAggregatedSessions();
     const overview = buildAttentionOverview(sessions, {
       includeCompleted: c.req.query('includeCompleted') === 'true',
+      includeOldLost: c.req.query('includeOldLost') === 'true',
       limit: limitResult.value,
       highCostThreshold: highCostResult.value,
       staleHours: staleHoursResult.value,
+      lostHours: lostHoursResult.value,
       digests: getSessionDigestMap(sessions.map((session) => session.sessionId)),
     });
 

--- a/src/web/client/src/components/OrchestratorPanel/OrchestratorPanel.tsx
+++ b/src/web/client/src/components/OrchestratorPanel/OrchestratorPanel.tsx
@@ -33,7 +33,9 @@ export const OrchestratorPanel = memo(function OrchestratorPanel({
     needingAttention: 0,
     critical: 0,
     warning: 0,
+    hiddenOldLost: 0,
   }
+  const scopeText = formatScopeText(stats.hiddenOldLost, stats.lostWindowHours)
 
   return (
     <section
@@ -46,7 +48,9 @@ export const OrchestratorPanel = memo(function OrchestratorPanel({
         <div className={styles.headerText}>
           <h2 className={styles.title}>Orchestrator</h2>
           <div className={styles.meta}>
-            {overview ? `Generated ${formatRelativeTime(overview.generatedAt)}` : 'Waiting for overview'}
+            {overview
+              ? `Generated ${formatRelativeTime(overview.generatedAt)}${scopeText}`
+              : 'Waiting for overview'}
           </div>
         </div>
         <button
@@ -214,4 +218,9 @@ function DigestList({ title, items }: { title: string; items: string[] }) {
       </ul>
     </div>
   )
+}
+
+function formatScopeText(hiddenOldLost: number, lostWindowHours?: number): string {
+  if (hiddenOldLost === 0 || lostWindowHours == null) return ''
+  return ` | ${hiddenOldLost} old lost hidden (>${lostWindowHours}h)`
 }

--- a/src/web/client/src/types/orchestrator.ts
+++ b/src/web/client/src/types/orchestrator.ts
@@ -55,6 +55,8 @@ export interface OrchestratorOverviewStats {
   needingAttention: number
   critical: number
   warning: number
+  hiddenOldLost: number
+  lostWindowHours?: number
 }
 
 export interface OrchestratorOverviewData {


### PR DESCRIPTION
## 摘要
- 默认只把 1 小时内的 lost 会话放进 Orchestrator recovery/critical 队列，避免历史 lost 会话淹没当前视图
- 新增 `hiddenOldLost` / `lostWindowHours` 统计，让 UI 和 CLI 明确显示被隐藏的旧 lost 数量
- 新增 `--lost-hours`、`--include-old-lost` 和 API `lostHours`、`includeOldLost`，需要排查历史会话时仍可显式打开

## 验证
- `git diff --check`
- `bun test`：350 pass, 0 fail
- `bun run typecheck`
- `bun run build`
- `bun dist/index.js overview --limit 20 --json`：当前机器从旧口径的数百个关注项降到 60 candidates / 22 attention / 13 critical / 9 warning，并显示 hiddenOldLost=313

## 备注
- 这是 #62 合并后的口径修复，不删除任何历史 session 数据。