### PR TITLE
fix: LanceDB 过滤器注入 (#74) + completed 会话被 sync 回滚 (#77)

### DIFF
--- a/src/__tests__/lancedb.filter-injection.test.ts
+++ b/src/__tests__/lancedb.filter-injection.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression tests for LanceDB filter-DSL injection (GH #74).
+ *
+ * getById/getBySessionId/delete/deleteBySessionId interpolate their argument
+ * into a Datafusion SQL filter literal. Datafusion escapes a single quote by
+ * doubling it (backslash is not an escape char), so escapeFilterLiteral must
+ * neutralize any embedded quote before interpolation.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { escapeFilterLiteral } from '../infrastructure/vector/lancedb.adapter.js';
+
+describe('LanceDB filter injection (GH #74)', () => {
+  test('doubles single quotes so the payload cannot break out of the literal', () => {
+    const malicious = "x' OR '1'='1";
+    const escaped = escapeFilterLiteral(malicious);
+
+    // Every quote is doubled → the whole value stays inside one string literal.
+    expect(escaped).toBe("x'' OR ''1''=''1");
+
+    const filter = `id = '${escaped}'`;
+    // No lone (odd) quote remains that could terminate the literal early.
+    const loneQuotes = filter.replace(/''/g, '').match(/'/g)?.length ?? 0;
+    // Only the two delimiter quotes survive after collapsing escaped pairs.
+    expect(loneQuotes).toBe(2);
+    expect(filter).toBe("id = 'x'' OR ''1''=''1'");
+  });
+
+  test('leaves injection-free ids unchanged', () => {
+    expect(escapeFilterLiteral('obs-123_ABC')).toBe('obs-123_ABC');
+  });
+
+  test('neutralizes a mass-delete payload', () => {
+    // `' OR '1'='1` is the classic "delete everything" filter.
+    const filter = `id = '${escapeFilterLiteral("' OR '1'='1")}'`;
+    expect(filter).toBe("id = ''' OR ''1''=''1'");
+    // The tautology `OR '1'='1'` no longer appears as evaluable SQL.
+    expect(filter).not.toContain("OR '1'='1'");
+  });
+
+  test('handles empty and quote-only inputs', () => {
+    expect(escapeFilterLiteral('')).toBe('');
+    expect(escapeFilterLiteral("'")).toBe("''");
+    expect(escapeFilterLiteral("''")).toBe("''''");
+  });
+});

--- a/src/__tests__/session.sync-preserves-completed.test.ts
+++ b/src/__tests__/session.sync-preserves-completed.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression test for GH #77: a session explicitly marked `completed` (by the
+ * user in the dashboard or via a Stop hook) must not be resurrected to
+ * lost/idle by a later sync. detectSessionStatus never returns 'completed',
+ * so syncSessions has to preserve the persisted terminal status itself.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+
+// Feed a single controlled Claude session through the scanner boundary, and
+// report no live processes so detectSessionStatus(null, ...) computes 'lost'.
+const COMPLETED_ID = 'completed-session-0001';
+
+mock.module('../adapters/process/scanner.js', () => ({
+  getCachedProcesses: () => [],
+  clearProcessCache: () => {},
+}));
+
+mock.module('../adapters/claude/scanner.js', () => ({
+  getAllSessionsWithFailures: async () => ({
+    sessions: [
+      {
+        sessionId: COMPLETED_ID,
+        client: 'claude',
+        directory: '/tmp/repo',
+        firstMessage: 'done task',
+        messageCount: 3,
+        toolCount: 2,
+        lastActiveAt: new Date('2020-01-01T00:00:00.000Z'), // stale
+      },
+    ],
+    failures: [],
+  }),
+}));
+
+mock.module('../adapters/codex/scanner.js', () => ({
+  getAllCodexSessionsWithFailures: async () => ({ sessions: [], failures: [] }),
+}));
+
+const { resetDatabase } = await import('../db/migrations.js');
+const { closeDatabase } = await import('../infrastructure/database/sqlite.js');
+const { sessionRepository } = await import(
+  '../infrastructure/database/repositories/session.repository.js'
+);
+const { syncSessions } = await import('../services/session.service.js');
+
+describe('syncSessions preserves completed status (GH #77)', () => {
+  beforeEach(() => {
+    resetDatabase();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test('a completed session is not reverted to lost by a later scan', async () => {
+    sessionRepository.upsert({
+      sessionId: COMPLETED_ID,
+      client: 'claude',
+      directory: '/tmp/repo',
+      status: 'completed',
+      title: 'Finished task',
+      initialPrompt: 'done task',
+      lastActiveAt: new Date('2020-01-01T00:00:00.000Z'),
+      toolCount: 2,
+      messageCount: 3,
+    });
+
+    await syncSessions();
+
+    const after = sessionRepository.findBySessionId(COMPLETED_ID);
+    expect(after?.status).toBe('completed');
+  });
+
+  test('a non-completed session with no process is still updated to lost', async () => {
+    sessionRepository.upsert({
+      sessionId: COMPLETED_ID,
+      client: 'claude',
+      directory: '/tmp/repo',
+      status: 'running',
+      title: 'Active task',
+      initialPrompt: 'done task',
+      lastActiveAt: new Date('2020-01-01T00:00:00.000Z'),
+      toolCount: 2,
+      messageCount: 3,
+    });
+
+    await syncSessions();
+
+    const after = sessionRepository.findBySessionId(COMPLETED_ID);
+    expect(after?.status).toBe('lost');
+  });
+});

--- a/src/infrastructure/vector/lancedb.adapter.ts
+++ b/src/infrastructure/vector/lancedb.adapter.ts
@@ -19,6 +19,16 @@ import type {
   ObservationCategory,
 } from './types.js';
 
+/**
+ * Escape a value for safe interpolation into a LanceDB (Datafusion) SQL filter
+ * literal. Datafusion follows SQL-standard string literals where a single quote
+ * is escaped by doubling it and backslash is not an escape character, so
+ * doubling quotes neutralizes filter-DSL injection (e.g. `x' OR '1'='1`).
+ */
+export function escapeFilterLiteral(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
 /** Default configuration */
 const DEFAULT_CONFIG: VectorStoreConfig = {
   path: join(KEEPLINE_HOME, 'lancedb'),
@@ -242,7 +252,7 @@ export class LanceDBVectorStore implements IVectorStore {
 
     const results = await this.table
       .query()
-      .where(`id = '${id}'`)
+      .where(`id = '${escapeFilterLiteral(id)}'`)
       .limit(1)
       .toArray();
 
@@ -260,7 +270,7 @@ export class LanceDBVectorStore implements IVectorStore {
 
     const results = await this.table
       .query()
-      .where(`sessionId = '${sessionId}'`)
+      .where(`sessionId = '${escapeFilterLiteral(sessionId)}'`)
       .toArray();
 
     return results.map((row) => fromRow(row as unknown as LanceDBRow));
@@ -274,7 +284,7 @@ export class LanceDBVectorStore implements IVectorStore {
     if (!this.table) return false;
 
     try {
-      await this.table.delete(`id = '${id}'`);
+      await this.table.delete(`id = '${escapeFilterLiteral(id)}'`);
       logger.debug(`Deleted observation ${id}`);
       return true;
     } catch (error) {
@@ -292,12 +302,13 @@ export class LanceDBVectorStore implements IVectorStore {
 
     try {
       // Get count before delete
+      const escaped = escapeFilterLiteral(sessionId);
       const before = await this.table
         .query()
-        .where(`sessionId = '${sessionId}'`)
+        .where(`sessionId = '${escaped}'`)
         .toArray();
 
-      await this.table.delete(`sessionId = '${sessionId}'`);
+      await this.table.delete(`sessionId = '${escaped}'`);
       logger.debug(`Deleted ${before.length} observations for session ${sessionId}`);
 
       return before.length;

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -203,8 +203,13 @@ export class SessionService {
         );
 
         if (existing) {
-          // Update existing session
-          const wasLost = existing.status !== 'lost' && status === 'lost';
+          // Update existing session. A session that was explicitly completed
+          // (by the user in the dashboard or via a Stop hook) must not be
+          // resurrected to lost/idle by a later scan — detectSessionStatus
+          // never returns 'completed', so preserve it here.
+          const effectiveStatus =
+            existing.status === 'completed' ? 'completed' : status;
+          const wasLost = existing.status !== 'lost' && effectiveStatus === 'lost';
 
           // Update title if current one is Unknown and we have new info
           const shouldUpdateTitle =
@@ -215,7 +220,7 @@ export class SessionService {
           const updatedSession = this.repository.upsert({
             sessionId: agentSession.sessionId,
             client,
-            status,
+            status: effectiveStatus,
             ...(shouldUpdateTitle && {
               title: generateTitle(agentSession.firstMessage!),
               initialPrompt: agentSession.firstMessage,


### PR DESCRIPTION
两个来自 codebase-audit 的独立修复,各带回归测试。

## #74 — LanceDB 过滤器注入(Critical / 安全)

`getById` / `getBySessionId` / `delete` / `deleteBySessionId` 把参数直接插值进 Datafusion SQL 过滤字面量,而 `/observations/:id` 路由对 `id` 无校验(对比 sessionId 路由都有 `isValidSessionId`)。`DELETE /api/memory/observations/x' OR '1'='1` 可删光整个向量记忆库,GET 变体可导出任意行。

**修复**:新增 `escapeFilterLiteral()`(SQL 标准单引号翻倍;Datafusion 不把反斜杠当转义符),在 adapter 层全部 4 个方法 / 5 处插值应用,不依赖调用方校验。

## #77 — completed 会话被 sync 回滚(P1)

sync 的 existing 分支无条件用 `detectSessionStatus` 重算 status,而它永不返回 `completed`。用户标记完成的会话,只要 JSONL 还在 7 天窗口内,下一轮 sync 无进程 → 算成 `lost` → 覆盖 `completed`。

**修复**:在 `syncSessions` 保留已持久化的 `completed` 终态,与展示层 aggregator 已有的守卫一致。

## 测试(先复现后修)

- `lancedb.filter-injection.test.ts` — 注入 payload 被引号翻倍中和;合法 id 不变。
- `session.sync-preserves-completed.test.ts` — `mock.module` 喂入无进程的 completed 会话,断言 sync 后仍 completed;对照组 running → lost,证明未过度保留。

## 验证

- `bun test`:363 pass / 0 fail
- `bun x tsc --noEmit`:exit 0

Closes #74
Closes #77
