### PR TITLE
fix: tolerate truncated jsonl tail records

### DIFF
--- a/specs/GH76/product.md
+++ b/specs/GH76/product.md
@@ -1,0 +1,35 @@
+# Truncated JSONL Tail Recovery Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/76
+
+## Summary
+
+Keepline must keep recoverable sessions visible when a Claude Code or Codex JSONL transcript ends with a truncated final line. A crash or interrupted write can leave the last JSONL record incomplete; the parser should preserve all complete records before that tail instead of rejecting the whole file.
+
+## User Problem
+
+The product promise is session recovery after terminal crashes. Crash-time JSONL files are exactly where a truncated final line is most likely. If one bad final line causes the whole file to be cached as a parse failure, the session disappears from the dashboard and recovery candidates.
+
+## Product Behavior
+
+1. Claude Code session JSONL files with complete prior lines and a malformed final line still produce a parsed session summary.
+2. Codex rollout JSONL files with complete prior lines and a malformed final line still produce a parsed session summary.
+3. Malformed non-final lines remain hard parse errors.
+4. Scanner failure caches are not populated for tolerated truncated-tail files, so repeated scans keep the session visible.
+5. Empty/blank trailing lines remain ignored.
+
+## Non-Goals
+
+- Do not silently tolerate corruption in the middle of a transcript.
+- Do not attempt partial JSON repair or schema inference.
+- Do not change scanner mtime cache semantics except through avoiding false parse failures.
+- Do not broaden accepted file names or session IDs.
+
+## Acceptance Criteria
+
+1. Claude parser skips a malformed final JSONL line and returns data from earlier valid entries.
+2. Codex parser skips a malformed final JSONL line and returns data from earlier valid entries.
+3. Claude parser still throws `ParseError` for malformed non-final JSONL lines.
+4. Codex parser still throws `ParseError` for malformed non-final JSONL lines.
+5. Tests prove truncated-tail sessions are visible through parser/scanner paths.
+6. Verification commands pass: focused parser/scanner tests, `bun run typecheck`, `bun test`, `bun run build`.

--- a/specs/GH76/tasks.md
+++ b/specs/GH76/tasks.md
@@ -1,0 +1,20 @@
+# Truncated JSONL Tail Recovery Tasks
+
+Issue: https://github.com/majiayu000/keepline/issues/76
+
+## Tasks
+
+- [x] Confirm root cause in Claude and Codex JSONL parser loops.
+- [x] Add GH76 product and tech specs.
+- [x] Update Claude parser to tolerate malformed final line only.
+- [x] Update Codex parser to tolerate malformed final line only.
+- [x] Add parser tests for truncated final line and corrupted middle line.
+- [x] Add scanner/cache tests proving truncated sessions remain visible.
+- [x] Run focused parser/scanner tests.
+- [x] Run `bun run typecheck`.
+- [x] Run `bun test`.
+- [x] Run `bun run build`.
+
+## Completion Mode
+
+Final implementation PR should use `Fixes #76` only after all acceptance criteria pass. Partial follow-up slices should use `Refs #76`.

--- a/specs/GH76/tech.md
+++ b/specs/GH76/tech.md
@@ -1,0 +1,44 @@
+# Truncated JSONL Tail Recovery Tech Spec
+
+Product spec: specs/GH76/product.md
+
+Issue: https://github.com/majiayu000/keepline/issues/76
+
+## Current Root Cause
+
+`src/adapters/claude/parser/jsonl.ts` and `src/adapters/codex/parser.ts` parse each JSONL line as soon as it is read. Any `JSON.parse` failure throws `ParseError`. Scanner callers catch that error, cache the file as failed for the current mtime, and return no session data for that file.
+
+This is correct for middle-of-file corruption, but wrong for a final partial line caused by a process crash or interrupted write.
+
+## Design
+
+Use one-line lookahead in both streaming parsers:
+
+1. Keep the current line pending.
+2. When the next line arrives, parse the previous pending line as definitely non-final.
+3. After the stream ends, parse the last pending line with `allowTruncatedTail: true`.
+4. If the last pending line fails JSON parse, return `null` for that line only and finalize the accumulator from earlier complete records.
+5. If any non-final line fails JSON parse, throw `ParseError` with the original file path and line number.
+
+This keeps memory constant and preserves the streaming parser shape.
+
+## Implementation Notes
+
+- Claude parser:
+  - Extend `parseLine` to accept `allowTruncatedTail`.
+  - Add a local `processLine` helper inside `parseSessionFile`.
+  - Reuse existing accumulator/finalizer unchanged.
+
+- Codex parser:
+  - Add a small `parseCodexLine` helper with the same last-line tolerance.
+  - Apply the same pending-line flow in `parseCodexSessionFile`.
+
+- Tests:
+  - Adjust invalid JSONL tests so non-final corruption is still asserted.
+  - Add final-line truncation tests for both parsers.
+  - Add scanner-level coverage that truncated tails do not become cached failures.
+
+## Risk Notes
+
+- Tolerating any malformed final line can hide a real final-record corruption. This is deliberate because final-record corruption is indistinguishable from crash truncation and should not hide an otherwise recoverable session.
+- The parser does not log tolerated tail truncation. Avoid noisy logs for files actively being written.

