### PR TITLE
fix: guard hook server requests

### DIFF
--- a/specs/GH79/product.md
+++ b/specs/GH79/product.md
@@ -1,0 +1,35 @@
+# Hook Server Request Security Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/79
+
+## Summary
+
+The local hook HTTP server must reject browser-originated or DNS-rebound requests that do not target a loopback host. Hook events and context reads are local automation surfaces, not public browser APIs.
+
+## User Problem
+
+Keepline's main web server validates local Host and browser request metadata, but the hook server accepts every Host, Origin, and browser fetch metadata value. A malicious browser page can attempt DNS-rebinding or cross-origin requests against the local hook port to forge hook events or read context data.
+
+## Product Behavior
+
+1. The hook server only accepts requests whose `Host` header names a loopback host such as `127.0.0.1`, `localhost`, or `[::1]`.
+2. Requests with a non-loopback `Host` are rejected with 403 before route handlers run.
+3. Requests with an `Origin` header must have a loopback origin.
+4. Requests with browser Fetch Metadata must be `same-origin`, `same-site`, or `none`.
+5. CLI/Claude hook requests without `Origin` or `Sec-Fetch-Site` remain supported when their Host header is loopback.
+6. The `/context` endpoint is protected by the same request gate as `/hook`, `/health`, and `/compression/stats`.
+
+## Non-Goals
+
+- Do not introduce a shared hook token in this tranche.
+- Do not change hook event payload semantics.
+- Do not make the hook server remotely accessible.
+- Do not change the configured default hook port.
+
+## Acceptance Criteria
+
+1. A `POST /hook` request with `Host: attacker.example` receives 403.
+2. A `GET /context` request with loopback Host but cross-origin `Origin` receives 403.
+3. A `GET /health` request with loopback Host remains accepted.
+4. A loopback `POST /hook` with an invalid body reaches validation and returns 400 rather than being rejected by the security gate.
+5. Focused tests, `bun run typecheck`, `bun test`, and `bun run build` pass.

--- a/specs/GH79/tasks.md
+++ b/specs/GH79/tasks.md
@@ -1,0 +1,78 @@
+# Hook Server Request Security Task Plan
+
+Issue: https://github.com/majiayu000/keepline/issues/79
+
+## Tasks
+
+### SP79-T1: Add SpecRail artifacts
+
+Done when:
+
+- `specs/GH79/product.md` exists.
+- `specs/GH79/tech.md` exists.
+- `specs/GH79/tasks.md` exists.
+
+Verify:
+
+```sh
+test -f specs/GH79/product.md
+test -f specs/GH79/tech.md
+test -f specs/GH79/tasks.md
+```
+
+### SP79-T2: Add hook request gate
+
+Writable files:
+
+- `src/adapters/hook/server.ts`
+
+Done when:
+
+- Hook server rejects non-loopback Host headers.
+- Hook server rejects non-loopback Origins when present.
+- Hook server rejects cross-site Fetch Metadata when present.
+- Loopback local automation without browser headers still works.
+
+Verify:
+
+```sh
+bun test src/__tests__/hook.server.test.ts
+```
+
+### SP79-T3: Add regression tests
+
+Writable files:
+
+- `src/__tests__/hook.server.test.ts`
+
+Done when:
+
+- Non-loopback Host on `/hook` returns 403.
+- Cross-origin `/context` returns 403.
+- Loopback `/health` returns 200.
+- Loopback invalid hook payload returns 400.
+
+Verify:
+
+```sh
+bun test src/__tests__/hook.server.test.ts
+```
+
+### SP79-T4: Full verification and PR
+
+Done when:
+
+- Focused tests pass.
+- Typecheck passes.
+- Full tests pass.
+- Build passes.
+- PR links and closes #79.
+
+Verify:
+
+```sh
+bun test src/__tests__/hook.server.test.ts
+bun run typecheck
+bun test
+bun run build
+```

