### PR TITLE
fix: harden observation id vector predicates

### DIFF
--- a/specs/GH74/product.md
+++ b/specs/GH74/product.md
@@ -1,0 +1,45 @@
+# LanceDB Observation ID Injection Hardening Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/74
+
+## Summary
+
+Keepline 的 memory observation API 必须拒绝带有 filter DSL 注入字符的 observation id。用户或本地集成只能读取或删除明确命中的单条 observation，不能通过路径参数扩大到其它 observation 或整张 LanceDB 表。
+
+## User Problem
+
+Keepline 将跨会话记忆持久化到 LanceDB。当前按 observation id 读取和删除的路径把 HTTP 参数直接拼进 LanceDB filter 字符串。认证用户或本地恶意页面一旦能触达 API，就可能用带引号和布尔表达式的 id 读取额外数据或删除全部 observation。
+
+用户需要的行为是 fail closed：非法 id 直接返回清晰的 400 错误，合法但不存在的 id 返回 404，底层向量库不应看到非法 filter。
+
+## Product Behavior
+
+1. `GET /api/memory/observations/:id` 对非法 observation id 返回 400。
+2. `DELETE /api/memory/observations/:id` 对非法 observation id 返回 400。
+3. 非法 observation id 包括空字符串、过短或过长字符串、空格、引号、SQL/filter 运算符片段、点号和其它不在允许字符集内的字符。
+4. 合法 observation id 使用与 Keepline 生成的 UUID 兼容的安全字符集。
+5. 合法但不存在的 observation id 保持现有 404 行为。
+6. 底层 vector store 被直接调用时也必须拒绝非法 observation id，不能依赖 HTTP 路由作为唯一防线。
+7. 此修复不改变 memory observation 的创建、搜索、sessionId 查询或 sessionId 批量删除行为。
+
+## Non-Goals
+
+- 不重写 LanceDB 查询层或替换向量数据库。
+- 不改变 `sessionId` 的现有校验策略。
+- 不实现 observation id 迁移或历史数据重写。
+- 不处理 P2 中的 LanceDB 维度迁移、`count()` 性能或 session 批量删除性能。
+- 不改变认证、JWT、rate limit 或 DNS-rebinding 防护。
+
+## Acceptance Criteria
+
+1. observation id 有单独的验证函数，允许 Keepline 当前生成的 UUID。
+2. `GET /api/memory/observations/:id` 在非法 id 下返回 400，且不初始化或查询 LanceDB。
+3. `DELETE /api/memory/observations/:id` 在非法 id 下返回 400，且不初始化或删除 LanceDB 数据。
+4. `LanceDBVectorStore.getById()` 在非法 id 下抛出明确错误。
+5. `LanceDBVectorStore.delete()` 在非法 id 下抛出明确错误。
+6. `getById()` 和 `delete()` 不再使用未经校验的 path 参数构造 LanceDB filter。
+7. 回归测试覆盖注入形 id，例如 `x' OR '1'='1`。
+
+## Open Questions
+
+- LanceDB 是否提供稳定的参数化 predicate API。如果没有，本次采用严格 id allowlist；后续可以在升级 LanceDB 时改为参数化查询。

