### PR TITLE
fix: make runtime identity mapping explicit

### DIFF
--- a/specs/GH80/product.md
+++ b/specs/GH80/product.md
@@ -1,0 +1,37 @@
+# Runtime Identity Contract Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/80
+
+## Summary
+
+Keepline must not silently coerce unknown agent runtimes into Claude. Runtime identity should have one registered runtime-id source, and legacy session `client` values should be mapped through explicit, checked bridges.
+
+## User Problem
+
+The codebase currently has separate runtime/client vocabularies. The highest-risk behavior is that unknown runtime IDs can fall through bridge functions and become `claude`, which hides integration mistakes and mislabels future runtimes.
+
+## Product Behavior
+
+1. Registered runtime IDs are defined once in the runtime domain.
+2. The active session runtime filter uses the registered runtime ID source instead of duplicating string literals.
+3. `cursor` is not advertised as a registered runtime until an adapter is actually registered.
+4. `clientForRuntimeId()` rejects unknown runtime IDs instead of returning Claude.
+5. `runtimeIdForClient()` rejects unknown legacy clients instead of returning Claude.
+6. Existing Claude Code and Codex behavior remains unchanged.
+
+## Non-Goals
+
+- Do not remove the persisted legacy `client` column in this tranche.
+- Do not migrate every UI and repository type from `AgentClient` to `RuntimeId`.
+- Do not add a Cursor adapter.
+- Do not change public API response shapes except to avoid silent fallback.
+
+## Acceptance Criteria
+
+1. `RuntimeId` no longer contains a registered `cursor` literal without an adapter.
+2. `SessionRuntimeId` derives from the runtime-domain registered ID type.
+3. Runtime filter parsing accepts only registered runtime IDs and reports unknown IDs as invalid.
+4. Unknown runtime IDs do not map to Claude.
+5. Unknown legacy clients do not map to Claude.
+6. Regression tests cover known mappings and unknown rejection.
+7. Focused tests, `bun run typecheck`, `bun test`, and `bun run build` pass.

--- a/specs/GH80/tasks.md
+++ b/specs/GH80/tasks.md
@@ -1,0 +1,96 @@
+# Runtime Identity Contract Task Plan
+
+Issue: https://github.com/majiayu000/keepline/issues/80
+
+## Tasks
+
+### SP80-T1: Add SpecRail artifacts
+
+Done when:
+
+- `specs/GH80/product.md` exists.
+- `specs/GH80/tech.md` exists.
+- `specs/GH80/tasks.md` exists.
+
+Verify:
+
+```sh
+test -f specs/GH80/product.md
+test -f specs/GH80/tech.md
+test -f specs/GH80/tasks.md
+```
+
+### SP80-T2: Move registered runtime IDs to runtime domain
+
+Writable files:
+
+- `src/domain/runtime/types.ts`
+
+Done when:
+
+- Registered runtime IDs are exported as a const tuple.
+- `RuntimeId` derives from registered IDs plus future extension strings.
+- The dead `cursor` registered literal is removed.
+
+Verify:
+
+```sh
+bun run typecheck
+```
+
+### SP80-T3: Make runtime-status bridges explicit
+
+Writable files:
+
+- `src/services/runtime-status.ts`
+
+Done when:
+
+- `SessionRuntimeId` derives from `RegisteredRuntimeId`.
+- `runtimeIdForClient()` does not default unknown clients to Claude.
+- `clientForRuntimeId()` does not default unknown runtime IDs to Claude.
+- `parseRuntimeFilter()` checks registered runtime IDs.
+
+Verify:
+
+```sh
+bun test src/__tests__/runtime-status.test.ts
+```
+
+### SP80-T4: Add regression tests
+
+Writable files:
+
+- `src/__tests__/runtime-status.test.ts`
+
+Done when:
+
+- Known mappings still pass.
+- Unknown runtime IDs throw instead of returning `claude`.
+- Unknown clients throw instead of returning `claude-code`.
+- Runtime filters reject unregistered IDs.
+
+Verify:
+
+```sh
+bun test src/__tests__/runtime-status.test.ts
+```
+
+### SP80-T5: Full verification and PR
+
+Done when:
+
+- Focused tests pass.
+- Typecheck passes.
+- Full tests pass.
+- Build passes.
+- PR links and closes #80.
+
+Verify:
+
+```sh
+bun test src/__tests__/runtime-status.test.ts src/__tests__/session-runtime-scan.test.ts src/__tests__/sessions.route-basic.test.ts
+bun run typecheck
+bun test
+bun run build
+```

