### PR TITLE
[codex] complete spec plans and stabilize orchestrator tests

### DIFF
--- a/specs/GH44/tasks.md
+++ b/specs/GH44/tasks.md
@@ -1,0 +1,314 @@
+# Runtime-Neutral Agent Orchestration Task Plan
+
+Issue: https://github.com/majiayu000/claude-hub/issues/44
+
+Product spec: `specs/GH44/product.md`
+Tech spec: `specs/GH44/tech.md`
+Discovery follow-up: `specs/GH44/cursor-runtime-discovery.md`
+
+## Thread Lane Map
+
+- `GH44-L1`: Coordinator/spec owner, read-only after this plan lands. Owns scope, dependency order, and PR handoff.
+- `GH44-L2`: Runtime foundation worker. Owns runtime domain contracts, registry, Claude Code wrapper, Codex adapter, and adapter tests.
+- `GH44-L3`: Work item and evidence worker. Owns WorkItem persistence/API, WorkItemSessionLink, ProgressEvidence, and Workboard projections.
+- `GH44-L4`: UI/API integration worker. Owns sessions/project API extensions, runtime badges/filters, docs/UI wording, and browser verification.
+- `GH44-L5`: Reviewer, read-only. Owns spec-vs-implementation review and verification risk notes.
+
+No two writable lanes may edit the same file in the same tranche. `AGENTS.md`, `CLAUDE.md`, `.claude/*`, hooks, settings, global config, and secret-bearing files are forbidden unless a maintainer explicitly asks.
+
+## Tasks
+
+### SP44-T1: Confirm SpecRail artifacts and scope
+
+Owner: coordinator
+
+Dependencies: #44 issue body and existing GH44 docs
+
+Done when:
+
+- `specs/GH44/product.md` exists.
+- `specs/GH44/tech.md` exists.
+- `specs/GH44/tasks.md` exists.
+- The scope keeps Codex, Claude Code, and future Cursor as runtime adapters, not product boundaries.
+- Cursor remains discovery-only until a stable source contract is selected.
+
+Verify:
+
+```sh
+test -f specs/GH44/product.md
+test -f specs/GH44/tech.md
+test -f specs/GH44/tasks.md
+test -f specs/GH44/cursor-runtime-discovery.md
+```
+
+### SP44-T2: Add WorkItem foundation
+
+Owner: Work item and evidence worker
+
+Dependencies: SP44-T1
+
+Expected writable files:
+
+- `src/domain/work-item/**`
+- `src/infrastructure/database/**`
+- `src/web/api/routes/work-items.ts`
+- focused work-item tests
+
+Done when:
+
+- Durable WorkItem storage supports inbox, planned, active, blocked, done, archived, and archived visibility rules.
+- Inbox/Todo/Idea capture works without selecting a project.
+- Formal status transitions require `statusSource` of `user` or `accepted_agent_suggestion`.
+- Agent suggestions cannot silently change planned/done/blocked state.
+
+Verify:
+
+```sh
+bun test src/__tests__/work-items.test.ts
+bun run typecheck
+```
+
+### SP44-T3: Add runtime domain contracts and registry
+
+Owner: runtime foundation worker
+
+Dependencies: SP44-T1
+
+Expected writable files:
+
+- `src/domain/runtime/**`
+- `src/adapters/runtimes/registry.ts`
+- runtime contract and registry tests
+
+Done when:
+
+- `RuntimeDescriptor`, `RuntimeSession`, `RuntimeCommand`, `RuntimeScanResult`, and `AgentRuntimeAdapter` are defined.
+- `RuntimeRegistry` registers adapters by stable `runtimeId` and rejects duplicates.
+- `scanAll()` isolates adapter failures and returns structured per-runtime errors.
+- Adapters declaring `resume`, `quota`, `plans`, or `hooks` have matching command builders, providers, or explicit compatibility routes.
+
+Verify:
+
+```sh
+bun test src/__tests__/runtime.registry.test.ts
+bun run typecheck
+```
+
+### SP44-T4: Wrap Claude Code as a runtime adapter
+
+Owner: runtime foundation worker
+
+Dependencies: SP44-T3
+
+Expected writable files:
+
+- `src/adapters/runtimes/claude-code.ts`
+- Claude parser/scanner adapter tests
+
+Done when:
+
+- Existing Claude Code scanner behavior is preserved through `ClaudeCodeRuntimeAdapter`.
+- Runtime ID is `claude-code`; legacy persisted client value `claude` normalizes correctly.
+- Default source hints include `~/.claude/projects` and `~/.claude-work/projects`.
+- `KEEPLINE_PROJECT_ROOTS` remains a colon-separated absolute-path override.
+- Resume, continue, and new recovery modes return structured `RuntimeCommand` values, not shell strings.
+- Per-file read/parse failures are exposed as `RuntimeScanResult.errors`.
+
+Verify:
+
+```sh
+bun test src/__tests__/claude-runtime-adapter.test.ts
+bun test src/__tests__/recovery-security.test.ts
+bun run typecheck
+```
+
+### SP44-T5: Add Codex runtime adapter
+
+Owner: runtime foundation worker
+
+Dependencies: SP44-T3
+
+Expected writable files:
+
+- `src/adapters/runtimes/codex.ts`
+- `src/adapters/Codex/parser/**`
+- Codex adapter/parser fixtures and tests
+
+Done when:
+
+- Codex rollout JSONL files under `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` parse into normalized `RuntimeSession` records.
+- Missing Codex sessions root is a no-op.
+- Bad JSONL files produce structured runtime scan errors without hiding good sessions.
+- `turn_context` records are accepted and stored as runtime metadata without replacing `session_meta` identity.
+- Codex resume, continue, and new recovery modes return structured `RuntimeCommand` values and use the raw runtime session ID.
+
+Verify:
+
+```sh
+bun test src/__tests__/codex.parser.test.ts
+bun test src/__tests__/codex-runtime-adapter.test.ts
+bun run typecheck
+```
+
+### SP44-T6: Integrate runtime sessions into APIs and project filters
+
+Owner: UI/API integration worker
+
+Dependencies: SP44-T3, SP44-T4, SP44-T5
+
+Expected writable files:
+
+- `src/services/session.aggregator.ts`
+- `src/web/api/routes/sessions.ts`
+- `src/web/api/routes/projects.ts`
+- session/project route tests
+
+Done when:
+
+- Sessions expose `runtimeId` while preserving compatibility for existing `client` consumers.
+- Runtime filters include legacy `client: "claude"` rows when callers request `runtimeId=claude-code`.
+- `projectRoot` filtering resolves cwd to project identity first, then applies exact root matching.
+- Project filter composes with search, status, runtime/client, sorting, and pagination.
+- Same-basename projects or worktrees do not merge.
+
+Verify:
+
+```sh
+bun test src/__tests__/sessions.route-basic.test.ts
+bun test src/__tests__/projects.test.ts
+bun run typecheck
+```
+
+### SP44-T7: Add AgentSession, evidence, and link model
+
+Owner: Work item and evidence worker
+
+Dependencies: SP44-T2, SP44-T3
+
+Expected writable files:
+
+- `src/domain/session/**`
+- `src/domain/work-item/**`
+- `src/infrastructure/database/repositories/**`
+- evidence and link tests
+
+Done when:
+
+- Runtime sessions map to collision-resistant global `AgentSession.id` values.
+- `WorkItemSessionLink` supports accepted, pending, and rejected links.
+- `ProgressEvidence` requires at least one stable attachment anchor.
+- `ProgressEvidence.outcome` drives completion/blocking/failure signals without parsing free text.
+- Inferred evidence can suggest progress but cannot mark a WorkItem planned, done, or blocked by itself.
+
+Verify:
+
+```sh
+bun test src/__tests__/agent-session-links.test.ts
+bun test src/__tests__/progress-evidence.test.ts
+bun run typecheck
+```
+
+### SP44-T8: Build Workboard projections
+
+Owner: Work item and evidence worker
+
+Dependencies: SP44-T2, SP44-T7
+
+Expected writable files:
+
+- `src/domain/work-item/workboard.ts`
+- `src/services/workboard*.ts`
+- Workboard projection tests
+
+Done when:
+
+- Now, Waiting, Stale, and Done buckets are projections, not status mutations.
+- Bucket precedence follows Done, Waiting, Stale, Now, with archived items hidden by default.
+- Waiting sessions do not also appear in Now.
+- Stale uses linked session/evidence timestamps and does not fall back to `WorkItem.updatedAt`.
+- No evidence renders blank progress instead of guessed completion.
+- Suggestions are visibly suggestions until accepted.
+
+Verify:
+
+```sh
+bun test src/__tests__/workboard.test.ts
+bun run typecheck
+```
+
+### SP44-T9: Update runtime-neutral UI, docs, and wording
+
+Owner: UI/API integration worker
+
+Dependencies: SP44-T4, SP44-T5, SP44-T6
+
+Expected writable files:
+
+- `README.md`
+- `docs/**`
+- `src/web/client/**`
+- CLI help and package metadata files, if in scope for the tranche
+
+Done when:
+
+- Dashboard, CLI, API docs, and specs describe Keepline as a runtime-neutral orchestration hub.
+- Runtime-specific labels appear only as adapter identity, migration history, compatibility text, or concrete runtime badges.
+- Session cards and project cards distinguish Claude Code, Codex, and future runtime identities through metadata, not text guesses.
+- No product boundary text says the system is only for Claude Code or only for Codex.
+
+Verify:
+
+```sh
+rg -n "Claude Hub|Codex Hub|Claude-only|Codex-only|session monitor" README.md docs src package.json || true
+bun run typecheck
+cd src/web/client && bun run typecheck && bun run build
+```
+
+### SP44-T10: Preserve Cursor as a follow-up discovery track
+
+Owner: coordinator
+
+Dependencies: SP44-T1
+
+Done when:
+
+- `specs/GH44/cursor-runtime-discovery.md` records Cursor source-truth questions and research boundaries.
+- No implementation guesses Cursor private storage schemas as adapter truth.
+- Any future Cursor implementation is gated on a separate product/tech spec or accepted follow-up issue.
+
+Verify:
+
+```sh
+test -f specs/GH44/cursor-runtime-discovery.md
+rg -n "Cursor" specs/GH44
+```
+
+### SP44-T11: Full verification and handoff
+
+Owner: verification owner
+
+Dependencies: SP44-T2, SP44-T3, SP44-T4, SP44-T5, SP44-T6, SP44-T7, SP44-T8, SP44-T9
+
+Done when:
+
+- Targeted tests for each tranche pass.
+- Full local typecheck, test, build, and web client build pass.
+- `git diff --check` passes.
+- If `checks/check_workflow.py` remains absent, the PR notes that path/link review plus `git diff --check` were used as the local substitute.
+- Human review and merge gates remain intact.
+
+Verify:
+
+```sh
+bun run typecheck
+bun test
+bun run build
+cd src/web/client && bun run typecheck && bun run build
+git diff --check
+```
+
+## Handoff Notes
+
+- This plan does not authorize implementation, PR creation, merge, force push, release, or remote issue mutation by itself.
+- `checks/route_gate.py` and `checks/check_workflow.py` are not present in this repository at the time this plan was written; use the explicit verification commands above unless those checks are added later.
+- Keep PRs narrow: spec/tasks, WorkItem foundation, runtime foundation, Codex adapter, evidence, Workboard, and UI/API wording should be separate tranches unless a maintainer explicitly asks for a combined PR.