--- a/src/__tests__/claude.scanner.test.ts
+++ b/src/__tests__/claude.scanner.test.ts
@@ -15,7 +15,8 @@ function writeSessionFile(
   homeDir: string,
   projectDirName: string,
   filename: string,
-  lines: Array<Record<string, unknown> | string>
+  lines: Array<Record<string, unknown> | string>,
+  options: { trailingNewline?: boolean } = {}
 ): string {
   const projectDir = join(homeDir, '.claude', 'projects', projectDirName);
   mkdirSync(projectDir, { recursive: true });
@@ -23,7 +24,7 @@ function writeSessionFile(
   const contents = lines
     .map((line) => (typeof line === 'string' ? line : JSON.stringify(line)))
     .join('\n');
-  writeFileSync(filePath, `${contents}\n`);
+  writeFileSync(filePath, options.trailingNewline === false ? contents : `${contents}\n`);
   return filePath;
 }
 
@@ -94,6 +95,18 @@ describe('Claude Scanner', () => {
         message: { role: 'user', content: 'This file is broken' },
       },
       '{"type":"assistant", invalid json',
+      {
+        type: 'assistant',
+        uuid: 'assistant-after-bad-line',
+        sessionId: 'broken-session',
+        cwd: '/tmp/broken-project',
+        timestamp: '2026-04-13T11:00:01.000Z',
+        message: {
+          role: 'assistant',
+          model: 'claude-3-5-sonnet-20241022',
+          content: [{ type: 'text', text: 'Line after corruption' }],
+        },
+      },
     ]);
 
     const result = runScannerScript(homeDir, `
@@ -124,6 +137,18 @@ describe('Claude Scanner', () => {
         message: { role: 'user', content: 'Broken on first scan' },
       },
       '{"type":"assistant", invalid json',
+      {
+        type: 'assistant',
+        uuid: 'assistant-after-bad-line',
+        sessionId: 'repair-session',
+        cwd: '/tmp/repair-project',
+        timestamp: '2026-04-13T11:10:01.000Z',
+        message: {
+          role: 'assistant',
+          model: 'claude-3-5-sonnet-20241022',
+          content: [{ type: 'text', text: 'Line after corruption' }],
+        },
+      },
     ]);
 
     const result = runScannerScript(homeDir, `
@@ -229,6 +254,43 @@ describe('Claude Scanner', () => {
       hasToolCalls: true,
       toolCalls: ['Read'],
       toolCount: 1,
+    });
+  });
+
+  test('does not cache a final-line truncation as a Claude parse failure', () => {
+    const homeDir = createTempHome();
+
+    writeSessionFile(homeDir, '-tmp-truncated-project', 'truncated-session.jsonl', [
+      {
+        type: 'user',
+        uuid: 'user-1',
+        sessionId: 'truncated-session',
+        cwd: '/tmp/truncated-project',
+        timestamp: '2026-04-13T11:30:00.000Z',
+        userType: 'external',
+        message: { role: 'user', content: 'Visible despite truncated tail' },
+      },
+      '{"type":"assistant","message":{"content":',
+    ], { trailingNewline: false });
+
+    const result = runScannerScriptDetailed(homeDir, `
+      const { clearSessionCache, getAllSessionsWithFailures } = await import('./src/adapters/claude/scanner.ts');
+      clearSessionCache();
+      const first = await getAllSessionsWithFailures();
+      const second = await getAllSessionsWithFailures();
+      console.log(JSON.stringify({
+        firstSessions: first.sessions.map((session) => session.sessionId),
+        firstFailures: first.failures.map((failure) => failure.filePath),
+        secondSessions: second.sessions.map((session) => session.sessionId),
+        secondFailures: second.failures.map((failure) => failure.filePath),
+      }));
+    `).data;
+
+    expect(result).toEqual({
+      firstSessions: ['truncated-session'],
+      firstFailures: [],
+      secondSessions: ['truncated-session'],
+      secondFailures: [],
     });
   });
 