--- a/specs/GH74/tasks.md
+++ b/specs/GH74/tasks.md
@@ -1,0 +1,87 @@
+# LanceDB Observation ID Injection Hardening Task Plan
+
+Issue: https://github.com/majiayu000/keepline/issues/74
+Product spec: `specs/GH74/product.md`
+Tech spec: `specs/GH74/tech.md`
+
+## Tasks
+
+### SP74-T1: Add observation id validation
+
+Owner: implementation agent
+
+Dependencies: GH74 issue evidence
+
+Done when:
+
+- `src/lib/observation-id.ts` exports `isValidObservationId()` and `assertValidObservationId()`.
+- Valid UUID observation ids pass.
+- Injection-style ids with quotes, spaces, or filter operators fail.
+- API validation exports the helper for route and test reuse.
+
+Verify:
+
+```sh
+bun test src/__tests__/validation.test.ts
+```
+
+### SP74-T2: Reject invalid ids at API boundary
+
+Owner: implementation agent
+
+Dependencies: SP74-T1
+
+Done when:
+
+- `GET /api/memory/observations/:id` returns 400 for invalid ids before vector store access.
+- `DELETE /api/memory/observations/:id` returns 400 for invalid ids before vector store access.
+- Valid but missing ids retain 404 behavior.
+
+Verify:
+
+```sh
+bun test src/__tests__/observation-id.test.ts
+```
+
+### SP74-T3: Guard vector adapter direct calls
+
+Owner: implementation agent
+
+Dependencies: SP74-T1
+
+Done when:
+
+- `LanceDBVectorStore.getById()` rejects invalid ids before initialization/query.
+- `LanceDBVectorStore.delete()` rejects invalid ids before initialization/delete.
+- Invalid ids cannot reach LanceDB filter construction through these methods.
+
+Verify:
+
+```sh
+bun test src/__tests__/observation-id.test.ts
+```
+
+### SP74-T4: Run deterministic verification and prepare PR
+
+Owner: coordinator
+
+Dependencies: SP74-T1, SP74-T2, SP74-T3
+
+Done when:
+
+- Focused tests pass.
+- Typecheck passes.
+- Full `bun test` passes or any unrelated failure is recorded with evidence.
+- Build passes.
+- PR references and closes #74 only if every acceptance criterion is satisfied.
+
+Verify:
+
+```sh
+test -f specs/GH74/product.md
+test -f specs/GH74/tech.md
+test -f specs/GH74/tasks.md
+bun run typecheck
+bun test
+bun run build
+```

--- a/specs/GH74/tech.md
+++ b/specs/GH74/tech.md
@@ -1,0 +1,91 @@
+# LanceDB Observation ID Injection Hardening Tech Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/74
+Product spec: `specs/GH74/product.md`
+
+## Current Behavior
+
+- `src/web/api/routes/memory.ts` 的 `GET /observations/:id` 和 `DELETE /observations/:id` 直接读取 `c.req.param('id')`，没有格式校验。
+- `src/infrastructure/vector/lancedb.adapter.ts` 在 `getById()` 中使用 `.where(\`id = '${id}'\`)`，在 `delete()` 中使用 `this.table.delete(\`id = '${id}'\`)`。
+- `POST /observations` 使用 `crypto.randomUUID()` 创建 id，因此正常新数据的 id 形如 UUID，能被安全 allowlist 覆盖。
+- `sessionId` 路径已有 `isValidSessionId()`，但 observation id 没有等价防线。
+
+## Design
+
+1. 新增共享 observation id 验证模块。
+
+   Suggested file: `src/lib/observation-id.ts`
+
+   Rules:
+
+   - 类型必须是 `string`。
+   - 长度 8 到 64。
+   - 只允许 `a-z`、`A-Z`、`0-9`、`-`、`_`。
+   - `crypto.randomUUID()` 生成的 UUID 必须通过。
+   - 引号、空格、点号、分号、等号等字符必须失败。
+
+2. API 路由 fail closed。
+
+   `src/web/api/routes/memory.ts` 在 `GET /observations/:id` 和 `DELETE /observations/:id` 进入 vector store 之前调用 `isValidObservationId(id)`。失败时返回：
+
+   ```json
+   { "success": false, "error": "Invalid observation ID format" }
+   ```
+
+   HTTP status 为 400。
+
+3. Vector adapter 加第二道防线。
+
+   `LanceDBVectorStore.getById()` 和 `delete()` 在任何初始化或 LanceDB 调用之前执行 `assertValidObservationId(id)`。这样即使未来新增内部调用路径，也不会把非法 id 拼入 filter。
+
+4. 保持合法 id 行为不变。
+
+   本次不改变 LanceDB 的 filter DSL 形态，因为严格 allowlist 已保证被插值的 id 不含引号、空格或运算符。若 LanceDB 版本提供参数化 API，可作为后续强化替换。
+
+## Affected Files
+
+- `src/lib/observation-id.ts`
+- `src/web/api/middleware/validation.ts`
+- `src/web/api/routes/memory.ts`
+- `src/infrastructure/vector/lancedb.adapter.ts`
+- `src/__tests__/validation.test.ts`
+- focused observation id / memory route regression tests
+- `specs/GH74/product.md`
+- `specs/GH74/tech.md`
+- `specs/GH74/tasks.md`
+
+## Verification Plan
+
+Focused:
+
+```sh
+bun test src/__tests__/validation.test.ts
+bun test src/__tests__/observation-id.test.ts
+```
+
+Repository:
+
+```sh
+bun run typecheck
+bun test
+bun run build
+```
+
+Workflow:
+
+```sh
+test -f specs/GH74/product.md
+test -f specs/GH74/tech.md
+test -f specs/GH74/tasks.md
+```
+
+`checks/check_workflow.py` is not present in this repository, so there is no repo-local SpecRail workflow checker to run for this tranche.
+
+## Risks
+
+- If historical observation ids used characters outside the allowlist, those rows would no longer be addressable by id through this endpoint. Current production creation path uses UUID, so this risk is acceptable.
+- `deleteBySessionId()` still interpolates `sessionId`, but the existing API boundary already validates `sessionId` and the sessionId issue is outside GH74 scope. A future adapter-level `assertValidSessionId()` would be a separate hardening change.
+
+## Rollback
+
+Revert the GH74 commit. The API returns to prior permissive behavior. No migration or persisted data shape is changed.

