### PR TITLE
fix: harden audit rollup basics

### DIFF
--- a/specs/GH82/product.md
+++ b/specs/GH82/product.md
@@ -1,0 +1,87 @@
+# P2 Audit Rollup Triage And Hardening Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/82
+
+## Summary
+
+GH82 is a P2 technical-debt rollup from codebase audit findings. It mixes
+immediate correctness bugs, security-adjacent persistence risks, stale findings,
+items already covered by open P1 PRs, and larger architecture cleanups.
+
+This tranche converts the rollup into SpecRail-owned work and fixes the
+high-confidence items that can be changed independently of the current P0/P1 PR
+queue. It does not close GH82 until every checklist item is either fixed,
+verified stale, or split into accepted follow-up issues.
+
+## User Problem
+
+Users trust Keepline for cost visibility, session recovery, and live status. A
+few silent or stale behaviors erode that trust:
+
+1. Codex sessions can display zero cost even when token usage exists in the
+   session stream.
+2. Non-Anthropic model pricing can be omitted or silently priced as Claude.
+3. The daemon can run with stale pricing or keep running after fatal process
+   errors.
+4. Concurrent SQLite writers can fail with avoidable `SQLITE_BUSY` errors.
+5. API pagination with invalid numbers can return misleading empty results.
+6. PID reuse can make an old session look attached to a new process.
+7. Session fields that should clear can remain stale forever.
+
+## Product Behavior
+
+1. Codex token and cost data should be parsed from supported Codex JSONL usage
+   events and persisted into `usageStats` when present.
+2. Pricing should use LiteLLM entries for all providers when token costs are
+   available, while preserving known Claude defaults.
+3. Unknown model pricing should be visible in logs instead of silently looking
+   precise.
+4. The daemon should initialize pricing before sync cycles and exit on
+   uncaught exceptions or unhandled rejections so a supervisor can restart it.
+5. SQLite should wait briefly for concurrent writers instead of failing
+   immediately.
+6. Session list pagination should reject invalid `limit` or `offset` values
+   with a 400 response.
+7. PID continuity should only preserve a PID match when process start time is
+   compatible with the previous session.
+8. Explicit nullable session fields should be clearable when an updater sends
+   the field with `undefined` or `null`.
+9. Test database reset should remove the optional `events` table as well as the
+   core migrated tables.
+
+## Non-Goals
+
+- Do not duplicate the open GH74 LanceDB predicate hardening PR.
+- Do not duplicate the open GH75 hook pipeline PR.
+- Do not duplicate the open GH78-GH81 P1 fixes.
+- Do not refactor frontend runtime validation, status displays, env config, or
+  adapter layer boundaries in this tranche.
+- Do not remove public EventStore exports in a hardening tranche.
+- Do not close GH82 from this partial tranche.
+
+## Acceptance Criteria
+
+1. `specs/GH82/product.md`, `tech.md`, and `tasks.md` exist.
+2. Codex parser tests prove supported `event_msg` usage entries produce
+   non-zero `usageStats`.
+3. Pricing tests prove OpenAI/LiteLLM-style non-Anthropic entries are retained
+   and unknown model fallback is logged.
+4. Daemon startup initializes pricing and fatal process errors exit instead of
+   continuing silently.
+5. SQLite connection setup applies a non-zero busy timeout.
+6. Session route tests prove invalid `limit` and `offset` return HTTP 400.
+7. Process matcher tests prove reused PIDs with incompatible start times are not
+   treated as continuity.
+8. Repository tests prove nullable activity fields can be explicitly cleared.
+9. Reset database tests prove the optional `events` table is dropped.
+10. Verification passes: focused tests, `bun run typecheck`, `bun test`, and
+    `bun run build`.
+
+## Related Work
+
+- PR #84 covers GH74 LanceDB predicate hardening.
+- PR #87 covers GH75 hook pipeline restoration.
+- PR #90 covers GH78 usage data in basic session payloads.
+- PR #91 covers GH79 hook server request guards.
+- PR #92 covers GH80 runtime identity contract cleanup.
+- PR #93 covers GH81 retention cleanup scheduling.

--- a/specs/GH82/tasks.md
+++ b/specs/GH82/tasks.md
@@ -1,0 +1,132 @@
+# P2 Audit Rollup Triage And Hardening Task Plan
+
+Issue: https://github.com/majiayu000/keepline/issues/82
+
+Product spec: `specs/GH82/product.md`
+Tech spec: `specs/GH82/tech.md`
+
+## Tasks
+
+### SP82-T1: Add SpecRail packet and scope map
+
+Done when:
+
+- `specs/GH82/product.md` exists.
+- `specs/GH82/tech.md` exists.
+- `specs/GH82/tasks.md` exists.
+- Scope explicitly avoids duplicating open P0/P1 PRs.
+
+Verify:
+
+```sh
+test -f specs/GH82/product.md
+test -f specs/GH82/tech.md
+test -f specs/GH82/tasks.md
+```
+
+### SP82-T2: Parse Codex usage events
+
+Done when:
+
+- Codex parser accumulates supported `event_msg` usage records.
+- Missing or malformed usage records are ignored without breaking session parse.
+- Parsed Codex sessions include non-zero `usageStats` when usage telemetry is
+  present.
+
+Verify:
+
+```sh
+bun test src/__tests__/codex.parser.test.ts
+```
+
+### SP82-T3: Remove silent/stale pricing behavior
+
+Done when:
+
+- LiteLLM pricing import retains non-Anthropic model entries with token costs.
+- Unknown-model fallback emits a warning once per model.
+- Usage extraction no longer caches per-model pricing forever.
+
+Verify:
+
+```sh
+bun test src/__tests__/usage.pricing.test.ts src/__tests__/usage.extractor.test.ts
+```
+
+### SP82-T4: Harden daemon and SQLite startup
+
+Done when:
+
+- Daemon scheduler initializes pricing before scans.
+- Fatal daemon errors log, emit, stop, and exit with code 1.
+- SQLite sets a non-zero busy timeout.
+
+Verify:
+
+```sh
+bun run typecheck
+```
+
+### SP82-T5: Validate session API pagination
+
+Done when:
+
+- Invalid `limit` and `offset` return HTTP 400.
+- Valid pagination behavior remains unchanged.
+
+Verify:
+
+```sh
+bun test src/__tests__/sessions.route-basic.test.ts
+```
+
+### SP82-T6: Prevent PID reuse continuity matches
+
+Done when:
+
+- Existing PID continuity still works for compatible process start times.
+- Reused PID with an incompatible start time falls back to matching logic and
+  does not attach to stale session history.
+
+Verify:
+
+```sh
+bun test src/__tests__/session.process-matcher.test.ts
+```
+
+### SP82-T7: Clear stale nullable session fields
+
+Done when:
+
+- Upsert preserves nullable fields when omitted.
+- Upsert clears nullable fields when the key is present with `undefined` or
+  `null`.
+
+Verify:
+
+```sh
+bun test src/__tests__/session-repository.test.ts
+```
+
+### SP82-T8: Reset optional events table
+
+Done when:
+
+- `resetDatabase()` drops `events`.
+- A test proves rows inserted through EventStore do not survive reset.
+
+Verify:
+
+```sh
+bun test src/__tests__/reset-database.test.ts
+```
+
+### SP82-T9: Full verification and PR gate
+
+Done when:
+
+- Focused tests pass.
+- `bun run typecheck` passes.
+- `bun test` passes.
+- `bun run build` passes.
+- PR uses `Refs #82`, not `Closes #82`.