--- a/specs/GH80/tech.md
+++ b/specs/GH80/tech.md
@@ -1,0 +1,58 @@
+# Runtime Identity Contract Tech Spec
+
+Product spec: `specs/GH80/product.md`
+
+Issue: https://github.com/majiayu000/keepline/issues/80
+
+## Context
+
+- `src/domain/runtime/types.ts` declares `RuntimeId`.
+- `src/services/runtime-status.ts` declares a separate `SessionRuntimeId` and bridges runtime IDs to legacy `AgentClient`.
+- `clientForRuntimeId()` currently uses a default branch that maps anything except `codex` to `claude`.
+- `RuntimeId` includes `cursor` even though the default registry only registers Claude Code and Codex.
+
+## Design
+
+In `src/domain/runtime/types.ts`:
+
+```ts
+export const REGISTERED_RUNTIME_IDS = ['claude-code', 'codex'] as const
+export type RegisteredRuntimeId = typeof REGISTERED_RUNTIME_IDS[number]
+export type RuntimeId = RegisteredRuntimeId | (string & {})
+```
+
+In `src/services/runtime-status.ts`:
+
+- Define `SessionRuntimeId = RegisteredRuntimeId`.
+- Re-export `SESSION_RUNTIME_IDS = REGISTERED_RUNTIME_IDS`.
+- Use compile-time checked maps:
+
+```ts
+const CLIENT_RUNTIME_IDS = {
+  claude: 'claude-code',
+  codex: 'codex',
+} satisfies Record<AgentClient, SessionRuntimeId>
+
+const RUNTIME_CLIENTS = {
+  'claude-code': 'claude',
+  codex: 'codex',
+} satisfies Record<SessionRuntimeId, AgentClient>
+```
+
+- Add a small `isSessionRuntimeId()` guard.
+- Make bridge functions throw on unknown inputs.
+- Make `parseRuntimeFilter()` check the registered runtime ID set.
+
+## Verification Plan
+
+- Add `src/__tests__/runtime-status.test.ts`.
+- Run:
+  - `bun test src/__tests__/runtime-status.test.ts src/__tests__/session-runtime-scan.test.ts src/__tests__/sessions.route-basic.test.ts`
+  - `bun run typecheck`
+  - `bun test`
+  - `bun run build`
+
+## Rollback
+
+- Restore duplicated `SessionRuntimeId` literal union and old bridge functions.
+- Remove the runtime-status regression tests.

--- a/src/__tests__/runtime-status.test.ts
+++ b/src/__tests__/runtime-status.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  REGISTERED_RUNTIME_IDS,
+  type RuntimeId,
+} from '../domain/runtime/index.js';
+import type { AgentClient } from '../domain/session/index.js';
+import {
+  clientForRuntimeId,
+  isSessionRuntimeId,
+  parseRuntimeFilter,
+  runtimeIdForClient,
+  SESSION_RUNTIME_IDS,
+} from '../services/runtime-status.js';
+
+describe('runtime identity status helpers', () => {
+  test('session runtime IDs come from registered runtime IDs', () => {
+    expect(SESSION_RUNTIME_IDS).toBe(REGISTERED_RUNTIME_IDS);
+    expect(SESSION_RUNTIME_IDS).toEqual(['claude-code', 'codex']);
+  });
+
+  test('maps known legacy clients to registered runtime IDs', () => {
+    expect(runtimeIdForClient('claude')).toBe('claude-code');
+    expect(runtimeIdForClient('codex')).toBe('codex');
+  });
+
+  test('maps known runtime IDs to legacy clients', () => {
+    expect(clientForRuntimeId('claude-code')).toBe('claude');
+    expect(clientForRuntimeId('codex')).toBe('codex');
+  });
+
+  test('does not silently map unknown runtime IDs to Claude', () => {
+    expect(isSessionRuntimeId('cursor')).toBe(false);
+    expect(() => clientForRuntimeId('cursor' as RuntimeId)).toThrow('Unsupported runtime id: cursor');
+  });
+
+  test('does not silently map unknown clients to Claude Code', () => {
+    expect(() => runtimeIdForClient('gemini' as AgentClient)).toThrow('Unsupported agent client: gemini');
+  });
+
+  test('runtime filter parser rejects unregistered runtime IDs', () => {
+    expect(parseRuntimeFilter('claude-code')).toEqual({ runtimeId: 'claude-code' });
+    expect(parseRuntimeFilter('codex')).toEqual({ runtimeId: 'codex' });
+    expect(parseRuntimeFilter('cursor')).toEqual({ invalid: 'cursor' });
+  });
+});