--- a/specs/GH79/tech.md
+++ b/specs/GH79/tech.md
@@ -1,0 +1,51 @@
+# Hook Server Request Security Tech Spec
+
+Product spec: `specs/GH79/product.md`
+
+Issue: https://github.com/majiayu000/keepline/issues/79
+
+## Context
+
+- `src/adapters/hook/server.ts` builds a standalone Fastify server bound to `127.0.0.1`.
+- The hook server exposes `/hook`, `/context`, `/compression/stats`, and `/health`.
+- `src/web/api/request-security.ts` already exposes request security helpers:
+  - `isLoopbackHostHeader`
+  - `isLoopbackOrigin`
+  - `isAllowedFetchMetadata`
+- Fastify request headers are plain Node headers, so the hook server needs a small adapter for header lookup.
+
+## Design
+
+Add a hook-server request gate:
+
+```ts
+function isAllowedHookServerRequest(request: FastifyRequest): boolean
+```
+
+Rules:
+
+1. `Host` must pass `isLoopbackHostHeader`.
+2. If `Origin` is present, it must pass `isLoopbackOrigin`.
+3. If `Sec-Fetch-Site` is present, it must be `same-origin`, `same-site`, or `none`.
+
+Register the gate with Fastify `onRequest` before all route handlers. Reject denied requests with 403 and a generic `Forbidden` response.
+
+Extract server construction into `createHookServer()` so tests can use Fastify `inject()` without binding a real port. `startHookServer()` should continue to call the same route registration path.
+
+## Verification Plan
+
+- Add `src/__tests__/hook.server.test.ts`:
+  - rejects non-loopback Host for `/hook`
+  - rejects cross-origin `/context`
+  - accepts loopback `/health`
+  - allows loopback `/hook` to reach payload validation and return 400
+- Run:
+  - `bun test src/__tests__/hook.server.test.ts`
+  - `bun run typecheck`
+  - `bun test`
+  - `bun run build`
+
+## Rollback
+
+- Remove the Fastify `onRequest` gate and `createHookServer()` extraction.
+- Remove the focused hook server security tests.

