### PR TITLE
fix: schedule retention cleanup

### DIFF
--- a/specs/GH81/product.md
+++ b/specs/GH81/product.md
@@ -1,0 +1,39 @@
+# Retention Cleanup Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/81
+
+## Summary
+
+Keepline's configured retention policy must actually delete old persisted data while the daemon is running. A default 30-day retention setting is currently declared but never executed.
+
+## User Problem
+
+Users are told that completed session data is retained for a bounded number of days, but completed sessions and related rows remain forever. Long-running daemon installations will grow the SQLite database indefinitely.
+
+## Product Behavior
+
+1. The daemon runs retention cleanup on startup and then periodically.
+2. `retentionDays > 0` enables cleanup.
+3. `retentionDays <= 0` disables cleanup.
+4. Cleanup deletes completed sessions older than the configured retention window.
+5. Cleanup deletes `tool_usage` and `hook_events` rows associated with deleted sessions.
+6. Cleanup deletes old domain events from the event store using the same cutoff.
+7. Active, waiting, idle, lost, or recent completed sessions are preserved.
+
+## Non-Goals
+
+- Do not delete active session history only because it is old.
+- Do not add a new user-facing config key.
+- Do not change the default retention value.
+- Do not vacuum or compact the SQLite database in this tranche.
+
+## Acceptance Criteria
+
+1. Daemon startup runs one retention cleanup cycle.
+2. Daemon schedules periodic retention cleanup when `retentionDays > 0`.
+3. `retentionDays <= 0` disables cleanup.
+4. Old completed sessions are deleted.
+5. Related `tool_usage` and `hook_events` rows for deleted sessions are deleted.
+6. Old event-store rows are deleted.
+7. Regression tests insert old records and prove cleanup removes only eligible data.
+8. Focused tests, `bun run typecheck`, `bun test`, and `bun run build` pass.

--- a/specs/GH81/tasks.md
+++ b/specs/GH81/tasks.md
@@ -1,0 +1,99 @@
+# Retention Cleanup Task Plan
+
+Issue: https://github.com/majiayu000/keepline/issues/81
+
+## Tasks
+
+### SP81-T1: Add SpecRail artifacts
+
+Done when:
+
+- `specs/GH81/product.md` exists.
+- `specs/GH81/tech.md` exists.
+- `specs/GH81/tasks.md` exists.
+
+Verify:
+
+```sh
+test -f specs/GH81/product.md
+test -f specs/GH81/tech.md
+test -f specs/GH81/tasks.md
+```
+
+### SP81-T2: Make old session deletion complete
+
+Writable files:
+
+- `src/infrastructure/database/repositories/session.repository.ts`
+
+Done when:
+
+- Old completed sessions are deleted in a transaction.
+- Matching `tool_usage` rows are deleted before sessions.
+- Matching `hook_events` rows are deleted.
+- Running or recent sessions are preserved.
+
+Verify:
+
+```sh
+bun test src/__tests__/retention.service.test.ts src/__tests__/session-repository.test.ts
+```
+
+### SP81-T3: Add retention service and scheduler wiring
+
+Writable files:
+
+- `src/services/retention.service.ts`
+- `src/services/daemon.scheduler.ts`
+
+Done when:
+
+- Cleanup can be called directly for tests.
+- Scheduler runs cleanup once on startup.
+- Scheduler schedules recurring cleanup when `retentionDays > 0`.
+- Scheduler clears the retention interval on stop.
+
+Verify:
+
+```sh
+bun run typecheck
+```
+
+### SP81-T4: Add retention regression tests
+
+Writable files:
+
+- `src/__tests__/retention.service.test.ts`
+
+Done when:
+
+- Old completed session rows are deleted.
+- Related usage and hook event rows are deleted.
+- Recent completed and old running sessions remain.
+- Old event-store rows are deleted.
+- `retentionDays <= 0` does not delete data.
+
+Verify:
+
+```sh
+bun test src/__tests__/retention.service.test.ts
+```
+
+### SP81-T5: Full verification and PR
+
+Done when:
+
+- Focused tests pass.
+- Typecheck passes.
+- Full tests pass.
+- Build passes.
+- PR links and closes #81.
+
+Verify:
+
+```sh
+bun test src/__tests__/retention.service.test.ts src/__tests__/session-repository.test.ts
+bun run typecheck
+bun test
+bun run build
+```

