### PR TITLE
fix: restore Claude hook event pipeline

### DIFF
--- a/specs/GH75/product.md
+++ b/specs/GH75/product.md
@@ -1,0 +1,42 @@
+# Hook Pipeline Recovery Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/75
+
+## Summary
+
+Keepline 的 Claude Code hook 安装必须让实时监控和跨会话上下文入口实际收到 Claude Code 事件。安装后，Claude Code 的 `PreToolUse`、`PostToolUse`、`Notification`、`Stop`、`UserPromptSubmit` 事件应全部转发到本地 hook server。
+
+## User Problem
+
+用户安装 hooks 后预期看到实时会话状态、工具活动、Stop 自动完成和首次 prompt 上下文注入。如果安装器只注册 `PostToolUse`，或依赖 Claude Code 不提供的环境变量拼接 payload，功能会静默失效：
+
+1. `Stop` 不会把会话标记为 completed。
+2. `UserPromptSubmit` 不会触发上下文注入。
+3. 工具事件无法稳定携带 session、cwd、tool input 和 tool response。
+4. `|| true` 会隐藏 hook 命令失败，用户只看到实时功能退化。
+
+## Product Behavior
+
+1. `keepline hooks install` 写入 Claude Code 当前 hook schema。
+2. 同一个 Keepline command hook 注册到 `PreToolUse`、`PostToolUse`、`Notification`、`Stop`、`UserPromptSubmit`。
+3. Command hook 从 stdin 接收 Claude Code JSON，并原样 POST 到 Keepline hook server。
+4. Hook server 接受 Claude Code 官方字段：`hook_event_name`、`session_id`、`cwd`、`tool_name`、`tool_input`、`tool_response`、`prompt`、`message`。
+5. Hook server 继续兼容旧 Keepline payload：`event_type`、`timestamp`、`tool_output`。
+6. 无效 payload 必须返回 400，不得被当作有效事件降级处理。
+
+## Non-Goals
+
+- 不在本 issue 引入 hook shared secret 或 Host/Origin 校验；安全加固由 GH79 覆盖。
+- 不改变 compression queue 或 memory extractor 的内部事件 contract。
+- 不要求 hook server 在 `keepline web` 默认启动；daemon/web 启动边界由其他 issue 覆盖。
+- 不移除旧 hook ownership detection；旧安装需要可升级。
+
+## Acceptance Criteria
+
+1. 安装器不再依赖 `$CLAUDE_EVENT_TYPE`、`$CLAUDE_SESSION_ID`、`$CLAUDE_TOOL_NAME`、`$CLAUDE_TOOL_INPUT`。
+2. 安装器注册全部五类已消费事件，而不只是 `PostToolUse`。
+3. `PostToolUse` 官方 `tool_response` 能被转为内部 `tool_output` 并进入现有 tool event/压缩路径。
+4. `UserPromptSubmit` 官方 payload 能通过 validation 并触发现有 prompt handling。
+5. 旧 Keepline payload 仍可被 hook server 接受。
+6. 回归测试覆盖安装结构、legacy 升级、官方 payload normalization 和 malformed payload 拒绝。
+7. 验证命令通过：focused hook tests、`bun run typecheck`、`bun test`、`bun run build`。

--- a/specs/GH75/tasks.md
+++ b/specs/GH75/tasks.md
@@ -1,0 +1,23 @@
+# Hook Pipeline Recovery Tasks
+
+Issue: https://github.com/majiayu000/keepline/issues/75
+
+## Tasks
+
+- [x] Verify current Claude Code hook contract from official docs.
+- [x] Add GH75 product and tech specs.
+- [x] Update hook settings types for current matcher-group schema.
+- [x] Replace env-var payload synthesis with stdin forwarding.
+- [x] Register Keepline hook command for all consumed event types.
+- [x] Preserve and upgrade legacy Keepline hook ownership detection.
+- [x] Normalize official Claude Code payloads at the hook server boundary.
+- [x] Keep legacy `event_type` payload compatibility.
+- [x] Add focused installer and server tests.
+- [x] Run focused hook tests.
+- [x] Run `bun run typecheck`.
+- [x] Run `bun test`.
+- [x] Run `bun run build`.
+
+## Completion Mode
+
+Final implementation PR should use `Fixes #75` only after all acceptance criteria pass. Partial follow-up slices should use `Refs #75`.

