### PR TITLE
feat(orchestrator): show actionable session intent

### DIFF
--- a/src/__tests__/attention.prioritizer.test.ts
+++ b/src/__tests__/attention.prioritizer.test.ts
@@ -244,6 +244,53 @@ describe('buildAttentionOverview', () => {
     expect(overview.items[0].context.lastMessage?.endsWith('...')).toBe(true);
   });
 
+  test('extracts actionable intent when prompt and title are instruction noise', () => {
+    const overview = buildAttentionOverview([
+      session({
+        sessionId: 'intent-session',
+        status: 'lost',
+        title: '# AGENTS.md instructions <INSTRUCTIONS> vibeguard-start',
+        initialPrompt: '# AGENTS.md instructions <INSTRUCTIONS> Files called AGENTS.md commonly appear in many places.',
+        lastMessage: 'Denoise probe 第一次启动失败了，我先看 stderr。通常这种是脚本路径或 OpenVINO Async API 细节。',
+        currentFile: '/Users/lifcc/Desktop/code/work/infra/vsr/runs/topaz_dragon_cleanup_20260629T035947Z/cleanup_standard.png',
+        lastTool: 'exec_command',
+      }),
+    ], { now: NOW });
+
+    expect(overview.items[0].intent).toMatchObject({
+      task: 'Investigate: Denoise probe 第一次启动失败了，我先看 stderr',
+      currentState: 'Denoise probe 第一次启动失败了，我先看 stderr。通常这种是脚本路径或 OpenVINO Async API 细节。',
+      nextAction: 'Recover this session and continue around topaz_dragon_cleanup_20260629T035947Z/cleanup_standard.png.',
+      whyAttention: 'Session is lost and may be recoverable',
+      confidence: 'medium',
+      noiseFlags: [
+        'instructions_heavy',
+        'derived_from_last_message',
+        'missing_user_goal',
+      ],
+      evidence: {
+        lastTool: 'exec_command',
+        currentFile: '/Users/lifcc/Desktop/code/work/infra/vsr/runs/topaz_dragon_cleanup_20260629T035947Z/cleanup_standard.png',
+      },
+    });
+  });
+
+  test('skips low-information response openers when deriving intent', () => {
+    const overview = buildAttentionOverview([
+      session({
+        sessionId: 'filler-session',
+        status: 'lost',
+        title: '# AGENTS.md instructions <INSTRUCTIONS> vibeguard-start',
+        initialPrompt: '# AGENTS.md instructions <INSTRUCTIONS> Files called AGENTS.md commonly appear in many places.',
+        lastMessage: '看了。结论是：gh21 应该学习产品行为和交互契约，不是照搬原型 UI。',
+      }),
+    ], { now: NOW });
+
+    expect(overview.items[0].intent.task).toBe(
+      'Continue: 结论是：gh21 应该学习产品行为和交互契约，不是照搬原型 UI'
+    );
+  });
+
   test('attaches serialized digest without changing queue order', () => {
     const digest: SessionDigest = {
       id: 'digest-id',

--- a/src/__tests__/orchestrator.route.test.ts
+++ b/src/__tests__/orchestrator.route.test.ts
@@ -61,6 +61,13 @@ describe('Orchestrator Route Contract', () => {
             messageCount: number;
             toolCount: number;
           };
+          intent: {
+            task?: string;
+            currentState?: string;
+            nextAction: string;
+            whyAttention: string;
+            confidence: string;
+          };
           reasons: Array<{ code: string }>;
         }>;
         stats: { totalCandidates: number };
@@ -81,6 +88,13 @@ describe('Orchestrator Route Contract', () => {
         currentFile: '/tmp/keepline-orchestrator/report.md',
         messageCount: 4,
         toolCount: 2,
+      },
+      intent: {
+        task: 'Track cost',
+        currentState: 'Cost is high, review before continuing',
+        nextAction: 'Recover this session and continue around keepline-orchestrator/report.md.',
+        whyAttention: 'Session is lost and may be recoverable; Session cost is $5.00',
+        confidence: 'high',
       },
     });
     expect(body.data.items[0].reasons.map((reason) => reason.code)).toContain('high_cost');

--- a/src/services/attention.prioritizer.ts
+++ b/src/services/attention.prioritizer.ts
@@ -31,6 +31,28 @@ export interface AttentionSessionContext {
   toolCount: number;
 }
 
+export type AttentionIntentConfidence = 'high' | 'medium' | 'low';
+export type AttentionIntentNoiseFlag =
+  | 'instructions_heavy'
+  | 'missing_user_goal'
+  | 'derived_from_last_message'
+  | 'derived_from_file';
+
+export interface AttentionIntent {
+  task?: string;
+  currentState?: string;
+  nextAction: string;
+  whyAttention: string;
+  confidence: AttentionIntentConfidence;
+  noiseFlags: AttentionIntentNoiseFlag[];
+  evidence: {
+    promptExcerpt?: string;
+    lastMessage?: string;
+    lastTool?: string;
+    currentFile?: string;
+  };
+}
+
 export interface AttentionQueueItem {
   rank: number;
   sessionId: string;
@@ -44,6 +66,7 @@ export interface AttentionQueueItem {
   recommendedAction: RecommendedAction;
   processRunning: boolean;
   context: AttentionSessionContext;
+  intent: AttentionIntent;
   usageCost?: number;
   digest?: SerializableSessionDigest;
 }
@@ -81,6 +104,7 @@ export const DEFAULT_STALE_HOURS = 24;
 export const DEFAULT_LOST_HOURS = 1;
 export const MAX_ATTENTION_CONTEXT_LENGTH = 700;
 export const MAX_ATTENTION_PATH_LENGTH = 260;
+export const MAX_ATTENTION_INTENT_LENGTH = 260;
 
 const WAITING_SCORE = 1000;
 const LOST_SCORE = 850;
@@ -218,6 +242,7 @@ function buildAttentionItem(
     recommendedAction: getRecommendedAction(reasons),
     processRunning: session.processRunning,
     context: buildSessionContext(session),
+    intent: buildSessionIntent(session, reasons, options.digest),
     usageCost,
     digest: options.digest ? serializeSessionDigest(options.digest) : undefined,
   };
@@ -260,6 +285,149 @@ function compactText(value: string | undefined, maxLength: number): string | und
   if (!compacted) return undefined;
   if (compacted.length <= maxLength) return compacted;
   return compacted.slice(0, maxLength - 3) + '...';
+}
+
+function buildSessionIntent(
+  session: AggregatedSession,
+  reasons: AttentionReason[],
+  digest?: SessionDigest
+): AttentionIntent {
+  const noiseFlags: AttentionIntentNoiseFlag[] = [];
+  const prompt = compactText(session.initialPrompt, MAX_ATTENTION_CONTEXT_LENGTH);
+  const promptIsNoise = isInstructionNoise(session.initialPrompt);
+  const titleIsNoise = isInstructionNoise(session.title);
+  if (promptIsNoise || titleIsNoise) noiseFlags.push('instructions_heavy');
+
+  const promptTask = promptIsNoise ? undefined : intentText(session.initialPrompt);
+  const digestTask = intentText(digest?.summary);
+  const titleTask = titleIsNoise ? undefined : intentText(session.title);
+  const lastMessage = intentText(session.lastMessage);
+  const taskMessage = meaningfulTaskMessage(session.lastMessage);
+  const fileTask = session.currentFile
+    ? `Working around ${formatPathTail(session.currentFile)}`
+    : undefined;
+
+  let task = firstNonEmpty([promptTask, digestTask, titleTask]);
+  let confidence: AttentionIntentConfidence = task ? 'high' : 'low';
+
+  if (!task && taskMessage) {
+    task = deriveTaskFromLastMessage(taskMessage);
+    confidence = 'medium';
+    noiseFlags.push('derived_from_last_message');
+  }
+
+  if (!task && fileTask) {
+    task = fileTask;
+    confidence = 'low';
+    noiseFlags.push('derived_from_file');
+  }
+
+  if (!promptTask && !titleTask) {
+    noiseFlags.push('missing_user_goal');
+  }
+
+  return {
+    task,
+    currentState: firstNonEmpty([lastMessage, digestTask, titleTask]),
+    nextAction: buildNextAction(session, reasons),
+    whyAttention: buildWhyAttention(reasons),
+    confidence,
+    noiseFlags: dedupeNoiseFlags(noiseFlags),
+    evidence: {
+      promptExcerpt: prompt,
+      lastMessage,
+      lastTool: compactText(session.lastTool, MAX_ATTENTION_PATH_LENGTH),
+      currentFile: compactText(session.currentFile, MAX_ATTENTION_PATH_LENGTH),
+    },
+  };
+}
+
+function intentText(value: string | undefined): string | undefined {
+  return compactText(value, MAX_ATTENTION_INTENT_LENGTH);
+}
+
+function isInstructionNoise(value: string | undefined): boolean {
+  if (!value) return false;
+  const lower = value.toLowerCase();
+  return lower.includes('agents.md instructions') ||
+    lower.startsWith('agents.md') ||
+    lower.startsWith('# agents.md') ||
+    lower.includes('<instructions>') ||
+    lower.includes('vibeguard-start') ||
+    lower.includes('vibeguard') ||
+    lower.includes('files called agents.md');
+}
+
+function meaningfulTaskMessage(value: string | undefined): string | undefined {
+  const text = intentText(value);
+  if (!text) return undefined;
+  if (text.length < 12 && /^(ok|okay|done|继续正常|好的|收到|完成)$/i.test(text)) {
+    return undefined;
+  }
+  return text;
+}
+
+function deriveTaskFromLastMessage(lastMessage: string): string {
+  const phrase = extractTaskPhrase(lastMessage);
+  const failureLike = /failed|failure|error|stderr|失败|报错|异常|启动失败/i.test(phrase);
+  const prefix = failureLike ? 'Investigate' : 'Continue';
+  return compactText(`${prefix}: ${phrase}`, MAX_ATTENTION_INTENT_LENGTH) ?? phrase;
+}
+
+function extractTaskPhrase(lastMessage: string): string {
+  const sentences = lastMessage
+    .split(/[.!?。！？]/u)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean);
+
+  return sentences.find((sentence) => !isLowInformationSentence(sentence)) ??
+    sentences[0] ??
+    lastMessage;
+}
+
+function isLowInformationSentence(sentence: string): boolean {
+  return sentence.length < 8 && /^(ok|okay|done|看了|好的|收到|完成|继续)$/i.test(sentence);
+}
+
+function buildNextAction(session: AggregatedSession, reasons: AttentionReason[]): string {
+  if (reasons.some((reason) => reason.code === 'recoverable_lost')) {
+    return session.currentFile
+      ? `Recover this session and continue around ${formatPathTail(session.currentFile)}.`
+      : 'Recover this session and continue from the current state.';
+  }
+  if (reasons.some((reason) => reason.code === 'waiting_for_human')) {
+    return 'Open details and provide the requested human input.';
+  }
+  if (reasons.some((reason) => reason.code === 'high_cost')) {
+    return 'Review recent activity and decide whether to stop, continue, or complete it.';
+  }
+  if (reasons.some((reason) => reason.code === 'stale_activity')) {
+    return 'Open details and decide whether to continue or mark it complete.';
+  }
+  if (session.status === 'idle' || session.status === 'running') {
+    return 'Monitor the session unless it needs manual follow-up.';
+  }
+  return 'No action needed.';
+}
+
+function buildWhyAttention(reasons: AttentionReason[]): string {
+  const attentionReasons = reasons.filter((reason) => reason.severity !== 'info');
+  if (attentionReasons.length === 0) return 'No critical or warning reason.';
+  return attentionReasons.map((reason) => reason.message).join('; ');
+}
+
+function firstNonEmpty(values: Array<string | undefined>): string | undefined {
+  return values.find((value) => value?.trim());
+}
+
+function formatPathTail(path: string): string {
+  const parts = path.split('/').filter(Boolean);
+  if (parts.length <= 2) return path;
+  return parts.slice(-2).join('/');
+}
+
+function dedupeNoiseFlags(flags: AttentionIntentNoiseFlag[]): AttentionIntentNoiseFlag[] {
+  return [...new Set(flags)];
 }
 
 function compareAttentionItems(a: AttentionQueueItem, b: AttentionQueueItem): number {

--- a/src/web/client/src/components/OrchestratorPanel/OrchestratorPanel.module.css
+++ b/src/web/client/src/components/OrchestratorPanel/OrchestratorPanel.module.css
@@ -284,13 +284,104 @@
   color: var(--text-bright);
 }
 
-.contextBlock {
+.intentBlock {
   display: grid;
   gap: var(--space-sm);
   padding: var(--space-md);
   background: var(--bg-elevated);
   border: 1px solid var(--border);
+  border-left: 3px solid var(--primary);
   border-radius: var(--radius-sm);
+}
+
+.intentHeader,
+.intentGrid {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.intentHeader {
+  grid-template-columns: repeat(auto-fit, minmax(120px, max-content));
+}
+
+.intentGrid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.intentSection {
+  min-width: 0;
+  display: grid;
+  gap: var(--space-xs);
+}
+
+.intentLabel {
+  color: var(--primary);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.intentText {
+  color: var(--text);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.confidenceBadge,
+.noiseBadge {
+  min-height: 22px;
+  display: inline-flex;
+  align-items: center;
+  width: max-content;
+  padding: 2px var(--space-sm);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+  line-height: 1.2;
+}
+
+.confidence_high {
+  color: var(--success);
+  border-color: var(--success);
+}
+
+.confidence_medium {
+  color: var(--warning);
+  border-color: var(--warning);
+}
+
+.confidence_low,
+.noiseBadge {
+  color: var(--text-dim);
+  border-color: var(--border);
+}
+
+.rawEvidence {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+}
+
+.rawSummary {
+  cursor: pointer;
+  padding: var(--space-sm) var(--space-md);
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+}
+
+.rawEvidence[open] .rawSummary {
+  border-bottom: 1px solid var(--border);
+}
+
+.contextBlock {
+  display: grid;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: transparent;
 }
 
 .contextSection {
@@ -471,7 +562,8 @@
   }
 
   .statsGrid,
-  .digestLists {
+  .digestLists,
+  .intentGrid {
     grid-template-columns: 1fr;
   }
 }

--- a/src/web/client/src/components/OrchestratorPanel/OrchestratorPanel.tsx
+++ b/src/web/client/src/components/OrchestratorPanel/OrchestratorPanel.tsx
@@ -3,6 +3,7 @@ import { Spinner } from '@/components/Spinner'
 import { useOrchestratorOverview } from '@/hooks'
 import type {
   OrchestratorDigest,
+  OrchestratorIntent,
   OrchestratorQueueItem,
   OrchestratorReason,
   OrchestratorRecommendedAction,
@@ -154,8 +155,8 @@ function QueueCard({
       <div className={styles.cardBody}>
         <div className={styles.cardHeader}>
           <div className={styles.identity}>
-            <h3 className={styles.itemTitle}>{item.title || item.sessionId}</h3>
-            <div className={styles.pathLine}>{formatPath(item.directory)}</div>
+            <h3 className={styles.itemTitle}>{item.intent.task || 'No clear task captured'}</h3>
+            <div className={styles.pathLine}>{formatIdentitySubtitle(item)}</div>
           </div>
           <div className={styles.badges}>
             <span className={`${styles.badge} ${styles[item.status]}`}>{item.status}</span>
@@ -176,8 +177,9 @@ function QueueCard({
         </div>
 
         <ReasonList reasons={item.reasons} />
-        <ContextBlock item={item} />
+        <IntentBlock intent={item.intent} />
         {item.digest && <DigestBlock digest={item.digest} />}
+        <RawEvidenceBlock item={item} />
         <ActionRow
           item={item}
           onOpenSession={onOpenSession}
@@ -192,33 +194,66 @@ function QueueCard({
   )
 }
 
-function ContextBlock({ item }: { item: OrchestratorQueueItem }) {
+function IntentBlock({ intent }: { intent: OrchestratorIntent }) {
+  const rows = [
+    { label: 'Task', text: intent.task },
+    { label: 'Current state', text: intent.currentState },
+    { label: 'Next action', text: intent.nextAction },
+    { label: 'Why attention', text: intent.whyAttention },
+  ].filter((row): row is { label: string; text: string } => Boolean(row.text))
+
+  return (
+    <div className={styles.intentBlock}>
+      <div className={styles.intentHeader}>
+        <span className={`${styles.confidenceBadge} ${styles[`confidence_${intent.confidence}`]}`}>
+          {intent.confidence} confidence
+        </span>
+        {intent.noiseFlags.map((flag) => (
+          <span className={styles.noiseBadge} key={flag}>{formatNoiseFlag(flag)}</span>
+        ))}
+      </div>
+      <div className={styles.intentGrid}>
+        {rows.map((row) => (
+          <section className={styles.intentSection} key={row.label}>
+            <div className={styles.intentLabel}>{row.label}</div>
+            <div className={styles.intentText}>{row.text}</div>
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function RawEvidenceBlock({ item }: { item: OrchestratorQueueItem }) {
   const rows = getContextRows(item)
   const details = [
-    item.context.currentFile ? `File: ${item.context.currentFile}` : undefined,
-    item.context.lastTool ? `Last tool: ${item.context.lastTool}` : undefined,
+    item.intent.evidence.currentFile ? `File: ${item.intent.evidence.currentFile}` : undefined,
+    item.intent.evidence.lastTool ? `Last tool: ${item.intent.evidence.lastTool}` : undefined,
   ].filter((value): value is string => Boolean(value))
 
   if (rows.length === 0 && details.length === 0) {
-    return <div className={styles.contextEmpty}>No prompt or response preview captured yet</div>
+    return null
   }
 
   return (
-    <div className={styles.contextBlock}>
-      {rows.map((row) => (
-        <section className={styles.contextSection} key={row.label}>
-          <div className={styles.contextLabel}>{row.label}</div>
-          <div className={styles.contextText}>{row.text}</div>
-        </section>
-      ))}
-      {details.length > 0 && (
-        <div className={styles.contextMeta}>
-          {details.map((detail) => (
-            <span key={detail}>{detail}</span>
-          ))}
-        </div>
-      )}
-    </div>
+    <details className={styles.rawEvidence}>
+      <summary className={styles.rawSummary}>Raw evidence</summary>
+      <div className={styles.contextBlock}>
+        {rows.map((row) => (
+          <section className={styles.contextSection} key={row.label}>
+            <div className={styles.contextLabel}>{row.label}</div>
+            <div className={styles.contextText}>{row.text}</div>
+          </section>
+        ))}
+        {details.length > 0 && (
+          <div className={styles.contextMeta}>
+            {details.map((detail) => (
+              <span key={detail}>{detail}</span>
+            ))}
+          </div>
+        )}
+      </div>
+    </details>
   )
 }
 
@@ -371,9 +406,8 @@ function getContextRows(item: OrchestratorQueueItem): Array<{ label: string; tex
   const seen = new Set<string>()
   const rows: Array<{ label: string; text: string }> = []
 
-  pushContextRow(rows, seen, 'Summary', item.digest?.summary)
-  pushContextRow(rows, seen, 'Last response', item.context.lastMessage)
-  pushContextRow(rows, seen, 'Prompt', item.context.initialPrompt)
+  pushContextRow(rows, seen, 'Last response', item.intent.evidence.lastMessage)
+  pushContextRow(rows, seen, 'Prompt excerpt', item.intent.evidence.promptExcerpt)
 
   return rows.slice(0, 3)
 }
@@ -393,4 +427,17 @@ function pushContextRow(
 function formatScopeText(hiddenOldLost: number, lostWindowHours?: number): string {
   if (hiddenOldLost === 0 || lostWindowHours == null) return ''
   return ` | ${hiddenOldLost} old lost hidden (>${lostWindowHours}h)`
+}
+
+function formatNoiseFlag(flag: string): string {
+  return flag.replace(/_/g, ' ')
+}
+
+function formatIdentitySubtitle(item: OrchestratorQueueItem): string {
+  const directory = formatPath(item.directory)
+  const titleIsNoise = item.intent.noiseFlags.includes('instructions_heavy')
+  if (!item.intent.task || !item.title || titleIsNoise || item.title === item.intent.task) {
+    return directory
+  }
+  return `${directory} | ${item.title}`
 }

--- a/src/web/client/src/types/orchestrator.ts
+++ b/src/web/client/src/types/orchestrator.ts
@@ -29,6 +29,28 @@ export interface OrchestratorSessionContext {
   toolCount: number
 }
 
+export type OrchestratorIntentConfidence = 'high' | 'medium' | 'low'
+export type OrchestratorIntentNoiseFlag =
+  | 'instructions_heavy'
+  | 'missing_user_goal'
+  | 'derived_from_last_message'
+  | 'derived_from_file'
+
+export interface OrchestratorIntent {
+  task?: string
+  currentState?: string
+  nextAction: string
+  whyAttention: string
+  confidence: OrchestratorIntentConfidence
+  noiseFlags: OrchestratorIntentNoiseFlag[]
+  evidence: {
+    promptExcerpt?: string
+    lastMessage?: string
+    lastTool?: string
+    currentFile?: string
+  }
+}
+
 export interface OrchestratorDigest {
   sessionId: string
   summary: string
@@ -56,6 +78,7 @@ export interface OrchestratorQueueItem {
   recommendedAction: OrchestratorRecommendedAction
   processRunning: boolean
   context: OrchestratorSessionContext
+  intent: OrchestratorIntent
   usageCost?: number
   digest?: OrchestratorDigest
 }


### PR DESCRIPTION
## Summary
- Add deterministic Orchestrator intent extraction for task, current state, next action, attention reason, confidence, and evidence
- Treat AGENTS/VibeGuard instruction-heavy prompts as noise and derive actionable task text from recent session activity
- Update Orchestrator cards to show intent first and collapse raw prompt/response evidence behind details

## Verification
- git diff --check
- bun test src/__tests__/attention.prioritizer.test.ts src/__tests__/orchestrator.route.test.ts
- bun run typecheck
- bun test
- bun run build
- curl -fsSI http://127.0.0.1:3377/
- curl -fsS http://127.0.0.1:3377/api/auth/status
- bun dist/index.js overview --limit 3 --json | jq ...

## Notes
- In-app browser screenshot verification was skipped because no in-app browser instance was available in this environment; local HTTP/API/CLI smoke checks passed.