--- a/specs/GH62/product.md
+++ b/specs/GH62/product.md
@@ -23,12 +23,13 @@ Agent Orchestrator 让 Keepline 从“会话列表”升级为本地 agent runti
 4. 没有数据就显示空白或低置信度，不得编造进度、阻塞点或完成状态。
 5. waiting session 优先级高于 lost/recoverable session；lost/recoverable 高于高成本 session；高成本高于 stale/idle session。
 6. 高成本信号只来自 persisted usage data。没有 usage data 时不能猜测成本。
-7. Memory 增强字段可以提供 `summary`、`nextActions`、`blockers`，但这些字段缺失时 Overview 仍可工作。
-8. Session Digest 的第一版必须可区分 deterministic digest 和 model-generated digest。模型摘要不可覆盖用户手动 memory 数据。
-9. 本地模型摘要默认本地优先；云模型必须显式配置，且 transcript 内容默认不离开本机。
-10. 摘要生成失败必须显示 stale/error 状态或保留旧摘要，不得 warning 后静默显示假新摘要。
-11. Web Orchestrator 视图应复用同一 Attention Queue API，不在前端重新实现排序规则。
-12. 所有新 API 和 CLI 行为必须保持 runtime-neutral：Codex、Claude Code、未来 Cursor 都是 runtime/client 数据源，不是产品边界。
+7. lost/recoverable session 默认只显示最近恢复窗口内的候选项，避免陈旧丢失会话淹没 Queue；被隐藏的旧 lost sessions 必须在 stats 中计数，并可通过显式参数重新包含。
+8. Memory 增强字段可以提供 `summary`、`nextActions`、`blockers`，但这些字段缺失时 Overview 仍可工作。
+9. Session Digest 的第一版必须可区分 deterministic digest 和 model-generated digest。模型摘要不可覆盖用户手动 memory 数据。
+10. 本地模型摘要默认本地优先；云模型必须显式配置，且 transcript 内容默认不离开本机。
+11. 摘要生成失败必须显示 stale/error 状态或保留旧摘要，不得 warning 后静默显示假新摘要。
+12. Web Orchestrator 视图应复用同一 Attention Queue API，不在前端重新实现排序规则。
+13. 所有新 API 和 CLI 行为必须保持 runtime-neutral：Codex、Claude Code、未来 Cursor 都是 runtime/client 数据源，不是产品边界。
 
 ## MVP Scope
 
