### PR TITLE
feat(orchestrator): show actionable session context

### DIFF
--- a/src/__tests__/attention.prioritizer.test.ts
+++ b/src/__tests__/attention.prioritizer.test.ts
@@ -18,7 +18,10 @@ function session(input: Partial<AggregatedSession> & {
     directory: input.directory ?? '/tmp/keepline',
     status: input.status,
     title: input.title ?? input.sessionId,
-    initialPrompt: '',
+    initialPrompt: input.initialPrompt ?? '',
+    lastTool: input.lastTool,
+    currentFile: input.currentFile,
+    lastMessage: input.lastMessage,
     startedAt: RECENT,
     lastActiveAt: input.lastActiveAt ?? RECENT,
     completedAt: input.completedAt,
@@ -202,6 +205,43 @@ describe('buildAttentionOverview', () => {
     expect(overview.items[0].sessionId).toBe('old-lost');
     expect(overview.stats.hiddenOldLost).toBe(0);
     expect(overview.stats.lostWindowHours).toBeUndefined();
+  });
+
+  test('includes compact session context for actionable review cards', () => {
+    const overview = buildAttentionOverview([
+      session({
+        sessionId: 'context-session',
+        status: 'waiting',
+        initialPrompt: '  Investigate issue 62\n\nand explain next step.  ',
+        lastMessage: 'I need human approval before merging the PR.',
+        lastTool: 'apply_patch',
+        currentFile: '/tmp/keepline/src/services/attention.prioritizer.ts',
+        messageCount: 12,
+        toolCount: 4,
+      }),
+    ], { now: NOW });
+
+    expect(overview.items[0].context).toEqual({
+      initialPrompt: 'Investigate issue 62 and explain next step.',
+      lastMessage: 'I need human approval before merging the PR.',
+      lastTool: 'apply_patch',
+      currentFile: '/tmp/keepline/src/services/attention.prioritizer.ts',
+      messageCount: 12,
+      toolCount: 4,
+    });
+  });
+
+  test('truncates long context previews in the overview payload', () => {
+    const overview = buildAttentionOverview([
+      session({
+        sessionId: 'long-context-session',
+        status: 'waiting',
+        lastMessage: 'x'.repeat(900),
+      }),
+    ], { now: NOW });
+
+    expect(overview.items[0].context.lastMessage).toHaveLength(700);
+    expect(overview.items[0].context.lastMessage?.endsWith('...')).toBe(true);
   });
 
   test('attaches serialized digest without changing queue order', () => {

--- a/src/__tests__/orchestrator.route.test.ts
+++ b/src/__tests__/orchestrator.route.test.ts
@@ -23,6 +23,9 @@ describe('Orchestrator Route Contract', () => {
       status: 'running',
       title: 'Expensive local run',
       initialPrompt: 'Track cost',
+      lastMessage: 'Cost is high, review before continuing',
+      lastTool: 'Read',
+      currentFile: '/tmp/keepline-orchestrator/report.md',
       lastActiveAt: new Date('2026-06-29T10:00:00.000Z'),
       toolCount: 2,
       messageCount: 4,
@@ -50,6 +53,14 @@ describe('Orchestrator Route Contract', () => {
         items: Array<{
           sessionId: string;
           lastActiveAt: string;
+          context: {
+            initialPrompt?: string;
+            lastMessage?: string;
+            lastTool?: string;
+            currentFile?: string;
+            messageCount: number;
+            toolCount: number;
+          };
           reasons: Array<{ code: string }>;
         }>;
         stats: { totalCandidates: number };
@@ -63,6 +74,14 @@ describe('Orchestrator Route Contract', () => {
     expect(body.data.items[0]).toMatchObject({
       sessionId: 'orchestrator-route-cost',
       lastActiveAt: '2026-06-29T10:00:00.000Z',
+      context: {
+        initialPrompt: 'Track cost',
+        lastMessage: 'Cost is high, review before continuing',
+        lastTool: 'Read',
+        currentFile: '/tmp/keepline-orchestrator/report.md',
+        messageCount: 4,
+        toolCount: 2,
+      },
     });
     expect(body.data.items[0].reasons.map((reason) => reason.code)).toContain('high_cost');
   });

--- a/src/services/attention.prioritizer.ts
+++ b/src/services/attention.prioritizer.ts
@@ -22,6 +22,15 @@ export interface AttentionReason {
   score: number;
 }
 
+export interface AttentionSessionContext {
+  initialPrompt?: string;
+  lastMessage?: string;
+  lastTool?: string;
+  currentFile?: string;
+  messageCount: number;
+  toolCount: number;
+}
+
 export interface AttentionQueueItem {
   rank: number;
   sessionId: string;
@@ -34,6 +43,7 @@ export interface AttentionQueueItem {
   reasons: AttentionReason[];
   recommendedAction: RecommendedAction;
   processRunning: boolean;
+  context: AttentionSessionContext;
   usageCost?: number;
   digest?: SerializableSessionDigest;
 }
@@ -69,6 +79,8 @@ export const MAX_ATTENTION_LIMIT = 100;
 export const DEFAULT_HIGH_COST_THRESHOLD = 1;
 export const DEFAULT_STALE_HOURS = 24;
 export const DEFAULT_LOST_HOURS = 1;
+export const MAX_ATTENTION_CONTEXT_LENGTH = 700;
+export const MAX_ATTENTION_PATH_LENGTH = 260;
 
 const WAITING_SCORE = 1000;
 const LOST_SCORE = 850;
@@ -205,6 +217,7 @@ function buildAttentionItem(
     reasons,
     recommendedAction: getRecommendedAction(reasons),
     processRunning: session.processRunning,
+    context: buildSessionContext(session),
     usageCost,
     digest: options.digest ? serializeSessionDigest(options.digest) : undefined,
   };
@@ -229,6 +242,24 @@ function getRecommendedAction(reasons: AttentionReason[]): RecommendedAction {
   if (reasons.some((reason) => reason.code === 'idle_activity')) return 'monitor';
   if (reasons.some((reason) => reason.code === 'active_session')) return 'monitor';
   return 'none';
+}
+
+function buildSessionContext(session: AggregatedSession): AttentionSessionContext {
+  return {
+    initialPrompt: compactText(session.initialPrompt, MAX_ATTENTION_CONTEXT_LENGTH),
+    lastMessage: compactText(session.lastMessage, MAX_ATTENTION_CONTEXT_LENGTH),
+    lastTool: compactText(session.lastTool, MAX_ATTENTION_PATH_LENGTH),
+    currentFile: compactText(session.currentFile, MAX_ATTENTION_PATH_LENGTH),
+    messageCount: session.messageCount,
+    toolCount: session.toolCount,
+  };
+}
+
+function compactText(value: string | undefined, maxLength: number): string | undefined {
+  const compacted = value?.trim().replace(/\s+/g, ' ');
+  if (!compacted) return undefined;
+  if (compacted.length <= maxLength) return compacted;
+  return compacted.slice(0, maxLength - 3) + '...';
 }
 
 function compareAttentionItems(a: AttentionQueueItem, b: AttentionQueueItem): number {

--- a/src/web/client/src/App.tsx
+++ b/src/web/client/src/App.tsx
@@ -165,6 +165,15 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
     setActiveTab('sessions')
   }, [])
 
+  const handleCopySessionId = useCallback(async (sessionId: string) => {
+    try {
+      await navigator.clipboard.writeText(sessionId)
+      showToast('Session ID copied', 'success')
+    } catch {
+      showToast('Failed to copy session ID', 'error')
+    }
+  }, [showToast])
+
   useKeyboardShortcuts({
     onRefresh: refresh,
     onSync: handleSync,
@@ -250,6 +259,10 @@ function DashboardApp({ token, onLogout }: DashboardAppProps) {
         <OrchestratorPanel
           token={token}
           onOpenSession={handleOpenOrchestratorSession}
+          onRecover={handleRecover}
+          onStop={handleStop}
+          onComplete={handleComplete}
+          onCopySessionId={handleCopySessionId}
         />
       )}
 

--- a/src/web/client/src/components/OrchestratorPanel/OrchestratorPanel.module.css
+++ b/src/web/client/src/components/OrchestratorPanel/OrchestratorPanel.module.css
@@ -203,6 +203,7 @@
 .actionBadge,
 .reasonPill,
 .openButton,
+.commandButton,
 .digestHeader span {
   min-height: 24px;
   display: inline-flex;
@@ -281,6 +282,93 @@
 
 .reasonCode {
   color: var(--text-bright);
+}
+
+.contextBlock {
+  display: grid;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.contextSection {
+  min-width: 0;
+  display: grid;
+  gap: var(--space-xs);
+}
+
+.contextLabel {
+  color: var(--primary);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.contextText {
+  max-height: 5.7rem;
+  overflow: hidden;
+  color: var(--text);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.contextMeta,
+.actionRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+}
+
+.contextMeta {
+  padding-top: var(--space-xs);
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+  border-top: 1px solid var(--border);
+}
+
+.contextMeta span {
+  overflow-wrap: anywhere;
+}
+
+.contextEmpty {
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+}
+
+.actionRow {
+  padding-top: var(--space-xs);
+}
+
+.commandButton {
+  cursor: pointer;
+  font-family: var(--font-mono);
+}
+
+.commandButton:hover,
+.commandButton:focus-visible {
+  color: var(--primary);
+  border-color: var(--primary);
+  outline: none;
+}
+
+.primaryCommand {
+  color: var(--primary);
+  border-color: var(--primary);
+}
+
+.recoverCommand {
+  color: var(--warning);
+  border-color: var(--warning);
+}
+
+.stopCommand {
+  color: var(--danger);
+  border-color: var(--danger);
 }
 
 .digestBlock {

--- a/src/web/client/src/components/OrchestratorPanel/OrchestratorPanel.tsx
+++ b/src/web/client/src/components/OrchestratorPanel/OrchestratorPanel.tsx
@@ -13,6 +13,10 @@ import styles from './OrchestratorPanel.module.css'
 interface OrchestratorPanelProps {
   token: string
   onOpenSession?: (sessionId: string) => void
+  onRecover?: (sessionId: string) => void | Promise<void>
+  onStop?: (sessionId: string) => void | Promise<void>
+  onComplete?: (sessionId: string) => void | Promise<void>
+  onCopySessionId?: (sessionId: string) => void | Promise<void>
 }
 
 const ACTION_LABELS: Record<OrchestratorRecommendedAction, string> = {
@@ -26,6 +30,10 @@ const ACTION_LABELS: Record<OrchestratorRecommendedAction, string> = {
 export const OrchestratorPanel = memo(function OrchestratorPanel({
   token,
   onOpenSession,
+  onRecover,
+  onStop,
+  onComplete,
+  onCopySessionId,
 }: OrchestratorPanelProps) {
   const { overview, loading, error, refresh } = useOrchestratorOverview(token)
   const stats = overview?.stats ?? {
@@ -85,7 +93,16 @@ export const OrchestratorPanel = memo(function OrchestratorPanel({
       ) : overview ? (
         <div className={styles.queueList}>
           {overview.items.map((item) => (
-            <QueueCard key={item.sessionId} item={item} onOpenSession={onOpenSession} />
+            <QueueCard
+              key={item.sessionId}
+              item={item}
+              onOpenSession={onOpenSession}
+              onRecover={onRecover}
+              onStop={onStop}
+              onComplete={onComplete}
+              onCopySessionId={onCopySessionId}
+              onActionComplete={refresh}
+            />
           ))}
         </div>
       ) : null}
@@ -113,9 +130,19 @@ function OrchestratorStat({
 function QueueCard({
   item,
   onOpenSession,
+  onRecover,
+  onStop,
+  onComplete,
+  onCopySessionId,
+  onActionComplete,
 }: {
   item: OrchestratorQueueItem
   onOpenSession?: (sessionId: string) => void
+  onRecover?: (sessionId: string) => void | Promise<void>
+  onStop?: (sessionId: string) => void | Promise<void>
+  onComplete?: (sessionId: string) => void | Promise<void>
+  onCopySessionId?: (sessionId: string) => void | Promise<void>
+  onActionComplete?: () => void | Promise<void>
 }) {
   return (
     <article className={styles.queueCard}>
@@ -136,30 +163,150 @@ function QueueCard({
             <span className={`${styles.actionBadge} ${styles[item.recommendedAction]}`}>
               {ACTION_LABELS[item.recommendedAction]}
             </span>
-            {onOpenSession && (
-              <button
-                type="button"
-                className={styles.openButton}
-                onClick={() => onOpenSession(item.sessionId)}
-              >
-                Open
-              </button>
-            )}
           </div>
         </div>
 
         <div className={styles.metaRow}>
           <span>{formatRelativeTime(item.lastActiveAt)}</span>
           <span>{item.processRunning ? 'process running' : 'no process'}</span>
+          <span>{item.context.messageCount} messages</span>
+          <span>{item.context.toolCount} tools</span>
           {item.usageCost != null && <span>{formatCost(item.usageCost)}</span>}
           <span>{item.sessionId}</span>
         </div>
 
         <ReasonList reasons={item.reasons} />
+        <ContextBlock item={item} />
         {item.digest && <DigestBlock digest={item.digest} />}
+        <ActionRow
+          item={item}
+          onOpenSession={onOpenSession}
+          onRecover={onRecover}
+          onStop={onStop}
+          onComplete={onComplete}
+          onCopySessionId={onCopySessionId}
+          onActionComplete={onActionComplete}
+        />
       </div>
     </article>
   )
+}
+
+function ContextBlock({ item }: { item: OrchestratorQueueItem }) {
+  const rows = getContextRows(item)
+  const details = [
+    item.context.currentFile ? `File: ${item.context.currentFile}` : undefined,
+    item.context.lastTool ? `Last tool: ${item.context.lastTool}` : undefined,
+  ].filter((value): value is string => Boolean(value))
+
+  if (rows.length === 0 && details.length === 0) {
+    return <div className={styles.contextEmpty}>No prompt or response preview captured yet</div>
+  }
+
+  return (
+    <div className={styles.contextBlock}>
+      {rows.map((row) => (
+        <section className={styles.contextSection} key={row.label}>
+          <div className={styles.contextLabel}>{row.label}</div>
+          <div className={styles.contextText}>{row.text}</div>
+        </section>
+      ))}
+      {details.length > 0 && (
+        <div className={styles.contextMeta}>
+          {details.map((detail) => (
+            <span key={detail}>{detail}</span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ActionRow({
+  item,
+  onOpenSession,
+  onRecover,
+  onStop,
+  onComplete,
+  onCopySessionId,
+  onActionComplete,
+}: {
+  item: OrchestratorQueueItem
+  onOpenSession?: (sessionId: string) => void
+  onRecover?: (sessionId: string) => void | Promise<void>
+  onStop?: (sessionId: string) => void | Promise<void>
+  onComplete?: (sessionId: string) => void | Promise<void>
+  onCopySessionId?: (sessionId: string) => void | Promise<void>
+  onActionComplete?: () => void | Promise<void>
+}) {
+  if (!onOpenSession && !onRecover && !onStop && !onComplete && !onCopySessionId) return null
+
+  const canRecover = item.recommendedAction === 'recover' && onRecover
+  const canStop = (item.status === 'running' || item.status === 'waiting') && onStop
+  const canComplete = item.status !== 'completed' && onComplete
+  const openLabel = item.recommendedAction === 'review' ? 'Review Details' : 'Open Details'
+
+  return (
+    <div className={styles.actionRow} role="group" aria-label={`Actions for ${item.sessionId}`}>
+      {onOpenSession && (
+        <button
+          type="button"
+          className={`${styles.commandButton} ${styles.primaryCommand}`}
+          onClick={() => onOpenSession(item.sessionId)}
+        >
+          {openLabel}
+        </button>
+      )}
+      {canRecover && (
+        <button
+          type="button"
+          className={`${styles.commandButton} ${styles.recoverCommand}`}
+          onClick={() => void runAction(() => onRecover(item.sessionId), onActionComplete)}
+        >
+          Recover
+        </button>
+      )}
+      {canStop && (
+        <button
+          type="button"
+          className={`${styles.commandButton} ${styles.stopCommand}`}
+          onClick={() => void runAction(() => onStop(item.sessionId), onActionComplete)}
+        >
+          Stop
+        </button>
+      )}
+      {canComplete && (
+        <button
+          type="button"
+          className={styles.commandButton}
+          onClick={() => void runAction(() => onComplete(item.sessionId), onActionComplete)}
+        >
+          Complete
+        </button>
+      )}
+      {onCopySessionId && (
+        <button
+          type="button"
+          className={styles.commandButton}
+          onClick={() => void runAction(() => onCopySessionId(item.sessionId))}
+        >
+          Copy ID
+        </button>
+      )}
+    </div>
+  )
+}
+
+async function runAction(
+  action: () => void | Promise<void>,
+  onActionComplete?: () => void | Promise<void>
+) {
+  try {
+    await action()
+    await onActionComplete?.()
+  } catch (error) {
+    console.error('Orchestrator action failed:', error)
+  }
 }
 
 function ReasonList({ reasons }: { reasons: OrchestratorReason[] }) {
@@ -218,6 +365,29 @@ function DigestList({ title, items }: { title: string; items: string[] }) {
       </ul>
     </div>
   )
+}
+
+function getContextRows(item: OrchestratorQueueItem): Array<{ label: string; text: string }> {
+  const seen = new Set<string>()
+  const rows: Array<{ label: string; text: string }> = []
+
+  pushContextRow(rows, seen, 'Summary', item.digest?.summary)
+  pushContextRow(rows, seen, 'Last response', item.context.lastMessage)
+  pushContextRow(rows, seen, 'Prompt', item.context.initialPrompt)
+
+  return rows.slice(0, 3)
+}
+
+function pushContextRow(
+  rows: Array<{ label: string; text: string }>,
+  seen: Set<string>,
+  label: string,
+  value: string | undefined
+) {
+  const text = value?.trim()
+  if (!text || seen.has(text)) return
+  seen.add(text)
+  rows.push({ label, text })
 }
 
 function formatScopeText(hiddenOldLost: number, lostWindowHours?: number): string {

--- a/src/web/client/src/types/orchestrator.ts
+++ b/src/web/client/src/types/orchestrator.ts
@@ -20,6 +20,15 @@ export interface OrchestratorReason {
   score: number
 }
 
+export interface OrchestratorSessionContext {
+  initialPrompt?: string
+  lastMessage?: string
+  lastTool?: string
+  currentFile?: string
+  messageCount: number
+  toolCount: number
+}
+
 export interface OrchestratorDigest {
   sessionId: string
   summary: string
@@ -46,6 +55,7 @@ export interface OrchestratorQueueItem {
   reasons: OrchestratorReason[]
   recommendedAction: OrchestratorRecommendedAction
   processRunning: boolean
+  context: OrchestratorSessionContext
   usageCost?: number
   digest?: OrchestratorDigest
 }


### PR DESCRIPTION
## 摘要
- Orchestrator overview item 新增 `context` payload：压缩后的 initial prompt、last message、last tool、current file、message/tool counts
- Orchestrator 卡片直接显示 Summary / Last response / Prompt 预览，避免只看到一排相似的 AGENTS.md 标题
- 卡片新增操作区：Review/Open Details、Recover、Stop、Complete、Copy ID，并在 Recover/Stop/Complete 后刷新 Orchestrator overview

## 验证
- `bun test src/__tests__/attention.prioritizer.test.ts src/__tests__/orchestrator.route.test.ts`：17 pass, 0 fail
- `bun run typecheck`
- `bun test`：352 pass, 0 fail
- `bun run build`
- `bun dist/index.js overview --limit 2 --json`：确认 item.context.lastMessage/messageCount/toolCount 已出现在真实 payload
- HTTP smoke：`curl -I http://127.0.0.1:3377/` 返回 200，`/api/auth/status` 正常

## 验证缺口
- 尝试用内置浏览器截图检查，但当前环境 `agent.browsers.list()` 返回空列表，无法执行截图级视觉验证。