--- a/specs/GH82/tech.md
+++ b/specs/GH82/tech.md
@@ -1,0 +1,148 @@
+# P2 Audit Rollup Triage And Hardening Tech Spec
+
+Product spec: `specs/GH82/product.md`
+
+Issue: https://github.com/majiayu000/keepline/issues/82
+
+## Implementation Scope
+
+This tranche changes only files needed for non-overlapping hardening:
+
+- `src/adapters/codex/parser.ts`
+- `src/services/usage.pricing.ts`
+- `src/services/usage.extractor.ts`
+- `src/services/daemon.scheduler.ts`
+- `src/infrastructure/database/sqlite.ts`
+- `src/infrastructure/database/repositories/session.repository.ts`
+- `src/db/migrations.ts`
+- `src/web/api/routes/sessions.ts`
+- `src/services/session.process-matcher.ts`
+- focused tests for those modules
+
+LanceDB predicate handling, hook server installation semantics, retention
+scheduling, runtime identity vocabulary, and basic usage serialization are
+covered by existing open PRs and should not be duplicated here.
+
+## Codex Usage Parsing
+
+Codex JSONL may include usage telemetry in `event_msg` payloads. The parser
+must tolerate multiple telemetry shapes because historical Codex event payloads
+are not a stable public API.
+
+Supported shapes:
+
+```ts
+{
+  type: 'event_msg',
+  timestamp: string,
+  payload: {
+    model?: string,
+    usage?: {
+      input_tokens?: number,
+      output_tokens?: number,
+      cache_creation_input_tokens?: number,
+      cache_read_input_tokens?: number
+    }
+  }
+}
+```
+
+```ts
+{
+  type: 'event_msg',
+  payload: {
+    msg?: {
+      model?: string,
+      usage?: {
+        input_tokens?: number,
+        output_tokens?: number
+      }
+    }
+  }
+}
+```
+
+The parser should also accept camelCase token fields for compatibility with
+normalized Codex event emitters. Usage with missing numeric input or output
+tokens is ignored.
+
+Use the existing usage accumulator helpers so cost logic stays shared with
+Claude usage aggregation.
+
+## Pricing
+
+`fetchLiteLLMPricing()` should retain every LiteLLM model entry with both
+`input_cost_per_token` and `output_cost_per_token`, regardless of provider. It
+should keep provider-prefixed keys such as `openai/gpt-4o-mini` and exact keys
+as LiteLLM publishes them.
+
+Unknown-model fallback remains available for continuity, but `getModelPricing`
+must emit a warning the first time a model falls back so silent mispricing does
+not pass as precise output.
+
+The usage extractor should not keep an independent forever cache of per-token
+pricing. Recomputing the per-token values from the current pricing config is
+cheap and prevents stale cost models after pricing refresh.
+
+## Daemon Fatal Errors
+
+`startScheduler()` should call `initPricing()` after database migrations and
+before initial sync. Failure to fetch remote pricing still falls back to default
+pricing inside the pricing module.
+
+`runDaemon()` should still log and emit errors for `uncaughtException` and
+`unhandledRejection`, then stop the scheduler and exit with code 1. Continuing
+after these fatal errors is unsafe because the daemon may be partially broken
+while status still appears running.
+
+## SQLite
+
+After opening the database, set:
+
+```sql
+PRAGMA busy_timeout = 5000
+```
+
+Keep WAL and foreign keys enabled.
+
+## Sessions API Pagination
+
+Parse `limit` and `offset` through a small validator:
+
+- default `limit`: 50
+- max `limit`: 100
+- default `offset`: 0
+- invalid, non-integer, negative, or zero-limit values return HTTP 400
+
+## PID Continuity
+
+PID continuity remains preferred only when the directory/client group matches
+and the process start time is compatible with the stored session timeline.
+
+A process is compatible when its start time is not materially after the stored
+session's last active timestamp. A small clock-skew tolerance is allowed.
+Incompatible PID reuse falls back to the normal assignment algorithm instead of
+being accepted as continuity.
+
+## Nullable Session Fields
+
+Repository upsert already uses presence checks for `pid` and `tty`. Apply the
+same pattern to nullable activity fields that can become stale:
+
+- `lastTool`
+- `lastToolInput`
+- `currentFile`
+- `lastMessage`
+- `completedAt`
+- `agentId`
+- `parentSessionId`
+- `usageStats`
+- `toolCalls`
+
+When a field is omitted, preserve the old value. When a field key is present
+with `undefined` or `null`, write NULL.
+
+## Reset Database
+
+`resetDatabase()` must drop `events` before re-running migrations so tests and
+local resets do not retain optional EventStore rows.

