### PR TITLE
docs: link the Agent Infra Stack across sibling repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,3 +387,22 @@ bun test             # Run tests
 MIT License
 
 </div>
+
+---
+
+## The Agent Infra Stack
+
+This project is one layer of an open-source stack for running coding agents (Claude Code, Codex) as serious infrastructure. Every piece works standalone; together they close the loop:
+
+`keepline` is the **Keep** layer — the session command center on top of the stack: monitor, recover, and never lose agent work.
+
+| Layer | Project | What it does |
+|---|---|---|
+| Extend | [claude-skill-registry](https://github.com/majiayu000/claude-skill-registry) | Discover and search community Claude Code skills |
+| Extend | [spellbook](https://github.com/majiayu000/spellbook) | Cross-runtime skills for Claude Code, Codex, and multi-agent workflows |
+| Trust | [argus](https://github.com/majiayu000/argus) | Static install-time scanner for supply-chain attacks (npm / PyPI / crates.io) |
+| Trust | [vibeguard](https://github.com/majiayu000/vibeguard) | Rules, hooks, and guards against hallucinated or unverified agent changes |
+| Remember | [remem](https://github.com/majiayu000/remem) | Local-first persistent memory for Claude Code and Codex sessions |
+| Orchestrate | [harness](https://github.com/majiayu000/harness) | Rust agent orchestration platform — rules, skills, GC, observability |
+| Route | [litellm-rs](https://github.com/majiayu000/litellm-rs) | High-performance Rust AI gateway — 100+ LLM APIs via OpenAI format |
+| Keep | [keepline](https://github.com/majiayu000/keepline) **◀ you are here** | Session command center — monitor, recover, never lose agent work |


### PR DESCRIPTION
Adds a shared **Agent Infra Stack** section cross-linking the 8 sibling repos (extend → trust → remember → orchestrate → route → keep). README-only.