### PR TITLE
fix(orchestrator): ignore low-information intent text

### DIFF
--- a/src/__tests__/attention.prioritizer.test.ts
+++ b/src/__tests__/attention.prioritizer.test.ts
@@ -291,6 +291,40 @@ describe('buildAttentionOverview', () => {
     );
   });
 
+  test('does not use low-information responses as derived tasks', () => {
+    const overview = buildAttentionOverview([
+      session({
+        sessionId: 'low-info-session',
+        status: 'waiting',
+        title: '# AGENTS.md instructions <INSTRUCTIONS> vibeguard-start',
+        initialPrompt: '# AGENTS.md instructions <INSTRUCTIONS> Files called AGENTS.md commonly appear in many places.',
+        lastMessage: '继续正常。',
+      }),
+    ], { now: NOW });
+
+    expect(overview.items[0].intent.task).toBeUndefined();
+    expect(overview.items[0].intent.currentState).toBe('继续正常。');
+    expect(overview.items[0].intent.noiseFlags).toEqual([
+      'instructions_heavy',
+      'missing_user_goal',
+    ]);
+  });
+
+  test('ignores greeting and citation footer responses when deriving intent', () => {
+    const overview = buildAttentionOverview([
+      session({
+        sessionId: 'greeting-session',
+        status: 'waiting',
+        title: '# AGENTS.md instructions <INSTRUCTIONS> vibeguard-start',
+        initialPrompt: '# AGENTS.md instructions <INSTRUCTIONS> Files called AGENTS.md commonly appear in many places.',
+        lastMessage: '你好，我在。 Memory citations: none',
+      }),
+    ], { now: NOW });
+
+    expect(overview.items[0].intent.task).toBeUndefined();
+    expect(overview.items[0].intent.currentState).toBe('你好，我在。 Memory citations: none');
+  });
+
   test('attaches serialized digest without changing queue order', () => {
     const digest: SessionDigest = {
       id: 'digest-id',

--- a/src/services/attention.prioritizer.ts
+++ b/src/services/attention.prioritizer.ts
@@ -361,32 +361,41 @@ function isInstructionNoise(value: string | undefined): boolean {
 function meaningfulTaskMessage(value: string | undefined): string | undefined {
   const text = intentText(value);
   if (!text) return undefined;
-  if (text.length < 12 && /^(ok|okay|done|继续正常|好的|收到|完成)$/i.test(text)) {
+  if (!extractTaskPhrase(text)) {
     return undefined;
   }
   return text;
 }
 
-function deriveTaskFromLastMessage(lastMessage: string): string {
+function deriveTaskFromLastMessage(lastMessage: string): string | undefined {
   const phrase = extractTaskPhrase(lastMessage);
+  if (!phrase) return undefined;
   const failureLike = /failed|failure|error|stderr|失败|报错|异常|启动失败/i.test(phrase);
   const prefix = failureLike ? 'Investigate' : 'Continue';
   return compactText(`${prefix}: ${phrase}`, MAX_ATTENTION_INTENT_LENGTH) ?? phrase;
 }
 
-function extractTaskPhrase(lastMessage: string): string {
+function extractTaskPhrase(lastMessage: string): string | undefined {
   const sentences = lastMessage
     .split(/[.!?。！？]/u)
     .map((sentence) => sentence.trim())
     .filter(Boolean);
 
-  return sentences.find((sentence) => !isLowInformationSentence(sentence)) ??
-    sentences[0] ??
-    lastMessage;
+  const meaningfulSentence = sentences.find((sentence) => !isLowInformationSentence(sentence));
+  if (meaningfulSentence) return meaningfulSentence;
+  if (sentences.length > 0) return undefined;
+  return isLowInformationSentence(lastMessage) ? undefined : lastMessage;
 }
 
 function isLowInformationSentence(sentence: string): boolean {
-  return sentence.length < 8 && /^(ok|okay|done|看了|好的|收到|完成|继续)$/i.test(sentence);
+  const normalized = sentence
+    .replace(/[.!?。！？]+$/u, '')
+    .trim();
+  const terseFiller =
+    normalized.length < 12 &&
+    /^(ok|okay|done|hi|hello|hey|看了|好的|收到|完成|继续|继续正常|你好|我在|你好，我在)$/i.test(normalized);
+  const memoryFooter = /^memory citations:\s*none$/i.test(normalized);
+  return terseFiller || memoryFooter;
 }
 
 function buildNextAction(session: AggregatedSession, reasons: AttentionReason[]): string {


### PR DESCRIPTION
## Summary
- Do not derive Orchestrator tasks from low-information responses such as `继续正常` or greeting/footer-only messages
- Keep those messages as current-state evidence while leaving task empty so the UI shows no clear task instead of a misleading task
- Add coverage for low-information Chinese responses and memory citation footer text

## Verification
- git diff --check
- bun test src/__tests__/attention.prioritizer.test.ts src/__tests__/orchestrator.route.test.ts
- bun run typecheck
- bun test
- bun run build
- bun dist/index.js overview --limit 20 --json | jq ... => 0 misleading low-info tasks