@@ -354,6 +416,18 @@ describe('Claude Scanner', () => {
         message: { role: 'user', content: 'broken file should be persisted' },
       },
       '{"type":"assistant", invalid json',
+      {
+        type: 'assistant',
+        uuid: 'assistant-after-bad-line',
+        sessionId: 'persist-broken',
+        cwd: '/tmp/persist-broken',
+        timestamp: '2026-04-13T12:00:01.000Z',
+        message: {
+          role: 'assistant',
+          model: 'claude-3-5-sonnet-20241022',
+          content: [{ type: 'text', text: 'Line after corruption' }],
+        },
+      },
     ]);
 
     const firstRun = runScannerScriptDetailed(homeDir, `
@@ -388,6 +462,18 @@ describe('Claude Scanner', () => {
         message: { role: 'user', content: 'broken file should still report errors' },
       },
       '{"type":"assistant", invalid json',
+      {
+        type: 'assistant',
+        uuid: 'assistant-after-bad-line',
+        sessionId: 'persist-error',
+        cwd: '/tmp/persist-runtime-error',
+        timestamp: '2026-04-13T12:05:01.000Z',
+        message: {
+          role: 'assistant',
+          model: 'claude-3-5-sonnet-20241022',
+          content: [{ type: 'text', text: 'Line after corruption' }],
+        },
+      },
     ]);
 
     const firstRun = runScannerScript(homeDir, `
@@ -428,6 +514,18 @@ describe('Claude Scanner', () => {
           message: { role: 'user', content: 'broken file' },
         },
         '{"type":"assistant", invalid json',
+        {
+          type: 'assistant',
+          uuid: `assistant-after-bad-line-${i}`,
+          sessionId: `broken-${i}`,
+          cwd: '/tmp/many-broken',
+          timestamp: '2026-04-13T12:10:01.000Z',
+          message: {
+            role: 'assistant',
+            model: 'claude-3-5-sonnet-20241022',
+            content: [{ type: 'text', text: 'Line after corruption' }],
+          },
+        },
       ]);
     }
 

