### PR TITLE
fix: include usage stats in basic sessions

### DIFF
--- a/specs/GH78/product.md
+++ b/specs/GH78/product.md
@@ -1,0 +1,36 @@
+# High-Cost Notification Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/78
+
+## Summary
+
+Keepline's high-cost notification must fire when a session crosses the user's configured cost threshold. The session list and realtime dashboard paths currently use the basic session payload, so that payload must preserve persisted usage data required by notifications.
+
+## User Problem
+
+Users can enable "High Cost Warning" and set a dollar threshold, but the notification never fires because the list and WebSocket payloads omit `usageStats`. A session can exceed the configured threshold while the dashboard keeps seeing `session.usageStats === undefined`.
+
+## Product Behavior
+
+1. Basic session responses include persisted `usageStats` when the database has token or cost data.
+2. Basic session responses continue to omit heavy transcript/detail fields such as `initialPrompt`, `lastMessage`, tool input, and current file.
+3. WebSocket session updates consider usage changes as meaningful changes so cost-only updates are broadcast.
+4. The client session version signature considers usage changes so notification checks run when cost changes.
+5. High-cost notifications fire once when a session cost crosses from below the configured threshold to at or above that threshold.
+6. Missing usage data remains missing; Keepline must not infer or fabricate costs.
+
+## Non-Goals
+
+- Do not fetch full session details only to power high-cost notifications.
+- Do not change pricing extraction or cost calculation.
+- Do not add a new notification settings UI.
+- Do not emit repeated high-cost notifications while the session remains above the same threshold.
+
+## Acceptance Criteria
+
+1. `GET /api/sessions?fields=basic` returns `usageStats` for sessions with persisted usage data.
+2. Basic serialization still excludes heavy session detail fields.
+3. Realtime dashboard updates broadcast when persisted usage cost or token totals change.
+4. Client session versioning changes when usage cost or token totals change.
+5. A regression test with a mocked high-cost session proves the high-cost notification event is produced when the cost crosses the threshold.
+6. Verification passes: focused tests, `bun run typecheck`, `bun test`, and `bun run build`.

--- a/specs/GH78/tasks.md
+++ b/specs/GH78/tasks.md
@@ -1,0 +1,96 @@
+# High-Cost Notification Task Plan
+
+Issue: https://github.com/majiayu000/keepline/issues/78
+
+## Tasks
+
+### SP78-T1: Add SpecRail artifacts
+
+Done when:
+
+- `specs/GH78/product.md` exists.
+- `specs/GH78/tech.md` exists.
+- `specs/GH78/tasks.md` exists.
+
+Verify:
+
+```sh
+test -f specs/GH78/product.md
+test -f specs/GH78/tech.md
+test -f specs/GH78/tasks.md
+```
+
+### SP78-T2: Preserve usage data in lightweight backend sessions
+
+Writable files:
+
+- `src/domain/session/entity.ts`
+- `src/infrastructure/database/repositories/session.repository.ts`
+- `src/web/api/session-response.ts`
+
+Done when:
+
+- Lightweight repository rows include persisted usage columns.
+- `SessionListItem` can carry `usageStats`.
+- `serializeBasicSession()` emits `usageStats` when available and still omits heavy fields.
+
+Verify:
+
+```sh
+bun test src/__tests__/session-response.test.ts src/__tests__/sessions.route-basic.test.ts
+```
+
+### SP78-T3: Make realtime and client versioning cost-aware
+
+Writable files:
+
+- `src/web/api/server.ts`
+- `src/web/client/src/hooks/useSessions.ts`
+
+Done when:
+
+- Realtime broadcast state changes when usage cost or token totals change.
+- Client session version signature changes when usage cost or token totals change.
+
+Verify:
+
+```sh
+bun run typecheck
+```
+
+### SP78-T4: Add high-cost notification regression
+
+Writable files:
+
+- `src/web/client/src/hooks/useNotifications.ts`
+- `src/__tests__/use-notifications.test.ts`
+
+Done when:
+
+- A mocked previous/new session pair crossing the threshold produces one high-cost notification event.
+- A session already above the threshold does not produce another crossing event.
+
+Verify:
+
+```sh
+bun test src/__tests__/use-notifications.test.ts
+```
+
+### SP78-T5: Full local verification and PR
+
+Done when:
+
+- Focused tests pass.
+- Typecheck passes.
+- Full test suite passes.
+- Build passes.
+- PR links and closes #78.
+
+Verify:
+
+```sh
+bun test src/__tests__/session-response.test.ts src/__tests__/sessions.route-basic.test.ts src/__tests__/use-notifications.test.ts
+bun run typecheck
+bun test
+bun run build
+```