@@ -68,7 +69,8 @@ Agent Orchestrator 让 Keepline 从“会话列表”升级为本地 agent runti
 8. 输出 reason 不解析 free-text 来推断 done 或 blocked。
 9. API route 需要沿用现有 auth middleware。
 10. 新增代码不破坏 `list`、`watch`、`recover`、`memory`、`work-items`、`projects` 流程。
-11. 验证命令通过：`bun run typecheck`、targeted tests、`bun test`、`bun run build`。
+11. 默认 Overview 隐藏超过 lost freshness window 的 lost sessions，`stats.hiddenOldLost` 计数，显式 `includeOldLost=true` 可以包含它们。
+12. 验证命令通过：`bun run typecheck`、targeted tests、`bun test`、`bun run build`。
 
 ## Open Questions
 

--- a/specs/GH62/tasks.md
+++ b/specs/GH62/tasks.md
@@ -115,6 +115,8 @@ Done when:
 - `GET /api/orchestrator/overview` returns serialized overview payload.
 - Route uses existing auth middleware.
 - Invalid numeric query values return 400.
+- Old lost sessions are hidden by default with `hiddenOldLost` stats and can be included with `includeOldLost=true`.
+- Route tests use relative timestamps for recent and old lost sessions so they remain deterministic over time.
 
 Verify:
 