--- a/src/__tests__/codex.parser.test.ts
+++ b/src/__tests__/codex.parser.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { ParseError } from '../lib/errors.js';
 import {
   parseCodexSessionFile,
   scopeCodexSessionId,
@@ -10,14 +11,17 @@ import {
 
 const tempDirs: string[] = [];
 
-function createCodexJsonlFile(lines: Array<Record<string, unknown> | string>): string {
+function createCodexJsonlFile(
+  lines: Array<Record<string, unknown> | string>,
+  options: { trailingNewline?: boolean } = {}
+): string {
   const dir = mkdtempSync(join(tmpdir(), 'keepline-jsonl-'));
   tempDirs.push(dir);
   const filePath = join(dir, 'rollout-019ed4a3-2186-7e51-9aa1-ca1e376549b8.jsonl');
   const contents = lines
     .map((line) => (typeof line === 'string' ? line : JSON.stringify(line)))
     .join('\n');
-  writeFileSync(filePath, `${contents}\n`);
+  writeFileSync(filePath, options.trailingNewline === false ? contents : `${contents}\n`);
   return filePath;
 }
 
@@ -30,7 +34,8 @@ function createTempHome(): string {
 function writeCodexSessionFile(
   homeDir: string,
   rawSessionId: string,
-  lines: Array<Record<string, unknown> | string>
+  lines: Array<Record<string, unknown> | string>,
+  options: { trailingNewline?: boolean } = {}
 ): string {
   const sessionDir = join(homeDir, '.codex', 'sessions', '2026', '06', '23');
   mkdirSync(sessionDir, { recursive: true });
@@ -38,7 +43,7 @@ function writeCodexSessionFile(
   const contents = lines
     .map((line) => (typeof line === 'string' ? line : JSON.stringify(line)))
     .join('\n');
-  writeFileSync(filePath, `${contents}\n`);
+  writeFileSync(filePath, options.trailingNewline === false ? contents : `${contents}\n`);
   return filePath;
 }
 
@@ -143,6 +148,60 @@ describe('Codex JSONL parser', () => {
       },
     ]);
   });
+
+  test('skips a truncated final JSONL line while preserving parsed session data', async () => {
+    const filePath = createCodexJsonlFile([
+      {
+        type: 'session_meta',
+        timestamp: '2026-06-17T01:00:00.000Z',
+        payload: {
+          id: '019ed4a3-2186-7e51-9aa1-ca1e376549b8',
+          cwd: '/tmp/codex-project',
+        },
+      },
+      {
+        type: 'response_item',
+        timestamp: '2026-06-17T01:00:03.000Z',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'Recover Codex tail' }],
+        },
+      },
+      '{"type":"response_item","payload":{"type":"message"',
+    ], { trailingNewline: false });
+
+    const parsed = await parseCodexSessionFile(filePath);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed!.rawSessionId).toBe('019ed4a3-2186-7e51-9aa1-ca1e376549b8');
+    expect(parsed!.firstMessage).toBe('Recover Codex tail');
+  });
+
+  test('throws ParseError for non-final invalid JSONL', async () => {
+    const filePath = createCodexJsonlFile([
+      {
+        type: 'session_meta',
+        timestamp: '2026-06-17T01:00:00.000Z',
+        payload: {
+          id: '019ed4a3-2186-7e51-9aa1-ca1e376549b8',
+          cwd: '/tmp/codex-project',
+        },
+      },
+      '{"type":"response_item", invalid json',
+      {
+        type: 'response_item',
+        timestamp: '2026-06-17T01:00:03.000Z',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'This should not mask corruption' }],
+        },
+      },
+    ]);
+
+    await expect(parseCodexSessionFile(filePath)).rejects.toBeInstanceOf(ParseError);
+  });
 });
 
 describe('Codex scanner', () => {
@@ -160,6 +219,15 @@ describe('Codex scanner', () => {
         },
       },
       '{"type":"response_item", invalid json',
+      {
+        type: 'response_item',
+        timestamp: '2026-06-23T01:00:02.000Z',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'Line after corruption' }],
+        },
+      },
     ]);
     writeCodexSessionFile(homeDir, healthyId, [
       {
@@ -199,6 +267,51 @@ describe('Codex scanner', () => {
       firstFailures: [brokenPath],
       secondSessions: [healthyId],
       secondFailures: [brokenPath],
+    });
+  });
+
+  test('does not cache a final-line truncation as a Codex parse failure', () => {
+    const homeDir = createTempHome();
+    const truncatedId = '019ed4a3-2186-7e51-9aa1-ca1e376549b8';
+    writeCodexSessionFile(homeDir, truncatedId, [
+      {
+        type: 'session_meta',
+        timestamp: '2026-06-23T01:00:00.000Z',
+        payload: {
+          id: truncatedId,
+          cwd: '/tmp/truncated-codex',
+        },
+      },
+      {
+        type: 'response_item',
+        timestamp: '2026-06-23T01:00:01.000Z',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'Visible despite truncation' }],
+        },
+      },
+      '{"type":"response_item","payload":{"type":"message"',
+    ], { trailingNewline: false });
+
+    const result = runCodexScannerScript(homeDir, `
+      const { clearCodexSessionCache, getAllCodexSessionsWithFailures } = await import('./src/adapters/codex/scanner.ts');
+      clearCodexSessionCache();
+      const first = await getAllCodexSessionsWithFailures();
+      const second = await getAllCodexSessionsWithFailures();
+      console.log(JSON.stringify({
+        firstSessions: first.sessions.map((session) => session.rawSessionId),
+        firstFailures: first.failures.map((failure) => failure.filePath),
+        secondSessions: second.sessions.map((session) => session.rawSessionId),
+        secondFailures: second.failures.map((failure) => failure.filePath),
+      }));
+    `);
+
+    expect(result).toEqual({
+      firstSessions: [truncatedId],
+      firstFailures: [],
+      secondSessions: [truncatedId],
+      secondFailures: [],
     });
   });
 });

