### PR TITLE
fix: preserve completed sessions during sync

### DIFF
--- a/specs/GH77/product.md
+++ b/specs/GH77/product.md
@@ -1,0 +1,32 @@
+# Completed Session Sync Preservation Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/77
+
+## Summary
+
+When a user marks a session completed, later sync cycles must preserve that explicit completed state. File rescans can refresh metadata, but they must not turn a user-completed session back into `lost`, `idle`, `waiting`, or `running`.
+
+## User Problem
+
+Users mark sessions completed to remove them from active recovery/attention workflows. If the next JSONL sync recomputes status from process state and overwrites `completed`, the dashboard shows completed work as lost or idle again.
+
+## Product Behavior
+
+1. A persisted `completed` session remains `completed` during later syncs.
+2. `completedAt` is not overwritten by scanner metadata.
+3. Sync may still refresh non-authoritative metadata such as title, message counts, tool info, and usage.
+4. Non-completed sessions keep existing behavior: no process still becomes `lost`; live process can become `running`, `waiting`, or `idle`.
+
+## Non-Goals
+
+- Do not infer completed from tools or transcript text.
+- Do not change the explicit `completeSession` API behavior.
+- Do not change retention cleanup semantics.
+
+## Acceptance Criteria
+
+1. Existing completed session plus no process plus scanned JSONL remains completed after sync.
+2. `completedAt` remains the original explicit completion timestamp.
+3. Existing non-completed session can still become lost when no process exists.
+4. Focused sync regression test covers the completed preservation path.
+5. Verification commands pass: focused sync test, `bun run typecheck`, `bun test`, `bun run build`.

--- a/specs/GH77/tasks.md
+++ b/specs/GH77/tasks.md
@@ -1,0 +1,18 @@
+# Completed Session Sync Preservation Tasks
+
+Issue: https://github.com/majiayu000/keepline/issues/77
+
+## Tasks
+
+- [x] Confirm root cause in existing-session sync branch.
+- [x] Add GH77 product and tech specs.
+- [x] Preserve existing `completed` status during sync.
+- [x] Add subprocess-backed sync regression test.
+- [x] Run focused sync test.
+- [x] Run `bun run typecheck`.
+- [x] Run `bun test`.
+- [x] Run `bun run build`.
+
+## Completion Mode
+
+Final implementation PR should use `Fixes #77` only after all acceptance criteria pass. Partial follow-up slices should use `Refs #77`.

--- a/specs/GH77/tech.md
+++ b/specs/GH77/tech.md
@@ -1,0 +1,35 @@
+# Completed Session Sync Preservation Tech Spec
+
+Product spec: specs/GH77/product.md
+
+Issue: https://github.com/majiayu000/keepline/issues/77
+
+## Current Root Cause
+
+`src/services/session.service.ts` computes `detectSessionStatus(process || null, agentSession.lastActiveAt)` for every scanned session. In the existing-session branch, that detected status is passed directly into `repository.upsert`. `detectSessionStatus` never returns `completed`, so a user-completed session is overwritten on the next scan.
+
+The later dead-process loop already excludes completed sessions via `findActiveLightweight()`, but the primary scanned-session update path does not.
+
+## Implementation Plan
+
+- In the existing-session branch, compute:
+
+  ```ts
+  const nextStatus = existing.status === 'completed' ? 'completed' : detectedStatus;
+  ```
+
+- Use `nextStatus` for `wasLost` and `repository.upsert`.
+- Do not pass `completedAt` during sync; repository `COALESCE` keeps the original value.
+- Keep metadata refresh behavior unchanged.
+
+## Tests
+
+Add a subprocess-backed sync test that:
+
+1. Uses temporary `HOME` and `KEEPLINE_HOME`.
+2. Writes a real Claude project JSONL file inside `.claude/projects`.
+3. Inserts a matching DB session with `status: 'completed'`, `completedAt`, and a stale pid.
+4. Runs `sessionService.syncSessions({ fullSync: true })`.
+5. Asserts status remains `completed`, `completedAt` is unchanged, and `lost` count remains `0`.
+
+This tests the real scanner, process matcher, service, and repository path without weakening production code.