--- a/specs/GH75/tech.md
+++ b/specs/GH75/tech.md
@@ -1,0 +1,91 @@
+# Hook Pipeline Recovery Tech Spec
+
+Product spec: specs/GH75/product.md
+
+Issue: https://github.com/majiayu000/keepline/issues/75
+
+## External Contract
+
+Claude Code command hooks receive the event JSON on stdin. Common fields include `session_id`, `transcript_path`, `cwd`, and `hook_event_name`. Tool events add `tool_name` and `tool_input`; `PostToolUse` adds `tool_response`; `UserPromptSubmit` adds `prompt`; `Stop` adds stop-specific fields.
+
+The hook settings schema is event keyed and contains matcher groups with nested hook handlers:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "..."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Implementation Plan
+
+### Installer
+
+Update `src/adapters/hook/installer.ts`:
+
+- Generate one command that forwards stdin:
+
+  ```bash
+  KEEPLINE_HOOK_MARKER=keepline-hook-v1 curl -fsS -X POST http://127.0.0.1:<port>/hook -H "Content-Type: application/json" --data-binary @- > /dev/null 2>&1 || true
+  ```
+
+- Register Keepline hook handlers for:
+  - `PreToolUse`
+  - `PostToolUse`
+  - `Notification`
+  - `Stop`
+  - `UserPromptSubmit`
+- Use `matcher: "*"` only for tool events.
+- Preserve unrelated hook handlers and remove/upgrade only Keepline-owned legacy hooks.
+- Treat fully installed five-event config as installed; partial `PostToolUse` only should be repaired by reinstall.
+
+### Server Boundary
+
+Update `src/adapters/hook/server.ts`:
+
+- Add a pure `normalizeHookEvent(raw, now)` boundary function.
+- Accept both official `hook_event_name` and legacy `event_type`.
+- Fill missing `timestamp` at receive time for official payloads.
+- Convert official `tool_response` to internal string `tool_output` with `JSON.stringify`.
+- Keep existing internal handlers unchanged after normalization.
+- Reject malformed payloads with 400.
+
+### Types
+
+Update `src/adapters/hook/types.ts`:
+
+- Model current hook settings as matcher groups with nested command handlers.
+- Keep legacy direct command entries in the union for ownership detection and uninstall.
+- Keep internal `HookEvent` normalized around `event_type` and `timestamp`.
+
+## Tests
+
+- `src/__tests__/hook.installer.test.ts`
+  - unrelated localhost hooks are preserved.
+  - foreign legacy-shaped hooks are not claimed.
+  - install writes all five events in current schema.
+  - uninstall removes only Keepline-owned handlers.
+  - legacy Keepline command is upgraded without duplication.
+  - reinstall of the full config is a no-op.
+
+- `src/__tests__/hook.server.test.ts`
+  - official `PostToolUse` stdin payload normalizes successfully.
+  - legacy `event_type` payload remains accepted.
+  - official `UserPromptSubmit` without command-synthesized timestamp is valid.
+  - malformed tool payload is rejected.
+
+## Risk Notes
+
+- The command keeps `|| true` to avoid blocking Claude Code when Keepline is not running. This preserves existing non-blocking behavior but means users need status/health tooling to discover delivery failures.
+- GH79 should add Host/Origin/auth checks; this issue only restores event delivery.

--- a/src/__tests__/hook.installer.test.ts
+++ b/src/__tests__/hook.installer.test.ts
@@ -10,6 +10,7 @@ const markedCommand = 'KEEPLINE_HOOK_MARKER=keepline-hook-v1 curl -s -X POST htt
 const unrelatedLocalhostCommand = 'curl -s http://127.0.0.1:7777/other-hook';
 const legacyKeeplineCommand = `curl -s -X POST http://127.0.0.1:7890/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
 const foreignLegacyShapeCommand = `curl -s -X POST https://collector.example/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