--- a/specs/GH62/tech.md
+++ b/specs/GH62/tech.md
@@ -86,13 +86,21 @@ Add route module `src/web/api/routes/orchestrator.ts`:
 - `GET /api/orchestrator/overview`
 - query params:
   - `includeCompleted=true|false`
+  - `includeOldLost=true|false`
   - `limit=<number>` default 20, max 100
   - `highCostThreshold=<number>` optional, default from service
   - `staleHours=<number>` optional, default from service
+  - `lostHours=<number>` optional, default from service; ignored when `includeOldLost=true`
 
 Mount it in `src/web/api/routes/index.ts` and `src/web/api/server.ts`.
 
 Serialize dates to ISO strings. Do not expose raw internal class instances.
+
+By default, the API should hide lost sessions whose `lastActiveAt` is older than
+the configured lost freshness window, currently one hour. This keeps stale
+recovery candidates from dominating the queue. The response stats must include
+`hiddenOldLost` and `lostWindowHours` so the UI can explain the hidden scope.
+`includeOldLost=true` disables this filter and omits `lostWindowHours`.
 
 ## CLI
 
@@ -130,6 +138,7 @@ Future PR for Session Digest may add a dedicated `session_digests` table rather 
 
 - Unit test `buildAttentionOverview()` ordering and reason generation.
 - Route test `/api/orchestrator/overview` auth + serialization + limit.