--- a/specs/GH81/tech.md
+++ b/specs/GH81/tech.md
@@ -1,0 +1,70 @@
+# Retention Cleanup Tech Spec
+
+Product spec: `specs/GH81/product.md`
+
+Issue: https://github.com/majiayu000/keepline/issues/81
+
+## Context
+
+- `config.retentionDays` defaults to 30 and validates as non-negative.
+- `sessionRepository.deleteOldSessions(retentionDays)` exists but is not called.
+- `eventStore.deleteOlderThan(date)` exists but is not called.
+- `tool_usage` has a foreign key to `sessions(session_id)`, so old session deletion must remove child usage rows first.
+- `hook_events` has `session_id` but no foreign key; it should still be cleaned for deleted sessions.
+
+## Design
+
+Add `src/services/retention.service.ts`:
+
+```ts
+interface RetentionCleanupResult {
+  disabled: boolean
+  retentionDays: number
+  cutoff?: Date
+  sessionsDeleted: number
+  eventsDeleted: number
+}
+```
+
+`runRetentionCleanup(retentionDays = config.get().retentionDays, now = new Date())`:
+
+1. If `retentionDays <= 0`, return a disabled result without touching storage.
+2. Compute `cutoff = now - retentionDays`.
+3. Call `sessionRepository.deleteOldSessions(retentionDays, now)`.
+4. Call `eventStore.deleteOlderThan(cutoff)`.
+5. Log the cleanup result.
+
+Update `sessionRepository.deleteOldSessions()` to run in one transaction:
+
+1. Count completed sessions whose `last_active_at` is older than cutoff.
+2. Delete `tool_usage` rows for those session IDs.
+3. Delete `hook_events` rows for those session IDs.
+4. Delete the session rows.
+5. Return the deleted session count.
+
+Update `daemon.scheduler.ts`:
+
+- Add a daily retention interval.
+- Run one cleanup cycle after the initial scan.
+- Schedule recurring cleanup only when startup config has `retentionDays > 0`.
+- Clear the interval on scheduler stop.
+
+## Verification Plan
+
+- Add `src/__tests__/retention.service.test.ts`:
+  - old completed sessions and related usage/hook rows are removed
+  - recent completed sessions and old non-completed sessions are preserved
+  - old event-store rows are removed
+  - `retentionDays <= 0` is a no-op
+- Run:
+  - `bun test src/__tests__/retention.service.test.ts src/__tests__/session-repository.test.ts`
+  - `bun run typecheck`
+  - `bun test`
+  - `bun run build`
+
+## Rollback
+
+- Remove the scheduler retention interval.
+- Remove `retention.service.ts`.
+- Restore `deleteOldSessions()` to only delete sessions.
+- Remove retention tests.