--- a/src/__tests__/observation-id.test.ts
+++ b/src/__tests__/observation-id.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { LanceDBVectorStore } from '../infrastructure/vector/lancedb.adapter.js';
+import { resetDatabase } from '../db/migrations.js';
+import { closeDatabase } from '../infrastructure/database/sqlite.js';
+import { setupUser } from '../services/auth.service.js';
+import memory from '../web/api/routes/memory.js';
+
+const INJECTION_ID = "x' OR '1'='1";
+const MISSING_VALID_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('observation id hardening', () => {
+  const tempDirs: string[] = [];
+
+  beforeEach(() => {
+    resetDatabase();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function vectorStoreWithTempPath(): LanceDBVectorStore {
+    const path = mkdtempSync(join(tmpdir(), 'keepline-gh74-lancedb-'));
+    tempDirs.push(path);
+    return new LanceDBVectorStore({ path });
+  }
+
+  test('memory GET route rejects injection-shaped observation IDs before vector access', async () => {
+    const { token } = await setupUser('alice', 'password123');
+
+    const response = await memory.fetch(new Request(
+      `http://localhost/observations/${encodeURIComponent(INJECTION_ID)}`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(400);
+    const body = await response.json() as { success: boolean; error: string };
+    expect(body).toEqual({
+      success: false,
+      error: 'Invalid observation ID format',
+    });
+  });
+
+  test('memory DELETE route rejects injection-shaped observation IDs before vector access', async () => {
+    const { token } = await setupUser('bob', 'password123');
+
+    const response = await memory.fetch(new Request(
+      `http://localhost/observations/${encodeURIComponent(INJECTION_ID)}`,
+      {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    ));
+
+    expect(response.status).toBe(400);
+    const body = await response.json() as { success: boolean; error: string };
+    expect(body).toEqual({
+      success: false,
+      error: 'Invalid observation ID format',
+    });
+  });
+
+  test('LanceDBVectorStore rejects unsafe getById IDs before initialization', async () => {
+    const store = vectorStoreWithTempPath();
+
+    await expect(store.getById(INJECTION_ID)).rejects.toThrow('Invalid observation ID format');
+  });
+
+  test('LanceDBVectorStore rejects unsafe delete IDs before initialization', async () => {
+    const store = vectorStoreWithTempPath();
+
+    await expect(store.delete(INJECTION_ID)).rejects.toThrow('Invalid observation ID format');
+  });
+
+  test('LanceDBVectorStore preserves not-found semantics for safe missing IDs', async () => {
+    const store = vectorStoreWithTempPath();
+
+    await expect(store.getById(MISSING_VALID_ID)).resolves.toBeNull();
+    await expect(store.delete(MISSING_VALID_ID)).resolves.toBe(false);
+  });
+});

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, test, expect } from 'bun:test';
 import {
+  isValidObservationId,
   isValidSessionId,
   validateRecoverRequest,
   validateStopRequest,
@@ -70,6 +71,42 @@ describe('isValidSessionId', () => {
       expect(isValidSessionId(null as unknown as string)).toBe(false);
       expect(isValidSessionId(undefined as unknown as string)).toBe(false);
       expect(isValidSessionId({} as unknown as string)).toBe(false);
+    });
+  });
+});
+
+describe('isValidObservationId', () => {
+  describe('valid observation IDs', () => {
+    test('accepts UUIDs generated for observations', () => {
+      expect(isValidObservationId('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+    });
+
+    test('accepts safe alphanumeric IDs with hyphens and underscores', () => {
+      expect(isValidObservationId('obs_12345')).toBe(true);
+      expect(isValidObservationId('obs-12345_ABC')).toBe(true);
+      expect(isValidObservationId('a'.repeat(64))).toBe(true);
+    });
+  });
+
+  describe('invalid observation IDs', () => {
+    test('rejects injection-shaped filter predicates', () => {
+      expect(isValidObservationId("x' OR '1'='1")).toBe(false);
+      expect(isValidObservationId("obs12345'; DELETE FROM observations; --")).toBe(false);
+    });
+
+    test('rejects unsafe characters and invalid lengths', () => {
+      expect(isValidObservationId('abc1234')).toBe(false);
+      expect(isValidObservationId('')).toBe(false);
+      expect(isValidObservationId('a'.repeat(65))).toBe(false);
+      expect(isValidObservationId('abc.12345')).toBe(false);
+      expect(isValidObservationId('abc 12345')).toBe(false);
+    });
+
+    test('rejects non-string types', () => {
+      expect(isValidObservationId(123 as unknown as string)).toBe(false);
+      expect(isValidObservationId(null as unknown as string)).toBe(false);
+      expect(isValidObservationId(undefined as unknown as string)).toBe(false);
+      expect(isValidObservationId({} as unknown as string)).toBe(false);
     });
   });
 });

--- a/src/infrastructure/vector/lancedb.adapter.ts
+++ b/src/infrastructure/vector/lancedb.adapter.ts
@@ -9,6 +9,7 @@ import * as lancedb from '@lancedb/lancedb';
 import { join } from 'path';
 import { mkdirSync, existsSync } from 'fs';
 import { logger } from '../../lib/logger.js';
+import { assertValidObservationId } from '../../lib/observation-id.js';
 import { KEEPLINE_HOME } from '../../lib/paths.js';
 import type {
   IVectorStore,
@@ -70,6 +71,17 @@ function fromRow(row: LanceDBRow): Observation {
     tokenCount: row.tokenCount,
     compressed: row.compressed,
   };
+}
+
+/** Build a LanceDB string literal only after the observation id has passed the safe allowlist. */
+function safeObservationIdLiteral(id: string): string {
+  assertValidObservationId(id);
+  return `'${id}'`;
+}
+
+/** Build a LanceDB predicate only from a safe observation id literal. */
+function observationIdPredicate(id: string): string {
+  return `id = ${safeObservationIdLiteral(id)}`;
 }
 
 /**
@@ -237,12 +249,13 @@ export class LanceDBVectorStore implements IVectorStore {
    * Get observation by ID
    */
   async getById(id: string): Promise<Observation | null> {
+    const predicate = observationIdPredicate(id);
     if (!this.initialized) await this.initialize();
     if (!this.table) return null;
 
     const results = await this.table
       .query()
-      .where(`id = '${id}'`)
+      .where(predicate)
       .limit(1)
       .toArray();
 
@@ -270,11 +283,12 @@ export class LanceDBVectorStore implements IVectorStore {
    * Delete observation by ID
    */
   async delete(id: string): Promise<boolean> {
+    const predicate = observationIdPredicate(id);
     if (!this.initialized) await this.initialize();
     if (!this.table) return false;
 
     try {
-      await this.table.delete(`id = '${id}'`);
+      await this.table.delete(predicate);
       logger.debug(`Deleted observation ${id}`);
       return true;
     } catch (error) {

--- a/src/lib/observation-id.ts
+++ b/src/lib/observation-id.ts
@@ -1,0 +1,17 @@
+/**
+ * Observation ID validation shared by memory routes and vector stores.
+ */
+
+const OBSERVATION_ID_PATTERN = /^[a-zA-Z0-9-_]{8,64}$/;
+
+/** Validate observation ID format before it is used in vector-store predicates. */
+export function isValidObservationId(id: unknown): id is string {
+  return typeof id === 'string' && OBSERVATION_ID_PATTERN.test(id);
+}
+
+/** Throw when a value cannot safely be used as an observation ID. */
+export function assertValidObservationId(id: unknown): asserts id is string {
+  if (!isValidObservationId(id)) {
+    throw new Error('Invalid observation ID format');
+  }
+}

--- a/src/web/api/middleware/validation.ts
+++ b/src/web/api/middleware/validation.ts
@@ -14,6 +14,7 @@ export const VALID_TERMINAL_APPS = ['Terminal', 'iTerm', 'Warp', 'auto'] as cons
 export type TerminalAppOption = (typeof VALID_TERMINAL_APPS)[number];
 
 export { isValidSessionId } from '../../../lib/session-id.js';
+export { isValidObservationId } from '../../../lib/observation-id.js';
 
 /** Recovery request body */
 export interface RecoverRequestBody {

--- a/src/web/api/routes/memory.ts
+++ b/src/web/api/routes/memory.ts
@@ -11,7 +11,7 @@ import { buildContext, buildMinimalContext } from '../../../domain/memory/index.
 import type { MemoryUpsertData } from '../../../domain/memory/index.js';
 import { logger } from '../../../lib/logger.js';
 import { authMiddleware } from '../middleware/auth.js';
-import { isValidSessionId } from '../middleware/validation.js';
+import { isValidObservationId, isValidSessionId } from '../middleware/validation.js';
 import type { ObservationCategory } from '../../../infrastructure/vector/types.js';
 
 const app = new Hono();
@@ -444,6 +444,10 @@ app.get('/observations', async (c) => {
 app.get('/observations/:id', async (c) => {
   const id = c.req.param('id');
 
+  if (!isValidObservationId(id)) {
+    return c.json({ success: false, error: 'Invalid observation ID format' }, 400);
+  }
+
   try {
     const vectorStore = await getVectorStoreService();
     await vectorStore.initialize();
@@ -547,6 +551,10 @@ app.post('/observations', async (c) => {
 // DELETE /api/memory/observations/:id - Delete observation by ID
 app.delete('/observations/:id', async (c) => {
   const id = c.req.param('id');
+
+  if (!isValidObservationId(id)) {
+    return c.json({ success: false, error: 'Invalid observation ID format' }, 400);
+  }
 
   try {
     const vectorStore = await getVectorStoreService();


### PR DESCRIPTION
## Summary

- Closes #74
- Add SpecRail packet for GH74 (`product.md`, `tech.md`, `tasks.md`)
- Add observation id allowlist validation shared by API routes and vector store code
- Reject invalid `GET` / `DELETE /api/memory/observations/:id` requests with 400 before LanceDB access
- Guard direct `LanceDBVectorStore.getById()` / `delete()` calls before initialization or predicate construction

## Verification

- `bun test src/__tests__/validation.test.ts src/__tests__/observation-id.test.ts`
- `bun run typecheck`
- `bun test`
- `bun run build`
- `git diff --check`

## Notes

LanceDB JS exposes string predicates for `where()` and `delete()`, so this PR uses a strict fail-closed observation id allowlist and centralized safe predicate construction. It does not change session-id batch operations or unrelated P2 LanceDB cleanup work.