--- a/src/__tests__/session.service-sync.test.ts
+++ b/src/__tests__/session.service-sync.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const tempDirs: string[] = [];
+
+function createTempHome(): string {
+  const homeDir = mkdtempSync(join(tmpdir(), 'keepline-sync-home-'));
+  tempDirs.push(homeDir);
+  return homeDir;
+}
+
+function writeClaudeSessionFile(homeDir: string, sessionId: string): void {
+  const projectDir = join(homeDir, '.claude', 'projects', '-tmp-completed-sync');
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(
+    join(projectDir, `${sessionId}.jsonl`),
+    JSON.stringify({
+      type: 'user',
+      uuid: 'user-1',
+      sessionId,
+      cwd: '/tmp/completed-sync',
+      timestamp: '2026-04-13T16:05:00.000Z',
+      userType: 'external',
+      message: {
+        role: 'user',
+        content: 'Completed sync regression',
+      },
+    }) + '\n'
+  );
+}
+
+function runSyncScript(homeDir: string, script: string): Record<string, unknown> {
+  const proc = Bun.spawnSync({
+    cmd: [process.execPath, '--eval', script],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      KEEPLINE_HOME: join(homeDir, '.keepline'),
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  if (proc.exitCode !== 0) {
+    throw new Error(proc.stderr.toString() || `sync subprocess failed with code ${proc.exitCode}`);
+  }
+
+  const jsonLine = proc.stdout.toString().trim().split('\n').filter(Boolean).pop();
+  if (!jsonLine) {
+    throw new Error('sync subprocess produced no JSON output');
+  }
+  return JSON.parse(jsonLine) as Record<string, unknown>;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe('SessionService sync', () => {
+  test('preserves user-completed sessions during later file syncs', () => {
+    const homeDir = createTempHome();
+    const sessionId = 'completed-sync-1';
+    writeClaudeSessionFile(homeDir, sessionId);
+
+    const result = runSyncScript(homeDir, `
+      const { resetDatabase } = await import('./src/db/migrations.ts');
+      const { closeDatabase } = await import('./src/infrastructure/database/sqlite.ts');
+      const { sessionRepository } = await import('./src/infrastructure/database/repositories/session.repository.ts');
+      const { sessionService } = await import('./src/services/session.service.ts');
+
+      resetDatabase();
+      const completedAt = new Date('2026-04-13T16:00:00.000Z');
+      sessionRepository.upsert({
+        sessionId: ${JSON.stringify(sessionId)},
+        client: 'claude',
+        directory: '/tmp/completed-sync',
+        status: 'completed',
+        title: 'Completed task',
+        initialPrompt: 'Completed sync regression',
+        startedAt: new Date('2026-04-13T15:55:00.000Z'),
+        lastActiveAt: completedAt,
+        completedAt,
+        pid: 999999,
+        toolCount: 0,
+        messageCount: 1,
+      });
+
+      const syncResult = await sessionService.syncSessions({ fullSync: true });
+      const fetched = sessionRepository.findBySessionId(${JSON.stringify(sessionId)});
+      console.log(JSON.stringify({
+        syncResult,
+        status: fetched?.status,
+        completedAt: fetched?.completedAt?.toISOString(),
+        lastActiveAt: fetched?.lastActiveAt.toISOString(),
+        pid: fetched?.pid ?? null,
+      }));
+      closeDatabase();
+    `);
+
+    expect(result).toEqual({
+      syncResult: { discovered: 0, updated: 1, lost: 0 },
+      status: 'completed',
+      completedAt: '2026-04-13T16:00:00.000Z',
+      lastActiveAt: '2026-04-13T16:05:00.000Z',
+      pid: null,
+    });
+  });
+});

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -203,8 +203,9 @@ export class SessionService {
         );
 
         if (existing) {
+          const nextStatus = existing.status === 'completed' ? 'completed' : status;
           // Update existing session
-          const wasLost = existing.status !== 'lost' && status === 'lost';
+          const wasLost = existing.status !== 'lost' && nextStatus === 'lost';
 
           // Update title if current one is Unknown and we have new info
           const shouldUpdateTitle =
@@ -215,7 +216,7 @@ export class SessionService {
           const updatedSession = this.repository.upsert({
             sessionId: agentSession.sessionId,
             client,
-            status,
+            status: nextStatus,
             ...(shouldUpdateTitle && {
               title: generateTitle(agentSession.firstMessage!),
               initialPrompt: agentSession.firstMessage,


### PR DESCRIPTION
## Summary

- Fixes #77
- Add GH77 SpecRail product/tech/tasks packet
- Preserve existing user-completed session status during later file syncs
- Add subprocess-backed regression coverage for the real scanner + repository + service path

## Verification

- `bun test src/__tests__/session.service-sync.test.ts`
- `bun run typecheck`
- `bun test`
- `bun run build`