--- a/specs/GH78/tech.md
+++ b/specs/GH78/tech.md
@@ -1,0 +1,60 @@
+# High-Cost Notification Tech Spec
+
+Product spec: `specs/GH78/product.md`
+
+Issue: https://github.com/majiayu000/keepline/issues/78
+
+## Context
+
+- `src/web/client/src/hooks/useNotifications.ts` only evaluates the high-cost branch when `session.usageStats` exists.
+- `src/web/client/src/hooks/useSessions.ts` fetches `api.fetchSessions('basic', ...)` for the dashboard list and notification snapshots.
+- `src/web/api/server.ts` broadcasts `serializeBasicSessions(...)` over WebSocket.
+- `src/web/api/session-response.ts` currently strips `usageStats` from the basic payload.
+- `SessionRepository.findAllLightweight()` currently avoids heavy fields but also omits persisted usage columns.
+
+## Design
+
+Keep the basic payload lightweight, but include already-persisted usage columns:
+
+```ts
+usageStats?: {
+  totalInputTokens: number
+  totalOutputTokens: number
+  totalTokens: number
+  totalCost: number
+  apiCalls: number
+}
+```
+
+The database lightweight query should select `total_input_tokens`, `total_output_tokens`, `total_tokens`, `total_cost`, and `api_calls`. Mapping should match the full session mapper: return `usageStats` only when usage exists and use zero defaults for nullable parts.
+
+`serializeBasicSession()` should include `usageStats` without adding heavy detail fields.
+
+Realtime change detection should include stable usage fields in its state signature:
+
+- `totalCost`
+- `totalTokens`
+- `apiCalls`
+
+The client session version signature should include cost and token totals so `App` re-runs `checkSessionChanges` for cost-only changes.
+
+For a focused notification regression, expose a small pure helper that derives notification events from previous and next sessions. The hook can call that helper and forward events to `notify()`.
+
+## Failure Behavior
+
+- Missing usage columns must serialize as no `usageStats`, not zero-cost guessed data.
+- Cost updates must not require full session fetches.
+- Notification derivation must not throw when a previous session lacks `usageStats`.
+
+## Verification Plan
+
+- `bun test src/__tests__/session-response.test.ts src/__tests__/sessions.route-basic.test.ts src/__tests__/use-notifications.test.ts`
+- `bun run typecheck`
+- `bun test`
+- `bun run build`
+
+## Rollback
+
+- Remove usage fields from the lightweight query and basic serializer.
+- Remove the client usage fields from the version signature and realtime state signature.
+- Remove the notification helper test.

