### PR TITLE
fix(orchestrator): label inferred task sources

### DIFF
--- a/src/__tests__/attention.prioritizer.test.ts
+++ b/src/__tests__/attention.prioritizer.test.ts
@@ -259,6 +259,7 @@ describe('buildAttentionOverview', () => {
 
     expect(overview.items[0].intent).toMatchObject({
       task: 'Investigate: Denoise probe 第一次启动失败了，我先看 stderr',
+      taskSource: 'last_message',
       currentState: 'Denoise probe 第一次启动失败了，我先看 stderr。通常这种是脚本路径或 OpenVINO Async API 细节。',
       nextAction: 'Recover this session and continue around topaz_dragon_cleanup_20260629T035947Z/cleanup_standard.png.',
       whyAttention: 'Session is lost and may be recoverable',
@@ -289,6 +290,7 @@ describe('buildAttentionOverview', () => {
     expect(overview.items[0].intent.task).toBe(
       'Continue: 结论是：gh21 应该学习产品行为和交互契约，不是照搬原型 UI'
     );
+    expect(overview.items[0].intent.taskSource).toBe('last_message');
   });
 
   test('does not use low-information responses as derived tasks', () => {
@@ -303,6 +305,7 @@ describe('buildAttentionOverview', () => {
     ], { now: NOW });
 
     expect(overview.items[0].intent.task).toBeUndefined();
+    expect(overview.items[0].intent.taskSource).toBe('none');
     expect(overview.items[0].intent.currentState).toBe('继续正常。');
     expect(overview.items[0].intent.noiseFlags).toEqual([
       'instructions_heavy',
@@ -322,6 +325,7 @@ describe('buildAttentionOverview', () => {
     ], { now: NOW });
 
     expect(overview.items[0].intent.task).toBeUndefined();
+    expect(overview.items[0].intent.taskSource).toBe('none');
     expect(overview.items[0].intent.currentState).toBe('你好，我在。 Memory citations: none');
   });
 
@@ -361,5 +365,6 @@ describe('buildAttentionOverview', () => {
       status: 'fresh',
       generatedAt: '2026-06-29T12:00:00.000Z',
     });
+    expect(overview.items[1].intent.taskSource).toBe('digest');
   });
 });

--- a/src/__tests__/orchestrator.route.test.ts
+++ b/src/__tests__/orchestrator.route.test.ts
@@ -76,10 +76,12 @@ describe('Orchestrator Route Contract', () => {
           };
           intent: {
             task?: string;
+            taskSource: string;
             currentState?: string;
             nextAction: string;
             whyAttention: string;
             confidence: string;
+            noiseFlags: string[];
           };
           reasons: Array<{ code: string }>;
         }>;
@@ -104,6 +106,7 @@ describe('Orchestrator Route Contract', () => {
       },
       intent: {
         task: 'Track cost',
+        taskSource: 'initial_prompt',
         currentState: 'Cost is high, review before continuing',
         nextAction: 'Recover this session and continue around keepline-orchestrator/report.md.',
         whyAttention: 'Session is lost and may be recoverable; Session cost is $5.00',
@@ -111,6 +114,56 @@ describe('Orchestrator Route Contract', () => {
       },
     });
     expect(body.data.items[0].reasons.map((reason) => reason.code)).toContain('high_cost');
+  });
+
+  test('overview marks tasks derived from noisy prompt fallbacks as last-message sourced', async () => {
+    sessionRepository.upsert({
+      sessionId: 'orchestrator-last-message-derived',
+      client: 'codex',
+      directory: '/tmp/keepline-derived-intent',
+      status: 'waiting',
+      title: '# AGENTS.md instructions <INSTRUCTIONS> vibeguard-start',
+      initialPrompt: '# AGENTS.md instructions <INSTRUCTIONS> Files called AGENTS.md commonly appear in many places.',
+      lastMessage: 'Continue: 首页已经看到新定位，项目页这次正则没有命中，我会查一下 dev server 输出。',
+      lastActiveAt: recentSessionDate(),
+      toolCount: 3,
+      messageCount: 8,
+    });
+
+    const { token } = await setupUser('orchestrator-derived-intent-user', 'password123');
+    const response = await orchestrator.fetch(new Request(
+      'http://localhost/overview?limit=1',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as {
+      success: boolean;
+      data: {
+        items: Array<{
+          sessionId: string;
+          intent: {
+            task?: string;
+            taskSource: string;
+            noiseFlags: string[];
+          };
+        }>;
+      };
+    };
+
+    expect(body.success).toBe(true);
+    expect(body.data.items[0]).toMatchObject({
+      sessionId: 'orchestrator-last-message-derived',
+      intent: {
+        taskSource: 'last_message',
+        noiseFlags: expect.arrayContaining([
+          'instructions_heavy',
+          'derived_from_last_message',
+          'missing_user_goal',
+        ]),
+      },
+    });
+    expect(body.data.items[0].intent.task).toStartWith('Continue:');
   });
 
   test('server mounts the orchestrator overview route', async () => {

--- a/src/services/attention.prioritizer.ts
+++ b/src/services/attention.prioritizer.ts
@@ -32,6 +32,13 @@ export interface AttentionSessionContext {
 }
 
 export type AttentionIntentConfidence = 'high' | 'medium' | 'low';
+export type AttentionIntentTaskSource =
+  | 'initial_prompt'
+  | 'digest'
+  | 'title'
+  | 'last_message'
+  | 'current_file'
+  | 'none';
 export type AttentionIntentNoiseFlag =
   | 'instructions_heavy'
   | 'missing_user_goal'
@@ -40,6 +47,7 @@ export type AttentionIntentNoiseFlag =
 
 export interface AttentionIntent {
   task?: string;
+  taskSource: AttentionIntentTaskSource;
   currentState?: string;
   nextAction: string;
   whyAttention: string;
@@ -307,17 +315,26 @@ function buildSessionIntent(
     ? `Working around ${formatPathTail(session.currentFile)}`
     : undefined;
 
-  let task = firstNonEmpty([promptTask, digestTask, titleTask]);
+  const taskCandidate = firstNonEmptyTask([
+    { task: promptTask, source: 'initial_prompt' },
+    { task: digestTask, source: 'digest' },
+    { task: titleTask, source: 'title' },
+  ]);
+
+  let task = taskCandidate?.task;
+  let taskSource: AttentionIntentTaskSource = taskCandidate?.source ?? 'none';
   let confidence: AttentionIntentConfidence = task ? 'high' : 'low';
 
   if (!task && taskMessage) {
     task = deriveTaskFromLastMessage(taskMessage);
+    taskSource = task ? 'last_message' : 'none';
     confidence = 'medium';
     noiseFlags.push('derived_from_last_message');
   }
 
   if (!task && fileTask) {
     task = fileTask;
+    taskSource = 'current_file';
     confidence = 'low';
     noiseFlags.push('derived_from_file');
   }
@@ -328,6 +345,7 @@ function buildSessionIntent(
 
   return {
     task,
+    taskSource,
     currentState: firstNonEmpty([lastMessage, digestTask, titleTask]),
     nextAction: buildNextAction(session, reasons),
     whyAttention: buildWhyAttention(reasons),
@@ -427,6 +445,14 @@ function buildWhyAttention(reasons: AttentionReason[]): string {
 
 function firstNonEmpty(values: Array<string | undefined>): string | undefined {
   return values.find((value) => value?.trim());
+}
+
+function firstNonEmptyTask(
+  values: Array<{ task: string | undefined; source: AttentionIntentTaskSource }>
+): { task: string; source: AttentionIntentTaskSource } | undefined {
+  return values.find((value): value is { task: string; source: AttentionIntentTaskSource } =>
+    Boolean(value.task?.trim())
+  );
 }
 
 function formatPathTail(path: string): string {

--- a/src/web/client/src/components/OrchestratorPanel/OrchestratorPanel.tsx
+++ b/src/web/client/src/components/OrchestratorPanel/OrchestratorPanel.tsx
@@ -4,6 +4,7 @@ import { useOrchestratorOverview } from '@/hooks'
 import type {
   OrchestratorDigest,
   OrchestratorIntent,
+  OrchestratorIntentTaskSource,
   OrchestratorQueueItem,
   OrchestratorReason,
   OrchestratorRecommendedAction,
@@ -155,7 +156,7 @@ function QueueCard({
       <div className={styles.cardBody}>
         <div className={styles.cardHeader}>
           <div className={styles.identity}>
-            <h3 className={styles.itemTitle}>{item.intent.task || 'No clear task captured'}</h3>
+            <h3 className={styles.itemTitle}>{formatIntentTitle(item.intent)}</h3>
             <div className={styles.pathLine}>{formatIdentitySubtitle(item)}</div>
           </div>
           <div className={styles.badges}>
@@ -195,8 +196,9 @@ function QueueCard({
 }
 
 function IntentBlock({ intent }: { intent: OrchestratorIntent }) {
+  const taskSource = intent.taskSource ?? 'none'
   const rows = [
-    { label: 'Task', text: intent.task },
+    { label: formatTaskLabel(taskSource), text: intent.task },
     { label: 'Current state', text: intent.currentState },
     { label: 'Next action', text: intent.nextAction },
     { label: 'Why attention', text: intent.whyAttention },
@@ -431,6 +433,43 @@ function formatScopeText(hiddenOldLost: number, lostWindowHours?: number): strin
 
 function formatNoiseFlag(flag: string): string {
   return flag.replace(/_/g, ' ')
+}
+
+function formatIntentTitle(intent: OrchestratorIntent): string {
+  const taskSource = intent.taskSource ?? 'none'
+  if (!intent.task) return 'No original task captured'
+  switch (taskSource) {
+    case 'initial_prompt':
+      return intent.task
+    case 'digest':
+      return `Digest: ${intent.task}`
+    case 'title':
+      return `Session title: ${intent.task}`
+    case 'last_message':
+      return `Latest message: ${intent.task}`
+    case 'current_file':
+      return `Current file: ${intent.task}`
+    case 'none':
+      return `Unverified task: ${intent.task}`
+  }
+}
+
+function formatTaskLabel(source: OrchestratorIntentTaskSource | undefined): string {
+  switch (source) {
+    case 'initial_prompt':
+      return 'Original task'
+    case 'digest':
+      return 'Digest summary'
+    case 'title':
+      return 'Session title'
+    case 'last_message':
+      return 'Latest message'
+    case 'current_file':
+      return 'Current file'
+    case 'none':
+      return 'Task'
+  }
+  return 'Task'
 }
 
 function formatIdentitySubtitle(item: OrchestratorQueueItem): string {

--- a/src/web/client/src/types/orchestrator.ts
+++ b/src/web/client/src/types/orchestrator.ts
@@ -30,6 +30,13 @@ export interface OrchestratorSessionContext {
 }
 
 export type OrchestratorIntentConfidence = 'high' | 'medium' | 'low'
+export type OrchestratorIntentTaskSource =
+  | 'initial_prompt'
+  | 'digest'
+  | 'title'
+  | 'last_message'
+  | 'current_file'
+  | 'none'
 export type OrchestratorIntentNoiseFlag =
   | 'instructions_heavy'
   | 'missing_user_goal'
@@ -38,6 +45,7 @@ export type OrchestratorIntentNoiseFlag =
 
 export interface OrchestratorIntent {
   task?: string
+  taskSource: OrchestratorIntentTaskSource
   currentState?: string
   nextAction: string
   whyAttention: string


### PR DESCRIPTION
## Summary

Fixes #85.

Clarifies where Orchestrator `intent.task` came from so the attention queue does not present a mid-conversation fallback as the original user task.

## Changes

- Add `intent.taskSource` to the deterministic attention overview contract.
- Track task source across initial prompt, digest, session title, last message, current file, and no-task fallback paths.
- Update the Web Orchestrator card title and intent labels so non-original sources are explicit.
- Keep a UI fallback for stale/older API responses that do not include `taskSource`.
- Add route and unit coverage for noisy AGENTS prompt fallback to `last_message`.

## Verification

- `bun test src/__tests__/attention.prioritizer.test.ts src/__tests__/orchestrator.route.test.ts`
- `bun run typecheck`

Earlier full verification on the same diff also passed:

- `bun test`
- `bun run build`