+- Route test old-lost filtering with relative timestamps so the fixture does not drift with wall-clock time.
 - CLI smoke test can be covered by typecheck/build in PR1; a later CLI test harness can add subprocess coverage.
 - Run:
   - `bun test src/__tests__/attention.prioritizer.test.ts src/__tests__/orchestrator.route.test.ts`

--- a/specs/project-workspaces/tasks.md
+++ b/specs/project-workspaces/tasks.md
@@ -1,0 +1,287 @@
+# Project Workspaces Task Plan
+
+Product spec: `specs/project-workspaces/PRODUCT.md`
+Tech spec: `specs/project-workspaces/TECH.md`
+
+## Thread Lane Map
+
+- `PW-L1`: Coordinator/spec owner, read-only after this plan lands. Owns scope, route order, and handoff notes.
+- `PW-L2`: Backend worker. Owns project identity, aggregation, sessions/projects APIs, and backend tests.
+- `PW-L3`: Frontend worker. Owns Projects view data flow, explicit project filter state, client badges, and accessibility checks.
+- `PW-L4`: Realtime/notification worker. Owns WebSocket change detection and project-context notification behavior.
+- `PW-L5`: Reviewer, read-only. Owns spec-vs-implementation review and verification risk notes.
+
+No two writable lanes may edit the same file in the same tranche. `AGENTS.md`, `CLAUDE.md`, `.claude/*`, hooks, settings, global config, and secret-bearing files are forbidden unless a maintainer explicitly asks.
+
+## Tasks
+
+### SPPW-T1: Confirm SpecRail artifacts and scope
+
+Owner: coordinator
+
+Dependencies: existing Project Workspaces product and tech specs
+
+Done when:
+
+- `specs/project-workspaces/PRODUCT.md` exists.
+- `specs/project-workspaces/TECH.md` exists.
+- `specs/project-workspaces/tasks.md` exists.
+- MVP scope remains derived project identity, exact project filtering, client counts, Projects overview, and realtime project-card freshness.
+- Persisted aliases, icons, pinned order, project notes, Warp tab inspection, and direct agent spawning remain follow-ups.
+
+Verify:
+
+```sh
+test -f specs/project-workspaces/PRODUCT.md
+test -f specs/project-workspaces/TECH.md
+test -f specs/project-workspaces/tasks.md
+```
+
+### SPPW-T2: Add project identity helper
+
+Owner: backend worker
+
+Dependencies: SPPW-T1
+
+Expected writable files:
+
+- `src/services/project.identity.ts`
+- project identity unit tests
+
+Done when:
+
+- `resolveProjectIdentity()` normalizes paths, expands `~`, trims trailing separators, and returns `ProjectIdentity`.
+- Existing paths inside git repos resolve to repo/worktree roots, including `.git` files and `.git` directories.
+- Missing historical cwd values remain normalized cwd roots instead of disappearing.
+- Empty or unnormalizable cwd values map to stable `unknown`.
+- Project IDs are collision-resistant path hashes, not lowercased basename or lossy slugs.
+- Request-level caching avoids repeated filesystem walks for the same directory.
+
+Verify:
+
+```sh
+bun test src/__tests__/project-identity.test.ts
+bun run typecheck
+```
+
+### SPPW-T3: Add project aggregation service
+
+Owner: backend worker
+
+Dependencies: SPPW-T2
+
+Expected writable files:
+
+- `src/services/project.aggregator.ts`
+- `src/__tests__/projects.test.ts`
+
+Done when:
+
+- Project summaries group by `ProjectIdentity.id`, not project name.
+- Each summary includes `id`, `rootPath`, `name`, `displayPath`, sessions, stats, client counts, current task, last activity, and usage totals when data exists.
+- Same-basename repos and worktrees stay separate.
+- Older sessions without `client` metadata count under `unknown` instead of being inferred from title or shell state.
+- Aggregation can run from the full unfiltered session set.
+
+Verify:
+
+```sh
+bun test src/__tests__/projects.test.ts
+bun run typecheck
+```
+
+### SPPW-T4: Add exact project filtering to sessions API
+
+Owner: backend worker
+
+Dependencies: SPPW-T2
+
+Expected writable files:
+
+- `src/services/session.aggregator.ts`
+- `src/web/api/routes/sessions.ts`
+- sessions route tests
+
+Done when:
+
+- `GET /api/sessions?projectRoot=<absolute path>` filters by exact resolved project root.
+- Existing `directory` substring filtering remains available for backward compatibility.
+- Filtering order is load sessions, resolve project identity, apply project filter, apply status/client/search filters, sort, then paginate.
+- `projectRoot` composes with status, client, search, sorting, and pagination.
+- Invalid or unsafe project filter inputs return explicit errors instead of broad fallback behavior.
+
+Verify:
+
+```sh
+bun test src/__tests__/sessions.route-basic.test.ts
+bun test src/__tests__/projects.test.ts
+bun run typecheck
+```
+
+### SPPW-T5: Add projects API
+
+Owner: backend worker
+
+Dependencies: SPPW-T3
+
+Expected writable files:
+
+- `src/web/api/routes/projects.ts`
+- `src/web/api/routes/index.ts`
+- `src/web/api/server.ts`
+- projects route tests
+
+Done when:
+
+- `GET /api/projects?fields=basic|full` returns `{ success, data: { projects, stats } }`.
+- The route uses the same auth middleware pattern as sessions.
+- Basic mode avoids unnecessary expensive hydration.
+- Empty, loading, and degraded states are explicit in the API response or logs.
+- A parser failure for one client/runtime does not hide sessions from another client/runtime.
+
+Verify:
+
+```sh
+bun test src/__tests__/projects.route.test.ts
+bun run typecheck
+```
+
+### SPPW-T6: Wire Projects view to stable project summaries
+
+Owner: frontend worker
+
+Dependencies: SPPW-T3, SPPW-T5
+
+Expected writable files:
+
+- `src/web/client/src/types/project.ts`
+- `src/web/client/src/hooks/useProjects.ts`
+- `src/web/client/src/components/**`
+- project hook/component tests
+
+Done when:
+
+- Frontend `ProjectInfo` includes `id`, `rootPath`, `displayPath`, and `clientCounts`.
+- Projects overview uses `/api/projects` or a proven full-session fallback, not the current paginated Sessions list.
+- Project cards show status counts, client badges/counts, latest task, last activity, total sessions, and usage totals when available.
+- Long absolute paths are visually compact while preserving full path access in detail or tooltip surfaces.
+- Empty/loading/error states are explicit and do not produce a blank Projects tab.
+
+Verify:
+
+```sh
+cd src/web/client && bun run typecheck && bun run build
+bun test src/__tests__/projects.test.ts
+```
+
+### SPPW-T7: Replace text-search project selection with explicit filter state
+
+Owner: frontend worker
+
+Dependencies: SPPW-T4, SPPW-T6
+
+Expected writable files:
+
+- `src/web/client/src/App.tsx`
+- `src/web/client/src/components/**`
+- related frontend tests
+
+Done when:
+
+- Selecting a project sets `selectedProjectRoot` or equivalent explicit state.
+- Sessions view filters by the selected project root plus existing search/status/client filters.
+- Selecting a project does not overwrite search text.
+- Clearing the project filter restores the previous global search/status state.
+- Keyboard users can tab to a project card, press Enter to select it, and clear the filter predictably.
+
+Verify:
+
+```sh
+cd src/web/client && bun run typecheck && bun run build
+```
+
+### SPPW-T8: Update realtime project-card and notification behavior
+
+Owner: realtime/notification worker
+
+Dependencies: SPPW-T3, SPPW-T5
+
+Expected writable files:
+
+- `src/web/api/server.ts`
+- notification service files
+- realtime/notification tests
+
+Done when:
+
+- WebSocket change detection includes project-card inputs such as session id, client, status, directory or project ID, last activity, current task, and usage totals when used.
+- A session that only updates `lastActiveAt` or visible task text still refreshes the owning project card.
+- Notifications remain session-based but include project context when available.
+- Notification delivery does not depend on the current selected project filter.
+
+Verify:
+
+```sh
+bun test src/__tests__/projects.realtime.test.ts
+bun test src/__tests__/notifications.test.ts
+bun run typecheck
+```
+
+### SPPW-T9: Manual UI and accessibility verification
+
+Owner: frontend worker
+
+Dependencies: SPPW-T6, SPPW-T7, SPPW-T8
+
+Done when:
+
+- Projects tab is keyboard reachable.
+- Focus moves predictably after selecting a project and clearing the filter.
+- Same-basename projects are visually distinguishable.
+- Long paths elide without hiding the project name or overlapping neighboring UI.
+- Narrow desktop and standard desktop widths show coherent card layout.
+
+Verify:
+
+```sh
+cd src/web/client && bun run dev
+```
+
+Manual checks:
+
+- Tab to a project card and press Enter.
+- Confirm Sessions shows only that exact project root.
+- Confirm search text remains unchanged.
+- Clear project filter and confirm the previous search/status/client filters remain.
+
+### SPPW-T10: Full verification and handoff
+
+Owner: verification owner
+
+Dependencies: SPPW-T2, SPPW-T3, SPPW-T4, SPPW-T5, SPPW-T6, SPPW-T7, SPPW-T8, SPPW-T9
+
+Done when:
+
+- Targeted backend and frontend tests pass.
+- Full local typecheck, test, build, and web client build pass.
+- `git diff --check` passes.
+- If `checks/check_workflow.py` remains absent, the PR notes that path/link review plus `git diff --check` were used as the local substitute.
+- Human review and merge gates remain intact.
+
+Verify:
+
+```sh
+bun test src/__tests__/projects.test.ts
+bun test src/__tests__/sessions.route-basic.test.ts
+bun test
+bun run typecheck
+bun run build
+cd src/web/client && bun run typecheck && bun run build
+git diff --check
+```
+
+## Handoff Notes
+
+- This plan does not authorize implementation, PR creation, merge, force push, release, or remote issue mutation by itself.
+- There is no linked GitHub issue recorded in the existing Project Workspaces specs. If this work becomes remote-tracked, create or request a linked issue before opening an implementation PR.
+- `checks/route_gate.py` and `checks/check_workflow.py` are not present in this repository at the time this plan was written; use the explicit verification commands above unless those checks are added later.