--- a/src/__tests__/retention.service.test.ts
+++ b/src/__tests__/retention.service.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { resetDatabase } from '../db/migrations.js';
+import { closeDatabase, getDatabase } from '../infrastructure/database/sqlite.js';
+import { sessionRepository } from '../infrastructure/database/repositories/session.repository.js';
+import { eventStore } from '../infrastructure/events/store.js';
+import { runRetentionCleanup } from '../services/retention.service.js';
+
+const NOW = new Date('2026-07-02T12:00:00.000Z');
+const OLD_DATE = new Date('2026-05-01T12:00:00.000Z');
+const RECENT_DATE = new Date('2026-06-25T12:00:00.000Z');
+
+describe('retention cleanup', () => {
+  beforeEach(async () => {
+    resetDatabase();
+    await eventStore.deleteOlderThan(new Date('9999-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  function count(table: string, where: string = '1 = 1'): number {
+    const row = getDatabase()
+      .prepare(`SELECT COUNT(*) as count FROM ${table} WHERE ${where}`)
+      .get() as { count: number };
+    return row.count;
+  }
+
+  function insertSession(sessionId: string, status: 'completed' | 'running', lastActiveAt: Date) {
+    sessionRepository.upsert({
+      sessionId,
+      directory: '/tmp/project',
+      status,
+      title: sessionId,
+      initialPrompt: sessionId,
+      startedAt: lastActiveAt,
+      lastActiveAt,
+      completedAt: status === 'completed' ? lastActiveAt : undefined,
+      toolCount: 1,
+      messageCount: 1,
+    });
+  }
+
+  function insertUsageAndHookEvents(sessionId: string) {
+    const db = getDatabase();
+    db.prepare(`
+      INSERT INTO tool_usage (session_id, tool, input, output, duration, timestamp)
+      VALUES (?, 'Edit', '{}', '{}', 10, ?)
+    `).run(sessionId, OLD_DATE.toISOString());
+    db.prepare(`
+      INSERT INTO hook_events (session_id, event_type, payload, timestamp)
+      VALUES (?, 'PostToolUse', '{}', ?)
+    `).run(sessionId, OLD_DATE.toISOString());
+  }
+
+  test('deletes old completed sessions, related rows, and old events', async () => {
+    insertSession('old-completed-session', 'completed', OLD_DATE);
+    insertSession('recent-completed-session', 'completed', RECENT_DATE);
+    insertSession('old-running-session', 'running', OLD_DATE);
+    insertUsageAndHookEvents('old-completed-session');
+    insertUsageAndHookEvents('recent-completed-session');
+    insertUsageAndHookEvents('old-running-session');
+
+    await eventStore.append({
+      type: 'old:event',
+      aggregateId: 'old',
+      payload: {},
+      timestamp: OLD_DATE,
+    });
+    await eventStore.append({
+      type: 'recent:event',
+      aggregateId: 'recent',
+      payload: {},
+      timestamp: RECENT_DATE,
+    });
+
+    const result = await runRetentionCleanup(30, NOW);
+
+    expect(result).toMatchObject({
+      disabled: false,
+      retentionDays: 30,
+      sessionsDeleted: 1,
+      eventsDeleted: 1,
+    });
+    expect(sessionRepository.findBySessionId('old-completed-session')).toBeNull();
+    expect(sessionRepository.findBySessionId('recent-completed-session')).not.toBeNull();
+    expect(sessionRepository.findBySessionId('old-running-session')).not.toBeNull();
+    expect(count('tool_usage', "session_id = 'old-completed-session'")).toBe(0);
+    expect(count('hook_events', "session_id = 'old-completed-session'")).toBe(0);
+    expect(count('tool_usage', "session_id = 'recent-completed-session'")).toBe(1);
+    expect(count('hook_events', "session_id = 'old-running-session'")).toBe(1);
+    expect(await eventStore.count()).toBe(1);
+  });
+
+  test('retentionDays <= 0 disables cleanup', async () => {
+    insertSession('old-completed-session', 'completed', OLD_DATE);
+    insertUsageAndHookEvents('old-completed-session');
+    await eventStore.append({
+      type: 'old:event',
+      aggregateId: 'old',
+      payload: {},
+      timestamp: OLD_DATE,
+    });
+
+    const result = await runRetentionCleanup(0, NOW);
+
+    expect(result).toEqual({
+      disabled: true,
+      retentionDays: 0,
+      sessionsDeleted: 0,
+      eventsDeleted: 0,
+    });
+    expect(sessionRepository.findBySessionId('old-completed-session')).not.toBeNull();
+    expect(count('tool_usage', "session_id = 'old-completed-session'")).toBe(1);
+    expect(await eventStore.count()).toBe(1);
+  });
+});

--- a/src/infrastructure/database/repositories/session.repository.ts
+++ b/src/infrastructure/database/repositories/session.repository.ts
@@ -417,22 +417,41 @@ class SessionRepository implements ISessionRepository {
     });
   }
 
-  deleteOldSessions(retentionDays: number): number {
+  deleteOldSessions(retentionDays: number, now: Date = new Date()): number {
     const db = getDatabase();
-    const cutoff = new Date();
+    const cutoff = new Date(now);
     cutoff.setDate(cutoff.getDate() - retentionDays);
+    const cutoffIso = cutoff.toISOString();
 
-    const beforeCount = (db.prepare(`
-      SELECT COUNT(*) as count FROM sessions
-      WHERE status = 'completed' AND last_active_at < ?
-    `).get(cutoff.toISOString()) as { count: number }).count;
+    return transaction(() => {
+      const beforeCount = (db.prepare(`
+        SELECT COUNT(*) as count FROM sessions
+        WHERE status = 'completed' AND last_active_at < ?
+      `).get(cutoffIso) as { count: number }).count;
 
-    db.prepare(`
-      DELETE FROM sessions
-      WHERE status = 'completed' AND last_active_at < ?
-    `).run(cutoff.toISOString());
+      db.prepare(`
+        DELETE FROM tool_usage
+        WHERE session_id IN (
+          SELECT session_id FROM sessions
+          WHERE status = 'completed' AND last_active_at < ?
+        )
+      `).run(cutoffIso);
 
-    return beforeCount;
+      db.prepare(`
+        DELETE FROM hook_events
+        WHERE session_id IN (
+          SELECT session_id FROM sessions
+          WHERE status = 'completed' AND last_active_at < ?
+        )
+      `).run(cutoffIso);
+
+      db.prepare(`
+        DELETE FROM sessions
+        WHERE status = 'completed' AND last_active_at < ?
+      `).run(cutoffIso);
+
+      return beforeCount;
+    });
   }
 
   countByStatus(): Record<SessionStatus, number> {

--- a/src/services/daemon.scheduler.ts
+++ b/src/services/daemon.scheduler.ts
@@ -10,9 +10,13 @@ import { runMigrations } from '../db/migrations.js';
 import { closeDatabase } from '../infrastructure/database/sqlite.js';
 import { emit } from '../lib/events.js';
 import { initializeMemoryService } from './memory.service.js';
+import { runRetentionCleanup } from './retention.service.js';
 
 let scanInterval: NodeJS.Timeout | null = null;
+let retentionInterval: NodeJS.Timeout | null = null;
 let isRunning = false;
+
+const RETENTION_CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 /** Run a single scan cycle */
 async function runScanCycle(): Promise<void> {
@@ -22,6 +26,16 @@ async function runScanCycle(): Promise<void> {
   } catch (error) {
     logger.error('Scan cycle failed', error);
     emit('error', { error: error as Error, context: 'scan_cycle' });
+  }
+}
+
+/** Run one retention cleanup cycle */
+async function runRetentionCleanupCycle(): Promise<void> {
+  try {
+    await runRetentionCleanup();
+  } catch (error) {
+    logger.error('Retention cleanup failed', error);
+    emit('error', { error: error as Error, context: 'retention_cleanup' });
   }
 }
 
@@ -49,8 +63,17 @@ export async function startScheduler(): Promise<void> {
   // Run initial scan
   await runScanCycle();
 
+  // Run initial retention cleanup after sessions are synced.
+  await runRetentionCleanupCycle();
+
   // Start periodic scanning
   scanInterval = setInterval(runScanCycle, cfg.scanInterval);
+
+  if (cfg.retentionDays > 0) {
+    retentionInterval = setInterval(runRetentionCleanupCycle, RETENTION_CLEANUP_INTERVAL_MS);
+  } else {
+    logger.info('Retention cleanup disabled');
+  }
 
   logger.info(`Scheduler started (scan interval: ${cfg.scanInterval}ms)`);
 }
@@ -65,6 +88,11 @@ export async function stopScheduler(): Promise<void> {
   if (scanInterval) {
     clearInterval(scanInterval);
     scanInterval = null;
+  }
+
+  if (retentionInterval) {
+    clearInterval(retentionInterval);
+    retentionInterval = null;
   }
 
   // Stop hook server

--- a/src/services/retention.service.ts
+++ b/src/services/retention.service.ts
@@ -1,0 +1,52 @@
+import { config } from '../lib/config.js';
+import { logger } from '../lib/logger.js';
+import { sessionRepository } from '../infrastructure/database/repositories/session.repository.js';
+import { eventStore } from '../infrastructure/events/store.js';
+
+export interface RetentionCleanupResult {
+  disabled: boolean;
+  retentionDays: number;
+  cutoff?: Date;
+  sessionsDeleted: number;
+  eventsDeleted: number;
+}
+
+function retentionCutoff(retentionDays: number, now: Date): Date {
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - retentionDays);
+  return cutoff;
+}
+
+export async function runRetentionCleanup(
+  retentionDays: number = config.get().retentionDays,
+  now: Date = new Date()
+): Promise<RetentionCleanupResult> {
+  if (retentionDays <= 0) {
+    logger.debug('Retention cleanup disabled', { retentionDays });
+    return {
+      disabled: true,
+      retentionDays,
+      sessionsDeleted: 0,
+      eventsDeleted: 0,
+    };
+  }
+
+  const cutoff = retentionCutoff(retentionDays, now);
+  const sessionsDeleted = sessionRepository.deleteOldSessions(retentionDays, now);
+  const eventsDeleted = await eventStore.deleteOlderThan(cutoff);
+
+  logger.info('Retention cleanup completed', {
+    retentionDays,
+    cutoff: cutoff.toISOString(),
+    sessionsDeleted,
+    eventsDeleted,
+  });
+
+  return {
+    disabled: false,
+    retentionDays,
+    cutoff,
+    sessionsDeleted,
+    eventsDeleted,
+  };
+}


### PR DESCRIPTION
## Summary

- Fixes #81.
- Add a retention cleanup service and wire it into daemon startup plus a daily interval.
- Preserve retentionDays <= 0 as cleanup disabled.
- Delete old completed sessions in a transaction after removing related tool_usage and hook_events rows.
- Delete old event-store rows using the same retention cutoff.

## SpecRail

- specs/GH81/product.md
- specs/GH81/tech.md
- specs/GH81/tasks.md

## Verification

- bun test src/__tests__/retention.service.test.ts src/__tests__/session-repository.test.ts
- bun run typecheck
- bun test
- bun run build

Note: checks/check_workflow.py is not present in this repository, so the SpecRail workflow checker is not applicable here.