--- a/src/__tests__/session-response.test.ts
+++ b/src/__tests__/session-response.test.ts
@@ -3,7 +3,7 @@ import { generateTitle } from '../domain/session/entity.js';
 import { serializeBasicSession } from '../web/api/session-response.js';
 
 describe('Session Response Serialization', () => {
-  test('serializeBasicSession emits only lightweight list fields', () => {
+  test('serializeBasicSession emits lightweight list fields with usage stats', () => {
     const createdAt = new Date('2026-04-13T14:00:00.000Z');
     const updatedAt = new Date('2026-04-13T14:05:00.000Z');
     const startedAt = new Date('2026-04-13T13:55:00.000Z');
@@ -29,6 +29,13 @@ describe('Session Response Serialization', () => {
       tty: 'ttys001',
       toolCount: 7,
       messageCount: 3,
+      usageStats: {
+        totalInputTokens: 1200,
+        totalOutputTokens: 300,
+        totalTokens: 1500,
+        totalCost: 1.25,
+        apiCalls: 4,
+      },
       createdAt,
       updatedAt,
       processRunning: true,
@@ -55,6 +62,13 @@ describe('Session Response Serialization', () => {
       tty: 'ttys001',
       toolCount: 7,
       messageCount: 3,
+      usageStats: {
+        totalInputTokens: 1200,
+        totalOutputTokens: 300,
+        totalTokens: 1500,
+        totalCost: 1.25,
+        apiCalls: 4,
+      },
       processRunning: true,
       cpuUsage: 1.5,
       memoryUsage: 2.5,

--- a/src/__tests__/sessions.route-basic.test.ts
+++ b/src/__tests__/sessions.route-basic.test.ts
@@ -37,7 +37,7 @@ describe('Basic Sessions Route Contract', () => {
     return { root, nested };
   }
 
-  test('fields=basic returns lightweight session payloads without usageStats', async () => {
+  test('fields=basic returns lightweight session payloads with persisted usageStats', async () => {
     sessionRepository.upsert({
       sessionId: 'session-basic-1',
       directory: '/tmp/keepline-basic-contract',
@@ -52,6 +52,13 @@ describe('Basic Sessions Route Contract', () => {
       lastActiveAt: new Date('2026-04-13T10:00:05.000Z'),
       toolCount: 4,
       messageCount: 2,
+      usageStats: {
+        totalInputTokens: 1200,
+        totalOutputTokens: 300,
+        totalTokens: 1500,
+        totalCost: 1.25,
+        apiCalls: 4,
+      },
     });
 
     const { token } = await setupUser('basic-route-user', 'password123');
@@ -84,10 +91,16 @@ describe('Basic Sessions Route Contract', () => {
       toolCount: 4,
       messageCount: 2,
       processRunning: false,
+      usageStats: {
+        totalInputTokens: 1200,
+        totalOutputTokens: 300,
+        totalTokens: 1500,
+        totalCost: 1.25,
+        apiCalls: 4,
+      },
     });
     expect(session.startedAt).toBe('2026-04-13T10:00:00.000Z');
     expect(session.lastActiveAt).toBe('2026-04-13T10:00:05.000Z');
-    expect('usageStats' in session).toBe(false);
     expect('initialPrompt' in session).toBe(false);
     expect('lastMessage' in session).toBe(false);
     expect('lastTool' in session).toBe(false);

--- a/src/__tests__/use-notifications.test.ts
+++ b/src/__tests__/use-notifications.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  getSessionNotificationEvents,
+  type NotificationEventSettings,
+} from '../web/client/src/hooks/notification-events.js';
+import type { Session } from '../web/client/src/types/session.js';
+
+const settings: NotificationEventSettings = {
+  onStatusChange: true,
+  onSessionLost: true,
+  onHighCost: true,
+  costThreshold: 5,
+};
+
+function makeSession(overrides: Partial<Session>): Session {
+  return {
+    id: 'row-1',
+    sessionId: 'session-1',
+    client: 'claude',
+    runtimeId: 'claude-code',
+    directory: '/tmp/project',
+    status: 'running',
+    title: 'Expensive task',
+    initialPrompt: 'Run the task',
+    lastActiveAt: '2026-04-13T10:00:05.000Z',
+    toolCount: 1,
+    messageCount: 1,
+    createdAt: '2026-04-13T10:00:00.000Z',
+    updatedAt: '2026-04-13T10:00:05.000Z',
+    ...overrides,
+  };
+}
+
+describe('notification event derivation', () => {
+  test('emits high-cost notification when session cost crosses threshold', () => {
+    const events = getSessionNotificationEvents(
+      [makeSession({ usageStats: { totalInputTokens: 100, totalOutputTokens: 50, totalTokens: 150, totalCost: 4.99, apiCalls: 1 } })],
+      [makeSession({ usageStats: { totalInputTokens: 200, totalOutputTokens: 100, totalTokens: 300, totalCost: 5.01, apiCalls: 2 } })],
+      settings
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      title: 'High Cost Warning',
+      options: {
+        tag: 'high-cost-session-1',
+      },
+    });
+    expect(events[0].options.body).toContain('$5.00');
+    expect(events[0].options.body).toContain('$5.01');
+  });
+
+  test('does not repeat high-cost notification when previous cost was already above threshold', () => {
+    const events = getSessionNotificationEvents(
+      [makeSession({ usageStats: { totalInputTokens: 200, totalOutputTokens: 100, totalTokens: 300, totalCost: 5.01, apiCalls: 2 } })],
+      [makeSession({ usageStats: { totalInputTokens: 300, totalOutputTokens: 200, totalTokens: 500, totalCost: 6, apiCalls: 3 } })],
+      settings
+    );
+
+    expect(events).toEqual([]);
+  });
+});

--- a/src/domain/session/entity.ts
+++ b/src/domain/session/entity.ts
@@ -103,6 +103,7 @@ export type SessionListItem = Pick<
   | 'tty'
   | 'toolCount'
   | 'messageCount'
+  | 'usageStats'
   | 'createdAt'
   | 'updatedAt'
 >;

--- a/src/infrastructure/database/repositories/session.repository.ts
+++ b/src/infrastructure/database/repositories/session.repository.ts
@@ -61,6 +61,11 @@ interface SessionListRow {
   tty: string | null;
   tool_count: number;
   message_count: number;
+  total_input_tokens: number | null;
+  total_output_tokens: number | null;
+  total_tokens: number | null;
+  total_cost: number | null;
+  api_calls: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -90,6 +95,23 @@ function parseToolCalls(raw: string | null): ToolCallInfo[] | undefined {
   }
 }
 
+type UsageStatsRow = Pick<
+  SessionRow,
+  'total_input_tokens' | 'total_output_tokens' | 'total_tokens' | 'total_cost' | 'api_calls'
+>;
+
+function rowToUsageStats(row: UsageStatsRow): Session['usageStats'] {
+  return row.total_tokens != null
+    ? {
+        totalInputTokens: row.total_input_tokens ?? 0,
+        totalOutputTokens: row.total_output_tokens ?? 0,
+        totalTokens: row.total_tokens ?? 0,
+        totalCost: row.total_cost ?? 0,
+        apiCalls: row.api_calls ?? 0,
+      }
+    : undefined;
+}
+
 /** Convert database row to Session entity */
 function rowToSession(row: SessionRow): Session {
   return {
@@ -114,15 +136,7 @@ function rowToSession(row: SessionRow): Session {
     agentId: row.agent_id || undefined,
     parentSessionId: row.parent_session_id || undefined,
     isSubAgent: row.is_sub_agent === 1,
-    usageStats: row.total_tokens != null
-      ? {
-          totalInputTokens: row.total_input_tokens ?? 0,
-          totalOutputTokens: row.total_output_tokens ?? 0,
-          totalTokens: row.total_tokens ?? 0,
-          totalCost: row.total_cost ?? 0,
-          apiCalls: row.api_calls ?? 0,
-        }
-      : undefined,
+    usageStats: rowToUsageStats(row),
     toolCalls: parseToolCalls(row.tool_calls),
     createdAt: new Date(row.created_at),
     updatedAt: new Date(row.updated_at),
@@ -144,6 +158,7 @@ function rowToSessionListItem(row: SessionListRow): SessionListItem {
     tty: row.tty || undefined,
     toolCount: row.tool_count,
     messageCount: row.message_count,
+    usageStats: rowToUsageStats(row),
     createdAt: new Date(row.created_at),
     updatedAt: new Date(row.updated_at),
   };
@@ -242,6 +257,11 @@ class SessionRepository implements ISessionRepository {
           tty,
           tool_count,
           message_count,
+          total_input_tokens,
+          total_output_tokens,
+          total_tokens,
+          total_cost,
+          api_calls,
           created_at,
           updated_at
         FROM sessions

--- a/src/web/api/server.ts
+++ b/src/web/api/server.ts
@@ -157,6 +157,9 @@ async function checkAndBroadcastUpdates() {
           directory: s.directory,
           lastActiveAt: s.lastActiveAt.toISOString(),
           title: s.title,
+          usageCost: s.usageStats?.totalCost ?? null,
+          usageTokens: s.usageStats?.totalTokens ?? null,
+          usageApiCalls: s.usageStats?.apiCalls ?? null,
         }))
         .sort((a, b) => a.sessionId.localeCompare(b.sessionId)),
     });

--- a/src/web/api/session-response.ts
+++ b/src/web/api/session-response.ts
@@ -21,6 +21,7 @@ export function serializeBasicSession(session: SerializableBasicSession) {
     tty: session.tty,
     toolCount: session.toolCount,
     messageCount: session.messageCount,
+    usageStats: session.usageStats,
     processRunning: session.processRunning,
     cpuUsage: session.cpuUsage,
     memoryUsage: session.memoryUsage,

--- a/src/web/client/src/hooks/notification-events.ts
+++ b/src/web/client/src/hooks/notification-events.ts
@@ -1,0 +1,69 @@
+import type { Session } from '../types/session'
+
+export interface NotificationEventSettings {
+  onStatusChange: boolean
+  onSessionLost: boolean
+  onHighCost: boolean
+  costThreshold: number
+}
+
+export interface SessionNotificationOptions {
+  body?: string
+  tag?: string
+}
+
+export interface SessionNotificationEvent {
+  title: string
+  options: SessionNotificationOptions
+}
+
+export function getSessionNotificationEvents(
+  prevSessions: Session[],
+  newSessions: Session[],
+  settings: NotificationEventSettings
+): SessionNotificationEvent[] {
+  const events: SessionNotificationEvent[] = []
+  const prevMap = new Map(prevSessions.map((s) => [s.sessionId, s]))
+
+  for (const session of newSessions) {
+    const prev = prevMap.get(session.sessionId)
+    if (!prev) continue
+
+    if (settings.onStatusChange && prev.status !== session.status) {
+      if (settings.onSessionLost && session.status === 'lost') {
+        events.push({
+          title: 'Session Lost',
+          options: {
+            body: `Session "${session.title || session.sessionId}" has been lost`,
+            tag: `session-lost-${session.sessionId}`,
+          },
+        })
+      } else if (session.status === 'completed' && prev.status !== 'completed') {
+        events.push({
+          title: 'Session Completed',
+          options: {
+            body: `Session "${session.title || session.sessionId}" has completed`,
+            tag: `session-completed-${session.sessionId}`,
+          },
+        })
+      }
+    }
+
+    if (settings.onHighCost && session.usageStats) {
+      const prevCost = prev.usageStats?.totalCost || 0
+      const newCost = session.usageStats.totalCost || 0
+
+      if (prevCost < settings.costThreshold && newCost >= settings.costThreshold) {
+        events.push({
+          title: 'High Cost Warning',
+          options: {
+            body: `Session "${session.title || session.sessionId}" has exceeded $${settings.costThreshold.toFixed(2)} (current: $${newCost.toFixed(2)})`,
+            tag: `high-cost-${session.sessionId}`,
+          },
+        })
+      }
+    }
+  }
+
+  return events
+}

--- a/src/web/client/src/hooks/useNotifications.ts
+++ b/src/web/client/src/hooks/useNotifications.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import type { Session } from '@/types'
+import { getSessionNotificationEvents } from './notification-events'
 
 export interface NotificationSettings {
   enabled: boolean
@@ -106,47 +107,8 @@ export function useNotifications(): UseNotificationsReturn {
       return
     }
 
-    const prevMap = new Map(prevSessions.map((s) => [s.sessionId, s]))
-
-    for (const session of newSessions) {
-      const prev = prevMap.get(session.sessionId)
-
-      // New session
-      if (!prev) {
-        continue // Don't notify for new sessions
-      }
-
-      // Status changed
-      if (settings.onStatusChange && prev.status !== session.status) {
-        // Session became lost
-        if (settings.onSessionLost && session.status === 'lost') {
-          notify('Session Lost', {
-            body: `Session "${session.title || session.sessionId}" has been lost`,
-            tag: `session-lost-${session.sessionId}`,
-          })
-        }
-        // Session completed
-        else if (session.status === 'completed' && prev.status !== 'completed') {
-          notify('Session Completed', {
-            body: `Session "${session.title || session.sessionId}" has completed`,
-            tag: `session-completed-${session.sessionId}`,
-          })
-        }
-      }
-
-      // High cost warning
-      if (settings.onHighCost && session.usageStats) {
-        const prevCost = prev.usageStats?.totalCost || 0
-        const newCost = session.usageStats.totalCost || 0
-
-        // Check if cost crossed the threshold
-        if (prevCost < settings.costThreshold && newCost >= settings.costThreshold) {
-          notify('High Cost Warning', {
-            body: `Session "${session.title || session.sessionId}" has exceeded $${settings.costThreshold.toFixed(2)} (current: $${newCost.toFixed(2)})`,
-            tag: `high-cost-${session.sessionId}`,
-          })
-        }
-      }
+    for (const event of getSessionNotificationEvents(prevSessions, newSessions, settings)) {
+      notify(event.title, event.options)
     }
   }, [settings, permission, notify])
 

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -71,6 +71,9 @@ function getSessionVersionSignature(sessions: Session[]): string {
       session.completedAt || '',
       session.toolCount,
       session.messageCount,
+      session.usageStats?.totalCost ?? '',
+      session.usageStats?.totalTokens ?? '',
+      session.usageStats?.apiCalls ?? '',
       session.updatedAt,
     ].join(':'))
     .join('|')


### PR DESCRIPTION
## Summary

- Fixes #78.
- Keep persisted usage stats in lightweight/basic session rows and API serialization so high-cost notifications receive real cost data.
- Make realtime session update signatures and client version signatures cost-aware.
- Extract notification event derivation into a pure helper and cover high-cost threshold crossing with regression tests.

## SpecRail

- specs/GH78/product.md
- specs/GH78/tech.md
- specs/GH78/tasks.md

## Verification

- bun test src/__tests__/session-response.test.ts src/__tests__/sessions.route-basic.test.ts src/__tests__/use-notifications.test.ts
- bun run typecheck
- bun test
- bun run build

Note: checks/check_workflow.py is not present in this repository, so the SpecRail workflow checker is not applicable here.