+const expectedHandler = { type: 'command', command: markedCommand };
 
 describe('hook installer ownership detection', () => {
   test('does not claim unrelated localhost hooks', () => {
@@ -31,8 +32,20 @@ describe('hook installer ownership detection', () => {
 
     expect(changed).toBe(true);
     expect(settings.hooks?.PostToolUse).toHaveLength(2);
-    expect(settings.hooks?.PostToolUse?.[0].command).toBe(unrelatedLocalhostCommand);
-    expect(settings.hooks?.PostToolUse?.[1].command).toBe(markedCommand);
+    expect(settings.hooks?.PostToolUse?.[0]).toEqual({ command: unrelatedLocalhostCommand });
+    expect(settings.hooks?.PostToolUse?.[1]).toEqual({
+      matcher: '*',
+      hooks: [expectedHandler],
+    });
+    expect(settings.hooks?.PreToolUse).toEqual([
+      {
+        matcher: '*',
+        hooks: [expectedHandler],
+      },
+    ]);
+    expect(settings.hooks?.Notification).toEqual([{ hooks: [expectedHandler] }]);
+    expect(settings.hooks?.Stop).toEqual([{ hooks: [expectedHandler] }]);
+    expect(settings.hooks?.UserPromptSubmit).toEqual([{ hooks: [expectedHandler] }]);
   });
 
   test('uninstall removes only Keepline-owned hooks', () => {
@@ -56,6 +69,32 @@ describe('hook installer ownership detection', () => {
     expect(settings.hooks?.Stop).toEqual([{ command: 'echo keep-me' }]);
   });
 
+  test('uninstall removes Keepline handlers from mixed matcher groups', () => {
+    const settings: ClaudeSettings = {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: '*',
+            hooks: [
+              { type: 'command', command: markedCommand },
+              { type: 'command', command: 'echo keep-me' },
+            ],
+          },
+        ],
+      },
+    };
+
+    const removed = uninstallKeeplineHookConfig(settings);
+
+    expect(removed).toBe(1);
+    expect(settings.hooks?.PostToolUse).toEqual([
+      {
+        matcher: '*',
+        hooks: [{ type: 'command', command: 'echo keep-me' }],
+      },
+    ]);
+  });
+
   test('install upgrades a legacy Keepline hook without duplicating', () => {
     const settings: ClaudeSettings = {
       hooks: {
@@ -66,6 +105,27 @@ describe('hook installer ownership detection', () => {
     const changed = installKeeplineHookConfig(settings, markedCommand);
 
     expect(changed).toBe(true);
-    expect(settings.hooks?.PostToolUse).toEqual([{ command: markedCommand }]);
+    expect(settings.hooks?.PostToolUse).toEqual([
+      {
+        matcher: '*',
+        hooks: [expectedHandler],
+      },
+    ]);
+    expect(settings.hooks?.PreToolUse).toEqual([
+      {
+        matcher: '*',
+        hooks: [expectedHandler],
+      },
+    ]);
+    expect(settings.hooks?.Notification).toEqual([{ hooks: [expectedHandler] }]);
+    expect(settings.hooks?.Stop).toEqual([{ hooks: [expectedHandler] }]);
+    expect(settings.hooks?.UserPromptSubmit).toEqual([{ hooks: [expectedHandler] }]);
+  });
+
+  test('reinstalling an existing full Keepline config is a no-op', () => {
+    const settings: ClaudeSettings = {};
+
+    expect(installKeeplineHookConfig(settings, markedCommand)).toBe(true);
+    expect(installKeeplineHookConfig(settings, markedCommand)).toBe(false);
   });
 });

--- a/src/__tests__/hook.server.test.ts
+++ b/src/__tests__/hook.server.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test';
+import { isValidHookEvent, normalizeHookEvent } from '../adapters/hook/server.js';
+
+const fixedNow = new Date('2026-07-02T15:30:00.000Z');
+
+describe('hook server payload normalization', () => {
+  test('accepts current Claude Code PostToolUse stdin payloads', () => {
+    const event = normalizeHookEvent(
+      {
+        session_id: 'session-1234',
+        transcript_path: '/tmp/transcript.jsonl',
+        cwd: '/tmp/project',
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Write',
+        tool_input: {
+          file_path: '/tmp/project/file.txt',
+          content: 'hello',
+        },
+        tool_response: {
+          filePath: '/tmp/project/file.txt',
+          success: true,
+        },
+      },
+      fixedNow
+    );
+
+    expect(event).toEqual({
+      event_type: 'PostToolUse',
+      session_id: 'session-1234',
+      transcript_path: '/tmp/transcript.jsonl',
+      cwd: '/tmp/project',
+      timestamp: '2026-07-02T15:30:00.000Z',
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '/tmp/project/file.txt',
+        content: 'hello',
+      },
+      tool_output: '{"filePath":"/tmp/project/file.txt","success":true}',
+    });
+  });
+
+  test('accepts legacy Keepline event_type payloads', () => {
+    const event = normalizeHookEvent({
+      event_type: 'PreToolUse',
+      session_id: 'session-1234',
+      cwd: '/tmp/project',
+      timestamp: '2026-07-02T15:31:00.000Z',
+      tool_name: 'Bash',
+      tool_input: {
+        command: 'bun test',
+      },
+    });
+
+    expect(event).toEqual({
+      event_type: 'PreToolUse',
+      session_id: 'session-1234',
+      cwd: '/tmp/project',
+      timestamp: '2026-07-02T15:31:00.000Z',
+      transcript_path: undefined,
+      tool_name: 'Bash',
+      tool_input: {
+        command: 'bun test',
+      },
+      tool_output: undefined,
+    });
+  });
+
+  test('accepts UserPromptSubmit without a synthetic timestamp from the command', () => {
+    expect(
+      isValidHookEvent({
+        session_id: 'session-1234',
+        cwd: '/tmp/project',
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'Summarize this repo',
+      })
+    ).toBe(true);
+  });
+
+  test('rejects malformed tool payloads', () => {
+    expect(
+      normalizeHookEvent({
+        session_id: 'session-1234',
+        cwd: '/tmp/project',
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Write',
+      })
+    ).toBeNull();
+  });
+});

--- a/src/adapters/hook/installer.ts
+++ b/src/adapters/hook/installer.ts
@@ -6,7 +6,13 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { CLAUDE_SETTINGS } from '../../lib/paths.js';
 import { config } from '../../lib/config.js';
 import { logger } from '../../lib/logger.js';
-import type { ClaudeSettings, ClaudeHookConfig } from './types.js';
+import type {
+  ClaudeHookCommandHandler,
+  ClaudeHookConfig,
+  ClaudeHookMatcherGroup,
+  ClaudeSettings,
+  HookEventType,
+} from './types.js';
 
 const KEEPLINE_HOOK_MARKER = 'KEEPLINE_HOOK_MARKER=keepline-hook-v1';
 const HOOK_TYPES = ['PreToolUse', 'PostToolUse', 'Notification', 'Stop', 'UserPromptSubmit'] as const;
@@ -37,7 +43,7 @@ function saveClaudeSettings(settings: ClaudeSettings): void {
 /** Generate hook command */
 function getHookCommand(): string {
   const port = config.get().hookPort;
-  return `${KEEPLINE_HOOK_MARKER} curl -s -X POST http://127.0.0.1:${port}/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
+  return `${KEEPLINE_HOOK_MARKER} curl -fsS -X POST http://127.0.0.1:${port}/hook -H "Content-Type: application/json" --data-binary @- > /dev/null 2>&1 || true`;
 }
 
 function isLegacyKeeplineHookCommand(command: string): boolean {
@@ -52,49 +58,120 @@ function isLegacyKeeplineHookCommand(command: string): boolean {
   );
 }
 
+function isHookCommandHandler(hook: unknown): hook is ClaudeHookCommandHandler {
+  return Boolean(
+    hook &&
+    typeof hook === 'object' &&
+    typeof (hook as Partial<ClaudeHookCommandHandler>).command === 'string'
+  );
+}
+
+function isHookMatcherGroup(hook: unknown): hook is ClaudeHookMatcherGroup {
+  return Boolean(
+    hook &&
+    typeof hook === 'object' &&
+    Array.isArray((hook as Partial<ClaudeHookMatcherGroup>).hooks)
+  );
+}
+
 export function isKeeplineHook(hook: unknown): hook is ClaudeHookConfig {
-  if (
-    !hook ||
-    typeof hook !== 'object' ||
-    typeof (hook as Partial<ClaudeHookConfig>).command !== 'string'
-  ) {
-    return false;
+  if (isHookCommandHandler(hook)) {
+    return hook.command.includes(KEEPLINE_HOOK_MARKER) || isLegacyKeeplineHookCommand(hook.command);
   }
-  const command = (hook as ClaudeHookConfig).command;
-  return command.includes(KEEPLINE_HOOK_MARKER) || isLegacyKeeplineHookCommand(command);
+
+  if (isHookMatcherGroup(hook)) {
+    return hook.hooks.some(isKeeplineHook);
+  }
+
+  return false;
+}
+
+function removeKeeplineHooks(hooks: ClaudeHookConfig[]): ClaudeHookConfig[] {
+  const nextHooks: ClaudeHookConfig[] = [];
+
+  for (const hook of hooks) {
+    if (isHookCommandHandler(hook)) {
+      if (!isKeeplineHook(hook)) {
+        nextHooks.push(hook);
+      }
+      continue;
+    }
+
+    if (isHookMatcherGroup(hook)) {
+      const remainingHandlers = hook.hooks.filter((handler) => !isKeeplineHook(handler));
+      if (remainingHandlers.length > 0) {
+        nextHooks.push({
+          ...hook,
+          hooks: remainingHandlers,
+        });
+      }
+      continue;
+    }
+
+    nextHooks.push(hook);
+  }
+
+  return nextHooks;
+}
+
+function countKeeplineHooks(hooks: ClaudeHookConfig[]): number {
+  let count = 0;
+
+  for (const hook of hooks) {
+    if (isHookCommandHandler(hook)) {
+      if (isKeeplineHook(hook)) {
+        count++;
+      }
+      continue;
+    }
+
+    if (isHookMatcherGroup(hook)) {
+      count += hook.hooks.filter(isKeeplineHook).length;
+    }
+  }
+
+  return count;
+}
+
+function createKeeplineHookConfig(
+  hookType: HookEventType,
+  hookCommand: string
+): ClaudeHookMatcherGroup {
+  const config: ClaudeHookMatcherGroup = {
+    hooks: [
+      {
+        type: 'command',
+        command: hookCommand,
+      },
+    ],
+  };
+
+  if (hookType === 'PreToolUse' || hookType === 'PostToolUse') {
+    config.matcher = '*';
+  }
+
+  return config;
 }
 
 export function installKeeplineHookConfig(
   settings: ClaudeSettings,
   hookCommand: string = getHookCommand()
 ): boolean {
+  const before = JSON.stringify(settings.hooks ?? {});
+
   if (!settings.hooks) {
     settings.hooks = {};
   }
 
-  if (!settings.hooks.PostToolUse) {
-    settings.hooks.PostToolUse = [];
+  for (const hookType of HOOK_TYPES) {
+    const existingHooks = settings.hooks[hookType] ?? [];
+    settings.hooks[hookType] = [
+      ...removeKeeplineHooks(existingHooks),
+      createKeeplineHookConfig(hookType, hookCommand),
+    ];
   }
 
-  const existingIndex = settings.hooks.PostToolUse.findIndex(isKeeplineHook);
-  const keeplineHook: ClaudeHookConfig = {
-    command: hookCommand,
-  };
-
-  if (existingIndex >= 0) {
-    const existing = settings.hooks.PostToolUse[existingIndex];
-    if (existing.command !== hookCommand) {
-      settings.hooks.PostToolUse[existingIndex] = {
-        ...existing,
-        command: hookCommand,
-      };
-      return true;
-    }
-    return false;
-  }
-
-  settings.hooks.PostToolUse.push(keeplineHook);
-  return true;
+  return JSON.stringify(settings.hooks) !== before;
 }
 
 export function uninstallKeeplineHookConfig(settings: ClaudeSettings): number {
@@ -104,8 +181,8 @@ export function uninstallKeeplineHookConfig(settings: ClaudeSettings): number {
   for (const hookType of HOOK_TYPES) {
     const hooks = settings.hooks[hookType];
     if (!hooks) continue;
-    const nextHooks = hooks.filter((hook) => !isKeeplineHook(hook));
-    removed += hooks.length - nextHooks.length;
+    removed += countKeeplineHooks(hooks);
+    const nextHooks = removeKeeplineHooks(hooks);
     settings.hooks[hookType] = nextHooks;
   }
 
@@ -113,9 +190,7 @@ export function uninstallKeeplineHookConfig(settings: ClaudeSettings): number {
 }
 
 function hasKeeplineHook(settings: ClaudeSettings): boolean {
-  return Boolean(
-    settings.hooks?.PostToolUse?.some(isKeeplineHook)
-  );
+  return HOOK_TYPES.every((hookType) => settings.hooks?.[hookType]?.some(isKeeplineHook));
 }
 
 /** Check if keepline hooks are installed */

--- a/src/adapters/hook/server.ts
+++ b/src/adapters/hook/server.ts
@@ -37,46 +37,108 @@ const VALID_EVENT_TYPES: Set<HookEventType> = new Set([
 /** Track first prompts per session for context injection */
 const sessionFirstPrompts: Map<string, boolean> = new Map();
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function getHookEventType(event: Record<string, unknown>): HookEventType | null {
+  const eventType = event.event_type ?? event.hook_event_name;
+  if (typeof eventType !== 'string' || !VALID_EVENT_TYPES.has(eventType as HookEventType)) {
+    return null;
+  }
+  return eventType as HookEventType;
+}
+
+function stringifyToolOutput(output: unknown): string | undefined {
+  if (output === undefined) {
+    return undefined;
+  }
+  if (typeof output === 'string') {
+    return output;
+  }
+  return JSON.stringify(output);
+}
+
+/** Normalize Claude Code stdin payloads and legacy Keepline payloads. */
+export function normalizeHookEvent(event: unknown, now: Date = new Date()): HookEvent | null {
+  if (!isRecord(event)) {
+    return null;
+  }
+
+  const eventType = getHookEventType(event);
+  if (!eventType) {
+    return null;
+  }
+
+  if (!isValidSessionId(event.session_id) || typeof event.cwd !== 'string') {
+    return null;
+  }
+
+  const base = {
+    event_type: eventType,
+    session_id: event.session_id,
+    cwd: event.cwd,
+    timestamp: typeof event.timestamp === 'string' ? event.timestamp : now.toISOString(),
+    transcript_path: typeof event.transcript_path === 'string' ? event.transcript_path : undefined,
+  };
+
+  if (eventType === 'PreToolUse' || eventType === 'PostToolUse') {
+    if (typeof event.tool_name !== 'string' || event.tool_name.length === 0) {
+      return null;
+    }
+    if (!isRecord(event.tool_input)) {
+      return null;
+    }
+
+    return {
+      ...base,
+      event_type: eventType,
+      tool_name: event.tool_name,
+      tool_input: event.tool_input,
+      tool_output: stringifyToolOutput(event.tool_output ?? event.tool_response),
+    };
+  }
+
+  if (eventType === 'Notification') {
+    if (typeof event.message !== 'string') {
+      return null;
+    }
+    return {
+      ...base,
+      event_type: 'Notification',
+      message: event.message,
+    };
+  }
+
+  if (eventType === 'Stop') {
+    return {
+      ...base,
+      event_type: 'Stop',
+      reason: typeof event.reason === 'string' ? event.reason : undefined,
+    };
+  }
+
+  if (typeof event.prompt !== 'string') {
+    return null;
+  }
+  return {
+    ...base,
+    event_type: 'UserPromptSubmit',
+    prompt: event.prompt,
+  };
+}
+
 /** Validate hook event payload */
-function isValidHookEvent(event: unknown): event is HookEvent {
-  if (!event || typeof event !== 'object') {
+export function isValidHookEvent(event: unknown): event is HookEvent {
+  if (!isRecord(event)) {
     return false;
   }
 
-  const e = event as Record<string, unknown>;
-
-  // Required fields
-  if (!isValidSessionId(e.session_id)) {
-    return false;
-  }
-  if (typeof e.cwd !== 'string') {
-    return false;
-  }
-  if (typeof e.timestamp !== 'string') {
-    return false;
-  }
-  if (typeof e.event_type !== 'string' || !VALID_EVENT_TYPES.has(e.event_type as HookEventType)) {
+  if (!isValidSessionId(event.session_id)) {
     return false;
   }
 
-  // Tool events require additional fields
-  if (e.event_type === 'PreToolUse' || e.event_type === 'PostToolUse') {
-    if (typeof e.tool_name !== 'string' || e.tool_name.length === 0) {
-      return false;
-    }
-    if (!e.tool_input || typeof e.tool_input !== 'object') {
-      return false;
-    }
-  }
-
-  // UserPromptSubmit requires prompt field
-  if (e.event_type === 'UserPromptSubmit') {
-    if (typeof e.prompt !== 'string') {
-      return false;
-    }
-  }
-
-  return true;
+  return normalizeHookEvent(event) !== null;
 }
 
 /** Handle incoming hook event */
@@ -219,14 +281,16 @@ export async function startHookServer(): Promise<void> {
   // Hook event endpoint
   server.post<{ Body: unknown }>('/hook', async (request, reply) => {
     try {
+      const event = normalizeHookEvent(request.body);
+
       // Validate input before processing
-      if (!isValidHookEvent(request.body)) {
+      if (!event) {
         logger.warn('Invalid hook event received', { body: request.body });
         reply.status(400);
         return { success: false, error: 'Invalid hook event payload' };
       }
 
-      await handleHookEvent(request.body);
+      await handleHookEvent(event);
       return { success: true };
     } catch (error) {
       logger.error('Failed to handle hook event', error);

--- a/src/adapters/hook/types.ts
+++ b/src/adapters/hook/types.ts
@@ -12,9 +12,11 @@ export type HookEventType =
 
 /** Base hook event payload */
 export interface HookEventPayload {
+  event_type: HookEventType;
   session_id: string;
   cwd: string;
   timestamp: string;
+  transcript_path?: string;
 }
 
 /** Tool use hook event */
@@ -22,7 +24,7 @@ export interface ToolUseHookEvent extends HookEventPayload {
   event_type: 'PreToolUse' | 'PostToolUse';
   tool_name: string;
   tool_input: Record<string, unknown>;
-  tool_output?: string; // Only present in PostToolUse
+  tool_output?: string;
 }
 
 /** Notification hook event */
@@ -52,10 +54,21 @@ export type HookEvent =
   | UserPromptSubmitHookEvent;
 
 /** Claude settings hook configuration */
-export interface ClaudeHookConfig {
-  matcher?: string;
+export interface ClaudeHookCommandHandler {
+  type?: 'command' | string;
   command: string;
+  args?: string[];
+  timeout?: number;
+  [key: string]: unknown;
 }
+
+export interface ClaudeHookMatcherGroup {
+  matcher?: string;
+  hooks: ClaudeHookCommandHandler[];
+  [key: string]: unknown;
+}
+
+export type ClaudeHookConfig = ClaudeHookCommandHandler | ClaudeHookMatcherGroup;
 
 /** Claude settings structure */
 export interface ClaudeSettings {


### PR DESCRIPTION
## Summary

- Fixes #75
- Add GH75 SpecRail product/tech/tasks packet
- Install Keepline hooks using Claude Code current matcher-group schema for PreToolUse, PostToolUse, Notification, Stop, and UserPromptSubmit
- Forward Claude hook stdin JSON directly to the local hook server instead of synthesizing payloads from unsupported env vars
- Normalize official hook_event_name/tool_response payloads while keeping legacy event_type/tool_output compatibility

## Verification

- `bun test src/__tests__/hook.installer.test.ts src/__tests__/hook.server.test.ts`
- `bun run typecheck`
- `bun test`
- `bun run build`

## Notes

- GH79 remains responsible for hook server Host/Origin/auth hardening.
- The command stays non-blocking when Keepline is not running, preserving existing hook behavior.