--- a/src/domain/runtime/types.ts
+++ b/src/domain/runtime/types.ts
@@ -4,7 +4,11 @@
 
 import type { SessionStatus, ToolCallInfo } from '../session/index.js';
 
-export type RuntimeId = 'claude-code' | 'codex' | 'cursor' | (string & {});
+export const REGISTERED_RUNTIME_IDS = ['claude-code', 'codex'] as const;
+
+export type RegisteredRuntimeId = typeof REGISTERED_RUNTIME_IDS[number];
+
+export type RuntimeId = RegisteredRuntimeId | (string & {});
 
 export type RuntimeKind = 'cli' | 'ide' | 'cloud' | 'unknown';
 

--- a/src/services/runtime-status.ts
+++ b/src/services/runtime-status.ts
@@ -1,10 +1,25 @@
-import type { RuntimeId, RuntimeScanError } from '../domain/runtime/index.js';
+import {
+  REGISTERED_RUNTIME_IDS,
+  type RegisteredRuntimeId,
+  type RuntimeId,
+  type RuntimeScanError,
+} from '../domain/runtime/index.js';
 import type { AgentClient } from '../domain/session/index.js';
 
-export type SessionRuntimeId = 'claude-code' | 'codex';
+export type SessionRuntimeId = RegisteredRuntimeId;
 export type RuntimeFilter = SessionRuntimeId | 'all';
 
-export const SESSION_RUNTIME_IDS: readonly SessionRuntimeId[] = ['claude-code', 'codex'] as const;
+export const SESSION_RUNTIME_IDS: readonly SessionRuntimeId[] = REGISTERED_RUNTIME_IDS;
+
+const CLIENT_RUNTIME_IDS = {
+  claude: 'claude-code',
+  codex: 'codex',
+} satisfies Record<AgentClient, SessionRuntimeId>;
+
+const RUNTIME_CLIENTS = {
+  'claude-code': 'claude',
+  codex: 'codex',
+} satisfies Record<SessionRuntimeId, AgentClient>;
 
 export interface RuntimeScanSummary {
   runtimeId: SessionRuntimeId;
@@ -23,12 +38,23 @@ export type RuntimeScanFailure = {
 
 const latestRuntimeScan = new Map<SessionRuntimeId, RuntimeScanSummary>();
 
-export function runtimeIdForClient(client: AgentClient | undefined): SessionRuntimeId {
-  return client === 'codex' ? 'codex' : 'claude-code';
+export function isSessionRuntimeId(runtimeId: string): runtimeId is SessionRuntimeId {
+  return (SESSION_RUNTIME_IDS as readonly string[]).includes(runtimeId);
 }
 
-export function clientForRuntimeId(runtimeId: SessionRuntimeId): AgentClient {
-  return runtimeId === 'codex' ? 'codex' : 'claude';
+export function runtimeIdForClient(client: AgentClient): SessionRuntimeId {
+  const runtimeId = CLIENT_RUNTIME_IDS[client];
+  if (!runtimeId) {
+    throw new Error(`Unsupported agent client: ${String(client)}`);
+  }
+  return runtimeId;
+}
+
+export function clientForRuntimeId(runtimeId: RuntimeId): AgentClient {
+  if (!isSessionRuntimeId(runtimeId)) {
+    throw new Error(`Unsupported runtime id: ${String(runtimeId)}`);
+  }
+  return RUNTIME_CLIENTS[runtimeId];
 }
 
 export function parseRuntimeFilter(raw: string | undefined): {
@@ -37,7 +63,7 @@ export function parseRuntimeFilter(raw: string | undefined): {
 } {
   const value = raw?.trim();
   if (!value || value === 'all') return {};
-  if (value === 'claude-code' || value === 'codex') {
+  if (isSessionRuntimeId(value)) {
     return { runtimeId: value };
   }
   return { invalid: value };


### PR DESCRIPTION
## Summary

- Fixes #80.
- Move registered runtime IDs into the runtime domain and derive SessionRuntimeId from that source.
- Remove the dead registered cursor literal until an adapter exists.
- Replace default-to-Claude bridge logic with explicit checked maps and errors for unknown runtime IDs or legacy clients.
- Add runtime-status regression tests for known mappings, unknown rejection, and runtime filter parsing.

## SpecRail

- specs/GH80/product.md
- specs/GH80/tech.md
- specs/GH80/tasks.md

## Verification

- bun test src/__tests__/runtime-status.test.ts src/__tests__/session-runtime-scan.test.ts
- bun test src/__tests__/sessions.route-basic.test.ts
- bun run typecheck
- bun test
- bun run build

Note: checks/check_workflow.py is not present in this repository, so the SpecRail workflow checker is not applicable here.