--- a/src/__tests__/codex.parser.test.ts
+++ b/src/__tests__/codex.parser.test.ts
@@ -143,6 +143,43 @@ describe('Codex JSONL parser', () => {
       },
     ]);
   });
+
+  test('accumulates token usage from Codex event messages', async () => {
+    const filePath = createCodexJsonlFile([
+      {
+        type: 'session_meta',
+        timestamp: '2026-06-17T01:00:00.000Z',
+        payload: {
+          id: '019ed4a3-2186-7e51-9aa1-ca1e376549b8',
+          cwd: '/tmp/codex-project',
+        },
+      },
+      {
+        type: 'event_msg',
+        timestamp: '2026-06-17T01:00:05.000Z',
+        payload: {
+          msg: {
+            model: 'gpt-4o-mini',
+            usage: {
+              input_tokens: 1000,
+              output_tokens: 250,
+              cache_read_input_tokens: 100,
+            },
+          },
+        },
+      },
+    ]);
+
+    const parsed = await parseCodexSessionFile(filePath);
+
+    expect(parsed?.usageStats).toMatchObject({
+      totalInputTokens: 1100,
+      totalOutputTokens: 250,
+      totalTokens: 1350,
+      apiCalls: 1,
+    });
+    expect(parsed?.usageStats?.totalCost).toBeGreaterThan(0);
+  });
 });
 
 describe('Codex scanner', () => {

--- a/src/__tests__/reset-database.test.ts
+++ b/src/__tests__/reset-database.test.ts
@@ -39,4 +39,30 @@ describe('resetDatabase', () => {
     expect(queryOne<{ count: number }>('SELECT COUNT(*) as count FROM terminal_sessions')?.count).toBe(0);
     expect((queryOne<{ count: number }>('SELECT COUNT(*) as count FROM schema_migrations')?.count ?? 0)).toBeGreaterThan(0);
   });
+
+  test('sets a non-zero SQLite busy timeout', () => {
+    expect(queryOne<{ timeout: number }>('PRAGMA busy_timeout')?.timeout).toBe(5000);
+  });
+
+  test('drops optional events table during reset', () => {
+    runSql(`
+      CREATE TABLE IF NOT EXISTS events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        type TEXT NOT NULL,
+        aggregate_id TEXT,
+        payload TEXT,
+        timestamp TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    runSql(
+      'INSERT INTO events (type, aggregate_id, payload, timestamp) VALUES (?, ?, ?, ?)',
+      ['test.event', 'aggregate-1', '{}', '2026-04-13T10:00:00.000Z']
+    );
+
+    resetDatabase();
+
+    expect(queryOne<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'events'"
+    ) ?? undefined).toBeUndefined();
+  });
 });

--- a/src/__tests__/session-repository.test.ts
+++ b/src/__tests__/session-repository.test.ts
@@ -124,4 +124,58 @@ describe('Session Repository Upsert', () => {
     const fetched = sessionRepository.findBySessionId('session-completed-insert');
     expect(fetched?.completedAt?.toISOString()).toBe('2026-04-13T16:00:00.000Z');
   });
+
+  test('clears nullable activity fields when explicitly provided as undefined', () => {
+    sessionRepository.upsert({
+      sessionId: 'session-clear-nullable-fields',
+      directory: '/tmp/repo',
+      status: 'completed',
+      title: 'Clear fields',
+      initialPrompt: 'Prompt',
+      lastTool: 'Read',
+      lastToolInput: JSON.stringify({ path: '/tmp/repo/file.ts' }),
+      currentFile: '/tmp/repo/file.ts',
+      lastMessage: 'Done',
+      completedAt: new Date('2026-04-13T16:00:00.000Z'),
+      lastActiveAt: new Date('2026-04-13T16:00:00.000Z'),
+      agentId: 'agent-1',
+      parentSessionId: 'parent-1',
+      usageStats: {
+        totalInputTokens: 10,
+        totalOutputTokens: 20,
+        totalTokens: 30,
+        totalCost: 0.12,
+        apiCalls: 1,
+      },
+      toolCalls: [
+        { name: 'Read', input: { path: '/tmp/repo/file.ts' }, timestamp: '2026-04-13T15:59:00.000Z' },
+      ],
+    });
+
+    sessionRepository.upsert({
+      sessionId: 'session-clear-nullable-fields',
+      title: 'Still preserves omitted title updates',
+      lastTool: undefined,
+      lastToolInput: undefined,
+      currentFile: undefined,
+      lastMessage: undefined,
+      completedAt: undefined,
+      agentId: undefined,
+      parentSessionId: undefined,
+      usageStats: undefined,
+      toolCalls: undefined,
+    });
+
+    const fetched = sessionRepository.findBySessionId('session-clear-nullable-fields');
+    expect(fetched?.title).toBe('Still preserves omitted title updates');
+    expect(fetched?.lastTool).toBeUndefined();
+    expect(fetched?.lastToolInput).toBeUndefined();
+    expect(fetched?.currentFile).toBeUndefined();
+    expect(fetched?.lastMessage).toBeUndefined();
+    expect(fetched?.completedAt).toBeUndefined();
+    expect(fetched?.agentId).toBeUndefined();
+    expect(fetched?.parentSessionId).toBeUndefined();
+    expect(fetched?.usageStats).toBeUndefined();
+    expect(fetched?.toolCalls).toBeUndefined();
+  });
 });

--- a/src/__tests__/session.process-matcher.test.ts
+++ b/src/__tests__/session.process-matcher.test.ts
@@ -49,6 +49,27 @@ describe('matchProcessesToSessions', () => {
     expect(matches.get('session-b')?.pid).toBe(1002);
   });
 
+  test('does not preserve a reused PID when process start time is incompatible', () => {
+    const base = Date.now();
+    const sessions = [
+      sessionCandidate({
+        sessionId: 'stale-known-pid',
+        pid: 1001,
+        startedAt: new Date(base - 4 * 60 * 60 * 1000),
+        lastActiveAt: new Date(base - 3 * 60 * 60 * 1000),
+      }),
+    ];
+    const processes = [
+      processCandidate({
+        pid: 1001,
+        startTime: new Date(base),
+      }),
+    ];
+
+    const matches = matchProcessesToSessions(sessions, processes);
+    expect(matches.has('stale-known-pid')).toBe(false);
+  });
+
   test('matches same-directory sessions by closest start time', () => {
     const base = Date.now();
     const sessions = [

--- a/src/__tests__/sessions.route-basic.test.ts
+++ b/src/__tests__/sessions.route-basic.test.ts
@@ -347,6 +347,42 @@ describe('Basic Sessions Route Contract', () => {
     expect(body.data).toBeUndefined();
   });
 
+  test('rejects invalid limit instead of returning a misleading empty page', async () => {
+    const { token } = await setupUser('invalid-limit-route-user', 'password123');
+    const response = await sessions.fetch(new Request(
+      'http://localhost/?skipSync=true&fields=basic&limit=abc',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(400);
+
+    const body = await response.json() as {
+      success: boolean;
+      error: string;
+    };
+
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Invalid limit');
+  });
+
+  test('rejects invalid offset instead of returning a misleading page', async () => {
+    const { token } = await setupUser('invalid-offset-route-user', 'password123');
+    const response = await sessions.fetch(new Request(
+      'http://localhost/?skipSync=true&fields=basic&offset=-1',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(400);
+
+    const body = await response.json() as {
+      success: boolean;
+      error: string;
+    };
+
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Invalid offset');
+  });
+
   test('runtime filter composes with project, status, search, and pagination', async () => {
     const target = makeGitProject('keepline-runtime-target-');
     const other = makeGitProject('keepline-runtime-other-');

--- a/src/__tests__/usage.extractor.test.ts
+++ b/src/__tests__/usage.extractor.test.ts
@@ -2,9 +2,14 @@
  * Tests for token usage extraction from JSONL data
  */
 
-import { describe, test, expect } from 'bun:test'
+import { afterEach, describe, test, expect } from 'bun:test'
 import { extractUsageFromEntries, aggregateUsageStats } from '../services/usage.extractor.js'
+import { resetPricingForTests } from '../services/usage.pricing.js'
 import type { ClaudeAssistantEntry } from '../adapters/claude/types.js'
+
+afterEach(() => {
+  resetPricingForTests()
+})
 
 // Helper to create a mock assistant entry with usage
 function createAssistantEntry(
@@ -137,5 +142,19 @@ describe('aggregateUsageStats', () => {
     expect(stats.totalCost).toBe(0)
     expect(stats.apiCalls).toBe(0)
     expect(stats.modelBreakdown).toEqual([])
+  })
+
+  test('uses refreshed pricing for repeated model aggregation', () => {
+    const entries = [createAssistantEntry('priced-model', 1_000_000, 1_000_000)]
+
+    resetPricingForTests({
+      'priced-model': { inputPerMillion: 1, outputPerMillion: 2 },
+    })
+    expect(aggregateUsageStats(entries).totalCost).toBe(3)
+
+    resetPricingForTests({
+      'priced-model': { inputPerMillion: 10, outputPerMillion: 20 },
+    })
+    expect(aggregateUsageStats(entries).totalCost).toBe(30)
   })
 })

--- a/src/__tests__/usage.pricing.test.ts
+++ b/src/__tests__/usage.pricing.test.ts
@@ -2,12 +2,19 @@
  * Tests for pricing module
  */
 
-import { describe, test, expect, beforeAll } from 'bun:test'
-import { getModelPricing, calculateCost, FALLBACK_PRICING, initPricing } from '../services/usage.pricing.js'
+import { beforeEach, describe, test, expect } from 'bun:test'
+import {
+  DEFAULT_PRICING,
+  FALLBACK_PRICING,
+  calculateCost,
+  getModelPricing,
+  pricingConfigFromLiteLLMData,
+  resetPricingForTests,
+} from '../services/usage.pricing.js'
+import { logger } from '../lib/logger.js'
 
-// Initialize pricing before tests (uses defaults if fetch fails)
-beforeAll(async () => {
-  await initPricing()
+beforeEach(() => {
+  resetPricingForTests(DEFAULT_PRICING)
 })
 
 describe('getModelPricing', () => {
@@ -39,6 +46,61 @@ describe('getModelPricing', () => {
   test('returns fallback pricing for completely unknown model', () => {
     const pricing = getModelPricing('unknown-model-xyz')
     expect(pricing).toEqual(FALLBACK_PRICING)
+  })
+
+  test('keeps non-Anthropic LiteLLM pricing entries', () => {
+    const pricing = pricingConfigFromLiteLLMData({
+      'openai/gpt-4o-mini': {
+        litellm_provider: 'openai',
+        input_cost_per_token: 0.00000015,
+        output_cost_per_token: 0.0000006,
+      },
+      'claude/claude-3-5-sonnet-20241022': {
+        litellm_provider: 'anthropic',
+        input_cost_per_token: 0.000003,
+        output_cost_per_token: 0.000015,
+      },
+      'openai/free-embedding': {
+        litellm_provider: 'openai',
+        input_cost_per_token: 0,
+      },
+    })
+
+    expect(pricing['openai/gpt-4o-mini']).toEqual({
+      inputPerMillion: 0.15,
+      outputPerMillion: 0.6,
+    })
+    expect(pricing['claude/claude-3-5-sonnet-20241022']).toEqual({
+      inputPerMillion: 3,
+      outputPerMillion: 15,
+    })
+    expect(pricing['openai/free-embedding']).toBeUndefined()
+  })
+
+  test('logs fallback pricing for unknown models once per model', () => {
+    const warnings: Array<{ message: string; data: unknown }> = []
+    const originalWarn = logger.warn.bind(logger)
+    logger.warn = ((message: string, data?: unknown) => {
+      warnings.push({ message, data })
+    }) as typeof logger.warn
+
+    try {
+      getModelPricing('unknown-model-abc')
+      getModelPricing('unknown-model-abc')
+      getModelPricing('unknown-model-def')
+    } finally {
+      logger.warn = originalWarn
+    }
+
+    expect(warnings).toHaveLength(2)
+    expect(warnings[0]).toEqual({
+      message: 'Using fallback pricing for unknown model',
+      data: { model: 'unknown-model-abc' },
+    })
+    expect(warnings[1]).toEqual({
+      message: 'Using fallback pricing for unknown model',
+      data: { model: 'unknown-model-def' },
+    })
   })
 })
 

--- a/src/adapters/codex/parser.ts
+++ b/src/adapters/codex/parser.ts
@@ -7,6 +7,11 @@ import { createInterface } from 'readline';
 import { ParseError } from '../../lib/errors.js';
 import type { ToolCallInfo } from '../../domain/session/index.js';
 import type { CodexJsonlEntry, CodexParsedSessionData } from './types.js';
+import {
+  addUsageToAccumulator,
+  createUsageAccumulator,
+  usageStatsFromAccumulator,
+} from '../../services/usage.extractor.js';
 
 export interface ParseCodexSessionOptions {
   includeToolCalls?: boolean;
@@ -27,6 +32,7 @@ interface CodexAccumulator {
   lastActiveAtMs: number;
   toolCalls: ToolCallInfo[];
   includeToolCalls: boolean;
+  usageAccumulator: ReturnType<typeof createUsageAccumulator>;
 }
 
 export function scopeCodexSessionId(rawSessionId: string): string {
@@ -110,6 +116,7 @@ function createAccumulator(entry: CodexJsonlEntry, includeToolCalls: boolean): C
     lastActiveAtMs: startedAtMs ?? Date.now(),
     toolCalls: [],
     includeToolCalls,
+    usageAccumulator: createUsageAccumulator(),
   };
 }
 
@@ -163,6 +170,92 @@ function accumulateResponseItem(accumulator: CodexAccumulator, entry: CodexJsonl
   }
 }
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function numberField(record: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
+function stringField(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return undefined;
+}
+
+function findUsageRecord(payload: Record<string, unknown>): {
+  source: Record<string, unknown>;
+  usage: Record<string, unknown>;
+} | undefined {
+  const directUsage = asRecord(payload.usage);
+  if (directUsage) return { source: payload, usage: directUsage };
+
+  for (const key of ['msg', 'message', 'event', 'data']) {
+    const nested = asRecord(payload[key]);
+    const nestedUsage = nested ? asRecord(nested.usage) : undefined;
+    if (nested && nestedUsage) return { source: nested, usage: nestedUsage };
+  }
+
+  return undefined;
+}
+
+function accumulateCodexUsageEvent(accumulator: CodexAccumulator, entry: CodexJsonlEntry): void {
+  const payload = entry.payload;
+  if (!payload) return;
+
+  const usageRecord = findUsageRecord(payload);
+  if (!usageRecord) return;
+
+  const inputTokens = numberField(usageRecord.usage, [
+    'input_tokens',
+    'inputTokens',
+    'prompt_tokens',
+    'promptTokens',
+  ]);
+  const outputTokens = numberField(usageRecord.usage, [
+    'output_tokens',
+    'outputTokens',
+    'completion_tokens',
+    'completionTokens',
+  ]);
+
+  if (inputTokens === undefined || outputTokens === undefined) {
+    return;
+  }
+
+  const cacheCreationTokens = numberField(usageRecord.usage, [
+    'cache_creation_input_tokens',
+    'cacheCreationInputTokens',
+    'cache_write_input_tokens',
+    'cacheWriteInputTokens',
+    'cacheWriteTokens',
+  ]) ?? 0;
+  const cacheReadTokens = numberField(usageRecord.usage, [
+    'cache_read_input_tokens',
+    'cacheReadInputTokens',
+    'cacheReadTokens',
+  ]) ?? 0;
+  const model = stringField(usageRecord.source, ['model', 'modelName', 'model_name']) ??
+    stringField(usageRecord.usage, ['model', 'modelName', 'model_name']) ??
+    'codex-unknown';
+
+  addUsageToAccumulator(accumulator.usageAccumulator, model, {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    cache_creation_input_tokens: cacheCreationTokens,
+    cache_read_input_tokens: cacheReadTokens,
+  });
+}
+
 function finalizeAccumulator(accumulator: CodexAccumulator): CodexParsedSessionData {
   return {
     client: 'codex',
@@ -179,6 +272,9 @@ function finalizeAccumulator(accumulator: CodexAccumulator): CodexParsedSessionD
     startedAt: accumulator.startedAtMs === undefined ? undefined : new Date(accumulator.startedAtMs),
     lastActiveAt: new Date(accumulator.lastActiveAtMs),
     toolCalls: accumulator.includeToolCalls ? accumulator.toolCalls : undefined,
+    usageStats: accumulator.usageAccumulator.apiCalls === 0
+      ? undefined
+      : usageStatsFromAccumulator(accumulator.usageAccumulator),
   };
 }
 
@@ -217,6 +313,9 @@ export async function parseCodexSessionFile(
     if (!accumulator) continue;
     if (entry.type === 'response_item') {
       accumulateResponseItem(accumulator, entry);
+    } else if (entry.type === 'event_msg') {
+      accumulateCodexUsageEvent(accumulator, entry);
+      updateTimestamp(accumulator, entry.timestamp);
     } else {
       updateTimestamp(accumulator, entry.timestamp);
     }

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -25,6 +25,7 @@ export function resetDatabase(): void {
     DROP TABLE IF EXISTS session_memories;
     DROP TABLE IF EXISTS tool_usage;
     DROP TABLE IF EXISTS hook_events;
+    DROP TABLE IF EXISTS events;
     DROP TABLE IF EXISTS sessions;
     DROP TABLE IF EXISTS metadata;
     DROP TABLE IF EXISTS schema_migrations;

--- a/src/infrastructure/database/repositories/session.repository.ts
+++ b/src/infrastructure/database/repositories/session.repository.ts
@@ -302,32 +302,41 @@ class SessionRepository implements ISessionRepository {
     return transaction(() => {
       const hasPid = 'pid' in data;
       const hasTty = 'tty' in data;
+      const hasLastTool = 'lastTool' in data;
+      const hasLastToolInput = 'lastToolInput' in data;
+      const hasCurrentFile = 'currentFile' in data;
+      const hasLastMessage = 'lastMessage' in data;
+      const hasCompletedAt = 'completedAt' in data;
+      const hasAgentId = 'agentId' in data;
+      const hasParentSessionId = 'parentSessionId' in data;
+      const hasUsageStats = 'usageStats' in data;
+      const hasToolCalls = 'toolCalls' in data;
       const updateResult = db.prepare(`
         UPDATE sessions SET
           status = COALESCE(?, status),
           client = COALESCE(?, client),
           title = COALESCE(?, title),
           initial_prompt = COALESCE(?, initial_prompt),
-          last_tool = COALESCE(?, last_tool),
-          last_tool_input = COALESCE(?, last_tool_input),
-          current_file = COALESCE(?, current_file),
-          last_message = COALESCE(?, last_message),
+          last_tool = CASE WHEN ? THEN ? ELSE last_tool END,
+          last_tool_input = CASE WHEN ? THEN ? ELSE last_tool_input END,
+          current_file = CASE WHEN ? THEN ? ELSE current_file END,
+          last_message = CASE WHEN ? THEN ? ELSE last_message END,
           started_at = COALESCE(?, started_at),
           last_active_at = COALESCE(?, last_active_at),
-          completed_at = COALESCE(?, completed_at),
+          completed_at = CASE WHEN ? THEN ? ELSE completed_at END,
           pid = CASE WHEN ? THEN ? ELSE pid END,
           tty = CASE WHEN ? THEN ? ELSE tty END,
           tool_count = COALESCE(?, tool_count),
           message_count = COALESCE(?, message_count),
-          agent_id = COALESCE(?, agent_id),
-          parent_session_id = COALESCE(?, parent_session_id),
+          agent_id = CASE WHEN ? THEN ? ELSE agent_id END,
+          parent_session_id = CASE WHEN ? THEN ? ELSE parent_session_id END,
           is_sub_agent = COALESCE(?, is_sub_agent),
-          total_input_tokens = COALESCE(?, total_input_tokens),
-          total_output_tokens = COALESCE(?, total_output_tokens),
-          total_tokens = COALESCE(?, total_tokens),
-          total_cost = COALESCE(?, total_cost),
-          api_calls = COALESCE(?, api_calls),
-          tool_calls = COALESCE(?, tool_calls),
+          total_input_tokens = CASE WHEN ? THEN ? ELSE total_input_tokens END,
+          total_output_tokens = CASE WHEN ? THEN ? ELSE total_output_tokens END,
+          total_tokens = CASE WHEN ? THEN ? ELSE total_tokens END,
+          total_cost = CASE WHEN ? THEN ? ELSE total_cost END,
+          api_calls = CASE WHEN ? THEN ? ELSE api_calls END,
+          tool_calls = CASE WHEN ? THEN ? ELSE tool_calls END,
           updated_at = ?
         WHERE session_id = ?
       `).run(
@@ -335,12 +344,17 @@ class SessionRepository implements ISessionRepository {
         data.client ?? null,
         data.title ?? null,
         data.initialPrompt ?? null,
+        hasLastTool ? 1 : 0,
         data.lastTool ?? null,
+        hasLastToolInput ? 1 : 0,
         data.lastToolInput ?? null,
+        hasCurrentFile ? 1 : 0,
         data.currentFile ?? null,
+        hasLastMessage ? 1 : 0,
         data.lastMessage ?? null,
         data.startedAt?.toISOString() ?? null,
         data.lastActiveAt?.toISOString() ?? null,
+        hasCompletedAt ? 1 : 0,
         data.completedAt?.toISOString() ?? null,
         hasPid ? 1 : 0,
         data.pid ?? null,
@@ -348,14 +362,22 @@ class SessionRepository implements ISessionRepository {
         data.tty ?? null,
         data.toolCount ?? null,
         data.messageCount ?? null,
+        hasAgentId ? 1 : 0,
         data.agentId ?? null,
+        hasParentSessionId ? 1 : 0,
         data.parentSessionId ?? null,
         data.isSubAgent != null ? (data.isSubAgent ? 1 : 0) : null,
+        hasUsageStats ? 1 : 0,
         data.usageStats?.totalInputTokens ?? null,
+        hasUsageStats ? 1 : 0,
         data.usageStats?.totalOutputTokens ?? null,
+        hasUsageStats ? 1 : 0,
         data.usageStats?.totalTokens ?? null,
+        hasUsageStats ? 1 : 0,
         data.usageStats?.totalCost ?? null,
+        hasUsageStats ? 1 : 0,
         data.usageStats?.apiCalls ?? null,
+        hasToolCalls ? 1 : 0,
         data.toolCalls ? JSON.stringify(data.toolCalls) : null,
         now,
         data.sessionId

--- a/src/infrastructure/database/sqlite.ts
+++ b/src/infrastructure/database/sqlite.ts
@@ -25,6 +25,7 @@ export function getDatabase(): Database {
 
     db = new Database(KEEPLINE_DB);
     db.exec('PRAGMA journal_mode = WAL');
+    db.exec('PRAGMA busy_timeout = 5000');
     db.exec('PRAGMA foreign_keys = ON');
 
     logger.debug('Database connection established');

--- a/src/services/daemon.scheduler.ts
+++ b/src/services/daemon.scheduler.ts
@@ -10,6 +10,7 @@ import { runMigrations } from '../db/migrations.js';
 import { closeDatabase } from '../infrastructure/database/sqlite.js';
 import { emit } from '../lib/events.js';
 import { initializeMemoryService } from './memory.service.js';
+import { initPricing } from './usage.pricing.js';
 
 let scanInterval: NodeJS.Timeout | null = null;
 let isRunning = false;
@@ -39,6 +40,10 @@ export async function startScheduler(): Promise<void> {
 
   // Initialize database
   runMigrations();
+
+  // Initialize pricing before scan cycles. The pricing module falls back to
+  // defaults if remote LiteLLM pricing cannot be fetched.
+  await initPricing();
 
   // Initialize memory service (must be before hook server)
   initializeMemoryService();
@@ -97,15 +102,23 @@ export async function runDaemon(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 
   // Handle uncaught errors
+  const exitOnFatalError = async (error: Error, context: string): Promise<void> => {
+    try {
+      logger.error(`Fatal daemon error: ${context}`, error);
+      emit('error', { error, context });
+      await stopScheduler();
+    } finally {
+      process.exit(1);
+    }
+  };
+
   process.on('uncaughtException', (error) => {
-    logger.error('Uncaught exception', error);
-    emit('error', { error, context: 'uncaught_exception' });
+    void exitOnFatalError(error, 'uncaught_exception');
   });
 
   process.on('unhandledRejection', (reason) => {
     const error = reason instanceof Error ? reason : new Error(String(reason));
-    logger.error('Unhandled rejection', error);
-    emit('error', { error, context: 'unhandled_rejection' });
+    void exitOnFatalError(error, 'unhandled_rejection');
   });
 
   // Start scheduler

--- a/src/services/session.process-matcher.ts
+++ b/src/services/session.process-matcher.ts
@@ -16,6 +16,7 @@ import type { AgentClient } from '../domain/session/index.js';
 const UNMATCHED_PROCESS_PENALTY = 30 * 24 * 60 * 60 * 1000;
 const MAX_ACTIVITY_AGE_PENALTY = 24 * 60 * 60 * 1000;
 const START_TIME_WEIGHT = 10;
+const PID_REUSE_START_TOLERANCE_MS = 60 * 1000;
 
 export interface SessionProcessCandidate {
   sessionId: string;
@@ -69,6 +70,14 @@ function compareCandidates<T extends SessionProcessCandidate>(
     return right.meta.lastActiveAtMs - left.meta.lastActiveAtMs;
   }
   return left.meta.session.sessionId.localeCompare(right.meta.session.sessionId);
+}
+
+function isPidContinuityCompatible(
+  session: SessionProcessCandidate,
+  process: ClaudeProcessInfo
+): boolean {
+  return process.startTime.getTime() <=
+    session.lastActiveAt.getTime() + PID_REUSE_START_TOLERANCE_MS;
 }
 
 function selectCandidateSessions<T extends SessionProcessCandidate>(
@@ -217,6 +226,10 @@ export function matchProcessesToSessions<T extends SessionProcessCandidate>(
         const process = processByPid.get(session.pid);
         if (!process || usedProcessPids.has(process.pid)) {
           unmatchedSessions.push(session);
+          continue;
+        }
+
+        if (!isPidContinuityCompatible(session, process)) {
           continue;
         }
 

--- a/src/services/usage.extractor.ts
+++ b/src/services/usage.extractor.ts
@@ -58,21 +58,12 @@ export function createUsageAccumulator(): UsageAccumulator {
   }
 }
 
-const resolvedUsageCostModels = new Map<string, UsageCostModel>()
-
 function getUsageCostModel(model: string): UsageCostModel {
-  const cached = resolvedUsageCostModels.get(model)
-  if (cached) {
-    return cached
-  }
-
   const pricing = getModelPricing(model)
-  const costModel = {
+  return {
     inputPerToken: pricing.inputPerMillion / 1_000_000,
     outputPerToken: pricing.outputPerMillion / 1_000_000,
   }
-  resolvedUsageCostModels.set(model, costModel)
-  return costModel
 }
 
 export function addUsageToAccumulator(

--- a/src/services/usage.pricing.ts
+++ b/src/services/usage.pricing.ts
@@ -15,7 +15,7 @@ let cacheTime: number = 0
 const CACHE_TTL = 24 * 60 * 60 * 1000 // 24 hours
 
 /** LiteLLM model entry structure */
-interface LiteLLMModelEntry {
+export interface LiteLLMModelEntry {
   input_cost_per_token?: number
   output_cost_per_token?: number
   litellm_provider?: string
@@ -51,6 +51,29 @@ export const DEFAULT_PRICING: PricingConfig = {
   'claude-sonnet-4-5-20250929': { inputPerMillion: 3.0, outputPerMillion: 15.0 },
 }
 
+const fallbackWarningModels = new Set<string>()
+
+/** Convert LiteLLM model price data to Keepline pricing config. */
+export function pricingConfigFromLiteLLMData(
+  data: Record<string, LiteLLMModelEntry>
+): PricingConfig {
+  const pricing: PricingConfig = {}
+
+  for (const [modelId, entry] of Object.entries(data)) {
+    if (
+      entry.input_cost_per_token !== undefined &&
+      entry.output_cost_per_token !== undefined
+    ) {
+      pricing[modelId] = {
+        inputPerMillion: entry.input_cost_per_token * 1_000_000,
+        outputPerMillion: entry.output_cost_per_token * 1_000_000,
+      }
+    }
+  }
+
+  return pricing
+}
+
 /** Fetch pricing from LiteLLM */
 async function fetchLiteLLMPricing(): Promise<PricingConfig> {
   try {
@@ -60,25 +83,7 @@ async function fetchLiteLLMPricing(): Promise<PricingConfig> {
     }
 
     const data = (await response.json()) as Record<string, LiteLLMModelEntry>
-    const pricing: PricingConfig = {}
-
-    // Extract Claude models from Anthropic provider
-    for (const [modelId, entry] of Object.entries(data)) {
-      // Only process Anthropic models
-      if (
-        entry.litellm_provider === 'anthropic' &&
-        entry.input_cost_per_token !== undefined &&
-        entry.output_cost_per_token !== undefined
-      ) {
-        // Convert per-token cost to per-million cost
-        pricing[modelId] = {
-          inputPerMillion: entry.input_cost_per_token * 1_000_000,
-          outputPerMillion: entry.output_cost_per_token * 1_000_000,
-        }
-      }
-    }
-
-    return pricing
+    return pricingConfigFromLiteLLMData(data)
   } catch (error) {
     logger.warn('Failed to fetch LiteLLM pricing, using defaults', error)
     return DEFAULT_PRICING
@@ -137,6 +142,11 @@ export function getModelPricing(model: string): ModelPricing {
     return pricing['claude/claude-3-5-sonnet-20241022'] || pricing['claude-3-5-sonnet-20241022'] || { inputPerMillion: 3.0, outputPerMillion: 15.0 }
   }
 
+  if (!fallbackWarningModels.has(model)) {
+    fallbackWarningModels.add(model)
+    logger.warn('Using fallback pricing for unknown model', { model })
+  }
+
   return FALLBACK_PRICING
 }
 
@@ -178,4 +188,11 @@ export function calculateCostWithCache(
 /** Initialize pricing (call at startup) */
 export async function initPricing(): Promise<void> {
   await getPricingConfig()
+}
+
+/** Reset pricing internals for focused tests. */
+export function resetPricingForTests(pricing?: PricingConfig): void {
+  cachedPricing = pricing ?? null
+  cacheTime = pricing ? Date.now() : 0
+  fallbackWarningModels.clear()
 }

--- a/src/web/api/routes/sessions.ts
+++ b/src/web/api/routes/sessions.ts
@@ -60,6 +60,8 @@ type SearchableSession = {
 };
 
 const VALID_STATUSES = new Set(['running', 'waiting', 'idle', 'lost', 'completed']);
+const DEFAULT_SESSION_LIMIT = 50;
+const MAX_SESSION_LIMIT = 100;
 
 function parseStatusFilters(url: string): { filters: Set<string>; invalid: string[] } {
   const params = new URL(url).searchParams;
@@ -77,6 +79,36 @@ function parseStatusFilters(url: string): { filters: Set<string>; invalid: strin
   }
 
   return { filters, invalid: [...invalid] };
+}
+
+function parseIntegerQueryParam(
+  value: string | undefined,
+  defaultValue: number
+): number | null {
+  if (value === undefined) return defaultValue;
+  if (!/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function parsePaginationParams(limitParam: string | undefined, offsetParam: string | undefined):
+  | { valid: true; limit: number; offset: number }
+  | { valid: false; error: string } {
+  const rawLimit = parseIntegerQueryParam(limitParam, DEFAULT_SESSION_LIMIT);
+  if (rawLimit === null || rawLimit < 1) {
+    return { valid: false, error: 'Invalid limit. Must be an integer between 1 and 100.' };
+  }
+
+  const offset = parseIntegerQueryParam(offsetParam, 0);
+  if (offset === null) {
+    return { valid: false, error: 'Invalid offset. Must be a non-negative integer.' };
+  }
+
+  return {
+    valid: true,
+    limit: Math.min(rawLimit, MAX_SESSION_LIMIT),
+    offset,
+  };
 }
 
 function matchesSessionQuery(session: SearchableSession, query: string): boolean {
@@ -121,8 +153,14 @@ async function backgroundSync() {
 app.get('/', async (c) => {
   try {
     // Parse pagination parameters
-    const limit = Math.min(parseInt(c.req.query('limit') || '50'), 100);
-    const offset = parseInt(c.req.query('offset') || '0');
+    const pagination = parsePaginationParams(c.req.query('limit'), c.req.query('offset'));
+    if (!pagination.valid) {
+      return c.json({
+        success: false,
+        error: pagination.error,
+      }, 400);
+    }
+    const { limit, offset } = pagination;
     const statusParseResult = parseStatusFilters(c.req.url);
     if (statusParseResult.invalid.length > 0) {
       return c.json({


### PR DESCRIPTION
## Summary

Refs #82.

This is a bounded GH82 tranche, not a full closure of the P2 rollup. It adds the GH82 SpecRail packet and fixes the high-confidence items that do not duplicate the existing P0/P1 PRs.

Changes:
- parse supported Codex `event_msg` usage telemetry into persisted session `usageStats`
- retain non-Anthropic LiteLLM pricing entries, warn once on unknown model fallback, and remove the usage extractor's forever pricing cache
- initialize pricing in daemon startup and make fatal daemon errors stop and exit instead of continuing silently
- set SQLite `busy_timeout = 5000`
- reject invalid session list `limit` / `offset` with HTTP 400
- avoid PID-continuity matches when a reused PID has an incompatible start time
- allow explicit clearing of nullable session activity/usage fields in repository upsert
- drop optional `events` table from `resetDatabase()`

Out of scope in this tranche:
- GH74 LanceDB predicate hardening is already covered by PR #84
- GH75 hook pipeline behavior is already covered by PR #87
- GH78-GH81 are covered by PRs #90-#93
- frontend runtime validation, status display convergence, env/config consolidation, and adapter layer refactors need separate follow-up slices

## Verification

- `bun test src/__tests__/codex.parser.test.ts src/__tests__/usage.pricing.test.ts src/__tests__/usage.extractor.test.ts`
- `bun test src/__tests__/sessions.route-basic.test.ts src/__tests__/session.process-matcher.test.ts src/__tests__/session-repository.test.ts src/__tests__/reset-database.test.ts`
- `bun run typecheck`
- `bun test`
- `bun run build`
- `git diff --check`
- `checks/check_workflow.py` is not present in this repository, so the SpecRail workflow checker is N/A for this branch.