--- a/src/__tests__/hook.server.test.ts
+++ b/src/__tests__/hook.server.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { FastifyInstance } from 'fastify';
+import { createHookServer } from '../adapters/hook/server.js';
+
+describe('hook server request security', () => {
+  let server: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+      server = null;
+    }
+  });
+
+  function app(): FastifyInstance {
+    server = createHookServer();
+    return server;
+  }
+
+  test('rejects non-loopback Host headers before hook validation', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/hook',
+      headers: {
+        host: 'attacker.example',
+        'content-type': 'application/json',
+      },
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(403);
+    const body = response.json() as { success: boolean; error: string };
+    expect(body).toEqual({ success: false, error: 'Forbidden' });
+  });
+
+  test('rejects cross-origin context reads', async () => {
+    const response = await app().inject({
+      method: 'GET',
+      url: '/context?path=/tmp/project',
+      headers: {
+        host: '127.0.0.1:7890',
+        origin: 'https://attacker.example',
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  test('accepts loopback health requests', async () => {
+    const response = await app().inject({
+      method: 'GET',
+      url: '/health',
+      headers: {
+        host: 'localhost:7890',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ status: 'ok' });
+  });
+
+  test('allows loopback hook requests to reach payload validation', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/hook',
+      headers: {
+        host: '127.0.0.1:7890',
+        'content-type': 'application/json',
+      },
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json() as { success: boolean; error: string };
+    expect(body).toEqual({
+      success: false,
+      error: 'Invalid hook event payload',
+    });
+  });
+
+  test('rejects cross-site browser fetch metadata', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/hook',
+      headers: {
+        host: '127.0.0.1:7890',
+        'sec-fetch-site': 'cross-site',
+        'content-type': 'application/json',
+      },
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+});

--- a/src/adapters/hook/server.ts
+++ b/src/adapters/hook/server.ts
@@ -4,11 +4,16 @@
  * Integrates with the compression queue for async memory processing.
  */
 
-import Fastify, { FastifyInstance } from 'fastify';
+import Fastify, { FastifyInstance, FastifyRequest } from 'fastify';
 import { logger } from '../../lib/logger.js';
 import { config } from '../../lib/config.js';
 import { emit } from '../../lib/events.js';
 import { isValidSessionId } from '../../lib/session-id.js';
+import {
+  isAllowedFetchMetadata,
+  isLoopbackHostHeader,
+  isLoopbackOrigin,
+} from '../../web/api/request-security.js';
 import { updateSession } from '../../services/session.service.js';
 import {
   getCompressionQueue,
@@ -36,6 +41,30 @@ const VALID_EVENT_TYPES: Set<HookEventType> = new Set([
 
 /** Track first prompts per session for context injection */
 const sessionFirstPrompts: Map<string, boolean> = new Map();
+
+function getHeader(request: FastifyRequest, name: string): string | undefined {
+  const value = request.headers[name.toLowerCase()];
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function isAllowedHookServerRequest(request: FastifyRequest): boolean {
+  if (!isLoopbackHostHeader(getHeader(request, 'host'))) {
+    return false;
+  }
+
+  const origin = getHeader(request, 'origin');
+  if (origin && !isLoopbackOrigin(origin)) {
+    return false;
+  }
+
+  const syntheticRequest = new Request('http://127.0.0.1/', {
+    headers: {
+      'sec-fetch-site': getHeader(request, 'sec-fetch-site') ?? '',
+    },
+  });
+  return isAllowedFetchMetadata(syntheticRequest);
+}
 
 /** Validate hook event payload */
 function isValidHookEvent(event: unknown): event is HookEvent {
@@ -193,19 +222,26 @@ async function handleHookEvent(event: HookEvent): Promise<void> {
   }
 }
 
-/** Start hook server */
-export async function startHookServer(): Promise<void> {
-  if (server) {
-    logger.warn('Hook server already running');
-    return;
-  }
+export function createHookServer(): FastifyInstance {
+  const app = Fastify({ logger: false });
 
-  const port = config.get().hookPort;
+  app.addHook('onRequest', (request, reply, done) => {
+    if (isAllowedHookServerRequest(request)) {
+      done();
+      return;
+    }
 
-  server = Fastify({ logger: false });
+    logger.warn('Rejected hook server request', {
+      host: getHeader(request, 'host') ?? '<missing>',
+      origin: getHeader(request, 'origin') ?? '<missing>',
+      secFetchSite: getHeader(request, 'sec-fetch-site') ?? '<missing>',
+      path: request.url,
+    });
+    reply.status(403).send({ success: false, error: 'Forbidden' });
+  });
 
   // Health check endpoint
-  server.get('/health', async () => {
+  app.get('/health', async () => {
     const queue = getCompressionQueue();
     return {
       status: 'ok',
@@ -217,7 +253,7 @@ export async function startHookServer(): Promise<void> {
   });
 
   // Hook event endpoint
-  server.post<{ Body: unknown }>('/hook', async (request, reply) => {
+  app.post<{ Body: unknown }>('/hook', async (request, reply) => {
     try {
       // Validate input before processing
       if (!isValidHookEvent(request.body)) {
@@ -236,13 +272,13 @@ export async function startHookServer(): Promise<void> {
   });
 
   // Compression queue stats endpoint
-  server.get('/compression/stats', async () => {
+  app.get('/compression/stats', async () => {
     const queue = getCompressionQueue();
     return queue.getStats();
   });
 
   // Context injection endpoint - retrieve relevant memories for a project
-  server.get<{
+  app.get<{
     Querystring: { path?: string; prompt?: string };
   }>('/context', async (request, reply) => {
     const { path, prompt } = request.query;
@@ -276,6 +312,20 @@ export async function startHookServer(): Promise<void> {
       return { success: false, error: (error as Error).message };
     }
   });
+
+  return app;
+}
+
+/** Start hook server */
+export async function startHookServer(): Promise<void> {
+  if (server) {
+    logger.warn('Hook server already running');
+    return;
+  }
+
+  const port = config.get().hookPort;
+
+  server = createHookServer();
 
   try {
     await server.listen({ port, host: '127.0.0.1' });


### PR DESCRIPTION
## Summary

- Fixes #79.
- Add a Fastify onRequest gate for the local hook server.
- Reject non-loopback Host headers, non-loopback Origins, and cross-site Fetch Metadata before route handlers run.
- Extract createHookServer() so request-security behavior can be tested with Fastify inject.

## SpecRail

- specs/GH79/product.md
- specs/GH79/tech.md
- specs/GH79/tasks.md

## Verification

- bun test src/__tests__/hook.server.test.ts
- bun run typecheck
- bun test
- bun run build

Note: checks/check_workflow.py is not present in this repository, so the SpecRail workflow checker is not applicable here.