--- a/src/__tests__/orchestrator.route.test.ts
+++ b/src/__tests__/orchestrator.route.test.ts
@@ -6,6 +6,17 @@ import { resetDatabase } from '../db/migrations.js';
 import { closeDatabase } from '../infrastructure/database/sqlite.js';
 import { sessionRepository } from '../infrastructure/database/repositories/session.repository.js';
 
+const RECENT_SESSION_OFFSET_MS = 5 * 60 * 1000;
+const OLD_LOST_SESSION_OFFSET_MS = 2 * 60 * 60 * 1000;
+
+function recentSessionDate(): Date {
+  return new Date(Date.now() - RECENT_SESSION_OFFSET_MS);
+}
+
+function oldLostSessionDate(): Date {
+  return new Date(Date.now() - OLD_LOST_SESSION_OFFSET_MS);
+}
+
 describe('Orchestrator Route Contract', () => {
   beforeEach(() => {
     resetDatabase();
@@ -16,6 +27,8 @@ describe('Orchestrator Route Contract', () => {
   });
 
   test('overview returns serialized attention queue with auth', async () => {
+    const lastActiveAt = recentSessionDate();
+
     sessionRepository.upsert({
       sessionId: 'orchestrator-route-cost',
       client: 'codex',
@@ -26,7 +39,7 @@ describe('Orchestrator Route Contract', () => {
       lastMessage: 'Cost is high, review before continuing',
       lastTool: 'Read',
       currentFile: '/tmp/keepline-orchestrator/report.md',
-      lastActiveAt: new Date('2026-06-29T10:00:00.000Z'),
+      lastActiveAt,
       toolCount: 2,
       messageCount: 4,
       usageStats: {
@@ -80,7 +93,7 @@ describe('Orchestrator Route Contract', () => {
     expect(body.data.items).toHaveLength(1);
     expect(body.data.items[0]).toMatchObject({
       sessionId: 'orchestrator-route-cost',
-      lastActiveAt: '2026-06-29T10:00:00.000Z',
+      lastActiveAt: lastActiveAt.toISOString(),
       context: {
         initialPrompt: 'Track cost',
         lastMessage: 'Cost is high, review before continuing',
@@ -108,7 +121,7 @@ describe('Orchestrator Route Contract', () => {
       status: 'running',
       title: 'Mounted route',
       initialPrompt: 'Mounted',
-      lastActiveAt: new Date('2026-06-29T10:00:00.000Z'),
+      lastActiveAt: recentSessionDate(),
       toolCount: 1,
       messageCount: 1,
     });
@@ -137,7 +150,7 @@ describe('Orchestrator Route Contract', () => {
       status: 'waiting',
       title: 'Digest generate',
       lastMessage: 'Needs human review',
-      lastActiveAt: new Date('2026-06-29T10:00:00.000Z'),
+      lastActiveAt: recentSessionDate(),
     });
 
     const { token } = await setupUser('orchestrator-digest-user', 'password123');
@@ -191,7 +204,7 @@ describe('Orchestrator Route Contract', () => {
       status: 'waiting',
       title: 'Overview digest',
       lastMessage: 'Digest visible in overview',
-      lastActiveAt: new Date('2026-06-29T10:00:00.000Z'),
+      lastActiveAt: recentSessionDate(),
     });
 
     const { token } = await setupUser('orchestrator-overview-digest-user', 'password123');
@@ -263,7 +276,7 @@ describe('Orchestrator Route Contract', () => {
       directory: '/tmp/keepline-old-lost',
       status: 'lost',
       title: 'Old lost',
-      lastActiveAt: new Date('2026-06-27T10:00:00.000Z'),
+      lastActiveAt: oldLostSessionDate(),
     });
 
     const { token } = await setupUser('orchestrator-old-lost-user', 'password123');


### PR DESCRIPTION
## Summary

- Add missing SpecRail task plans for GH44 runtime-neutral orchestration and Project Workspaces.
- Document GH62 old-lost filtering behavior in product, tech, and task specs.
- Stabilize Orchestrator route tests by using relative recent/old timestamps instead of fixed 2026-06-29 fixtures.

## Root Cause

The Orchestrator route tests used fixed `lastActiveAt` timestamps. Aggregation marks sessions with no live process as `lost`, and the overview API hides lost sessions older than the default one-hour freshness window, so the fixtures aged out and the route tests returned empty queues.

## Validation

- `bun test src/__tests__/attention.prioritizer.test.ts src/__tests__/orchestrator.route.test.ts src/__tests__/overview.cli.test.ts`
- `bun run typecheck`
- `git diff --check`
- `bun test` (356 pass, 0 fail)
- `bun run build`

## Notes

- Draft PR; human review and merge gate preserved.
- `bun run build` reports the existing Vite chunk-size warning only; build exits successfully.