--- a/src/__tests__/codex.scanner.test.ts
+++ b/src/__tests__/codex.scanner.test.ts
@@ -65,7 +65,20 @@ describe('Codex session scanner', () => {
     const sessionsDir = join(tempDir, 'sessions');
     mkdirSync(sessionsDir);
     const invalidFile = join(sessionsDir, 'rollout-12345678-1234-1234-1234-123456789abc.jsonl');
-    writeFileSync(invalidFile, '{not-json}\n');
+    writeFileSync(
+      invalidFile,
+      [
+        '{not-json}',
+        JSON.stringify({
+          type: 'session_meta',
+          timestamp: '2026-06-23T01:00:00.000Z',
+          payload: {
+            id: '12345678-1234-1234-1234-123456789abc',
+            cwd: '/tmp/broken-codex',
+          },
+        }),
+      ].join('\n') + '\n'
+    );
 
     const sessions = await getAllCodexSessions({ sessionsDir });
 

--- a/src/__tests__/jsonl.parser.test.ts
+++ b/src/__tests__/jsonl.parser.test.ts
@@ -14,14 +14,17 @@ import { parseSessionFile } from '../adapters/claude/parser/jsonl.js';
 
 const tempDirs: string[] = [];
 
-function createJsonlFile(lines: Array<Record<string, unknown> | string>): string {
+function createJsonlFile(
+  lines: Array<Record<string, unknown> | string>,
+  options: { trailingNewline?: boolean } = {}
+): string {
   const dir = mkdtempSync(join(tmpdir(), 'keepline-jsonl-'));
   tempDirs.push(dir);
   const filePath = join(dir, 'session.jsonl');
   const contents = lines
     .map((line) => (typeof line === 'string' ? line : JSON.stringify(line)))
     .join('\n');
-  writeFileSync(filePath, `${contents}\n`);
+  writeFileSync(filePath, options.trailingNewline === false ? contents : `${contents}\n`);
   return filePath;
 }
 
@@ -225,7 +228,31 @@ describe('JSONL Session Parser', () => {
     expect(parsed!.lastActiveAt.toISOString()).toBe('2026-04-13T10:00:05.000Z');
   });
 
-  test('throws ParseError with file path and line number for invalid JSONL', async () => {
+  test('skips a truncated final JSONL line while preserving parsed session data', async () => {
+    const filePath = createJsonlFile([
+      {
+        type: 'user',
+        uuid: 'user-1',
+        sessionId: 'session-truncated-tail',
+        cwd: '/tmp/project',
+        timestamp: '2026-04-13T12:00:00.000Z',
+        userType: 'external',
+        message: {
+          role: 'user',
+          content: 'Recover me despite a truncated tail',
+        },
+      },
+      '{"type":"assistant","message":{"content":',
+    ], { trailingNewline: false });
+
+    const parsed = await parseSessionFile(filePath);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed!.sessionId).toBe('session-truncated-tail');
+    expect(parsed!.firstMessage).toBe('Recover me despite a truncated tail');
+  });
+
+  test('throws ParseError with file path and line number for non-final invalid JSONL', async () => {
     const filePath = createJsonlFile([
       {
         type: 'user',
@@ -240,6 +267,18 @@ describe('JSONL Session Parser', () => {
         },
       },
       '{"type":"assistant", bad json',
+      {
+        type: 'assistant',
+        uuid: 'assistant-after-bad-line',
+        sessionId: 'session-1',
+        cwd: '/tmp/project',
+        timestamp: '2026-04-13T12:00:01.000Z',
+        message: {
+          role: 'assistant',
+          model: 'claude-3-5-sonnet-20241022',
+          content: [{ type: 'text', text: 'This line must not hide the prior corruption' }],
+        },
+      },
     ]);
 
     try {

--- a/src/adapters/claude/parser/jsonl.ts
+++ b/src/adapters/claude/parser/jsonl.ts
@@ -62,12 +62,20 @@ interface AssistantBlockSummary {
 }
 
 /** Parse a single JSONL line */
-function parseLine(line: string, lineNumber: number, filePath: string): ClaudeEntryWithAgent | null {
+function parseLine(
+  line: string,
+  lineNumber: number,
+  filePath: string,
+  allowTruncatedTail = false
+): ClaudeEntryWithAgent | null {
   if (!line.trim()) return null;
 
   try {
     return JSON.parse(line) as ClaudeEntryWithAgent;
   } catch {
+    if (allowTruncatedTail) {
+      return null;
+    }
     throw new ParseError(filePath, lineNumber);
   }
 }
@@ -467,6 +475,7 @@ export async function parseSessionFile(
 ): Promise<ParsedSessionData | null> {
   let lineNumber = 0;
   let accumulator: SessionSummaryAccumulator | null = null;
+  let pendingLine: { line: string; lineNumber: number } | null = null;
 
   const fileStream = createReadStream(filePath);
   const rl = createInterface({
@@ -474,29 +483,41 @@ export async function parseSessionFile(
     crlfDelay: Infinity,
   });
 
-  for await (const line of rl) {
-    lineNumber++;
-    const entry = parseLine(line, lineNumber, filePath);
+  const processLine = (line: string, currentLineNumber: number, isLastLine: boolean): void => {
+    const entry = parseLine(line, currentLineNumber, filePath, isLastLine);
     if (
       !entry ||
       isFileHistorySnapshot(entry) ||
       isBootstrapOnlyEntry(entry) ||
       !entry.timestamp
     ) {
-      continue;
+      return;
     }
 
     if (!accumulator) {
       if (!entry.cwd) {
-        continue;
+        return;
       }
       accumulator = createSessionAccumulator(entry, options);
       if (!accumulator) {
-        return null;
+        return;
       }
     }
 
     accumulateSessionEntry(accumulator, entry);
+  };
+
+  for await (const line of rl) {
+    if (pendingLine) {
+      processLine(pendingLine.line, pendingLine.lineNumber, false);
+    }
+
+    lineNumber++;
+    pendingLine = { line, lineNumber };
+  }
+
+  if (pendingLine) {
+    processLine(pendingLine.line, pendingLine.lineNumber, true);
   }
 
   return accumulator ? finalizeSessionAccumulator(accumulator) : null;

--- a/src/adapters/codex/parser.ts
+++ b/src/adapters/codex/parser.ts
@@ -79,6 +79,24 @@ function parseFunctionArguments(argumentsValue: unknown): Record<string, unknown
   return undefined;
 }
 
+function parseCodexLine(
+  line: string,
+  lineNumber: number,
+  filePath: string,
+  allowTruncatedTail = false
+): CodexJsonlEntry | null {
+  if (!line.trim()) return null;
+
+  try {
+    return JSON.parse(line) as CodexJsonlEntry;
+  } catch {
+    if (allowTruncatedTail) {
+      return null;
+    }
+    throw new ParseError(filePath, lineNumber);
+  }
+}
+
 function extractCodexCurrentFile(toolInput: Record<string, unknown> | undefined): string | undefined {
   if (!toolInput) return undefined;
 
@@ -195,31 +213,38 @@ export async function parseCodexSessionFile(
   let lineNumber = 0;
   let accumulator: CodexAccumulator | null = null;
   const includeToolCalls = options.includeToolCalls ?? true;
+  let pendingLine: { line: string; lineNumber: number } | null = null;
 
-  for await (const line of rl) {
-    lineNumber++;
-    if (!line.trim()) continue;
-
-    let entry: CodexJsonlEntry;
-    try {
-      entry = JSON.parse(line) as CodexJsonlEntry;
-    } catch {
-      throw new ParseError(filePath, lineNumber);
-    }
+  const processLine = (line: string, currentLineNumber: number, isLastLine: boolean): void => {
+    const entry = parseCodexLine(line, currentLineNumber, filePath, isLastLine);
+    if (!entry) return;
 
     if (!accumulator) {
       accumulator = createAccumulator(entry, includeToolCalls);
       if (accumulator) {
-        continue;
+        return;
       }
     }
 
-    if (!accumulator) continue;
+    if (!accumulator) return;
     if (entry.type === 'response_item') {
       accumulateResponseItem(accumulator, entry);
     } else {
       updateTimestamp(accumulator, entry.timestamp);
     }
+  };
+
+  for await (const line of rl) {
+    if (pendingLine) {
+      processLine(pendingLine.line, pendingLine.lineNumber, false);
+    }
+
+    lineNumber++;
+    pendingLine = { line, lineNumber };
+  }
+
+  if (pendingLine) {
+    processLine(pendingLine.line, pendingLine.lineNumber, true);
   }
 
   return accumulator ? finalizeAccumulator(accumulator) : null;


### PR DESCRIPTION
## Summary

- Fixes #76
- Add GH76 SpecRail product/tech/tasks packet
- Let Claude and Codex JSONL parsers skip only malformed final-line tail records
- Preserve `ParseError` behavior for non-final corrupt JSONL lines
- Add parser and scanner/cache regression coverage for truncated tails and middle-line corruption

## Verification

- `bun test src/__tests__/jsonl.parser.test.ts src/__tests__/codex.parser.test.ts src/__tests__/claude.scanner.test.ts src/__tests__/codex.scanner.test.ts`
- `bun run typecheck`
- `bun test`
- `bun run build`