### PR TITLE
fix(hook): 修复实时 hook 管道整体失效 (#75)

### DIFF
--- a/src/__tests__/hook.installer.test.ts
+++ b/src/__tests__/hook.installer.test.ts
@@ -4,47 +4,79 @@ import {
   isKeeplineHook,
   uninstallKeeplineHookConfig,
 } from '../adapters/hook/installer.js';
-import type { ClaudeSettings } from '../adapters/hook/types.js';
+import type { ClaudeSettings, ClaudeHookMatcher } from '../adapters/hook/types.js';
 
-const markedCommand = 'KEEPLINE_HOOK_MARKER=keepline-hook-v1 curl -s -X POST http://127.0.0.1:7890/hook';
-const unrelatedLocalhostCommand = 'curl -s http://127.0.0.1:7777/other-hook';
+const markedCommand =
+  "KEEPLINE_HOOK_MARKER=keepline-hook-v2 curl -s -X POST http://127.0.0.1:7890/hook -H 'Content-Type: application/json' --data-binary @- >/dev/null 2>&1 || true";
+const unrelatedBlock: ClaudeHookMatcher = {
+  hooks: [{ type: 'command', command: 'curl -s http://127.0.0.1:7777/other-hook' }],
+};
 const legacyKeeplineCommand = `curl -s -X POST http://127.0.0.1:7890/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
-const foreignLegacyShapeCommand = `curl -s -X POST https://collector.example/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
 
 describe('hook installer ownership detection', () => {
   test('does not claim unrelated localhost hooks', () => {
-    expect(isKeeplineHook({ command: unrelatedLocalhostCommand })).toBe(false);
+    expect(
+      isKeeplineHook({ type: 'command', command: 'curl -s http://127.0.0.1:7777/other-hook' })
+    ).toBe(false);
   });
 
   test('does not claim non-local legacy-shaped hooks', () => {
-    expect(isKeeplineHook({ command: foreignLegacyShapeCommand })).toBe(false);
+    const foreign = legacyKeeplineCommand.replace('127.0.0.1:7890', 'collector.example');
+    expect(isKeeplineHook({ type: 'command', command: foreign })).toBe(false);
   });
 
-  test('install coexists with unrelated localhost hooks', () => {
+  test('registers under PostToolUse, Stop and UserPromptSubmit using the nested shape', () => {
+    const settings: ClaudeSettings = {};
+
+    const changed = installKeeplineHookConfig(settings, markedCommand);
+
+    expect(changed).toBe(true);
+    for (const event of ['PostToolUse', 'Stop', 'UserPromptSubmit'] as const) {
+      const blocks = settings.hooks?.[event];
+      expect(blocks).toHaveLength(1);
+      const entry = blocks?.[0].hooks[0];
+      expect(entry?.type).toBe('command');
+      expect(entry?.command).toBe(markedCommand);
+    }
+  });
+
+  test('install is idempotent (no duplicate registration)', () => {
+    const settings: ClaudeSettings = {};
+    installKeeplineHookConfig(settings, markedCommand);
+
+    const changedAgain = installKeeplineHookConfig(settings, markedCommand);
+
+    expect(changedAgain).toBe(false);
+    expect(settings.hooks?.PostToolUse).toHaveLength(1);
+  });
+
+  test('install coexists with unrelated hooks in the same event', () => {
     const settings: ClaudeSettings = {
-      hooks: {
-        PostToolUse: [{ command: unrelatedLocalhostCommand }],
-      },
+      hooks: { PostToolUse: [unrelatedBlock] },
     };
 
     const changed = installKeeplineHookConfig(settings, markedCommand);
 
     expect(changed).toBe(true);
     expect(settings.hooks?.PostToolUse).toHaveLength(2);
-    expect(settings.hooks?.PostToolUse?.[0].command).toBe(unrelatedLocalhostCommand);
-    expect(settings.hooks?.PostToolUse?.[1].command).toBe(markedCommand);
+    expect(settings.hooks?.PostToolUse?.[0]).toEqual(unrelatedBlock);
+    expect(settings.hooks?.PostToolUse?.[1].hooks[0].command).toBe(markedCommand);
   });
 
-  test('uninstall removes only Keepline-owned hooks', () => {
+  test('uninstall removes only Keepline-owned hooks and drops empty blocks', () => {
     const settings: ClaudeSettings = {
       hooks: {
         PostToolUse: [
-          { command: unrelatedLocalhostCommand },
-          { command: markedCommand },
+          unrelatedBlock,
+          { hooks: [{ type: 'command', command: markedCommand }] },
         ],
         Stop: [
-          { command: legacyKeeplineCommand },
-          { command: 'echo keep-me' },
+          {
+            hooks: [
+              { type: 'command', command: legacyKeeplineCommand },
+              { type: 'command', command: 'echo keep-me' },
+            ],
+          },
         ],
       },
     };
@@ -52,20 +84,36 @@ describe('hook installer ownership detection', () => {
     const removed = uninstallKeeplineHookConfig(settings);
 
     expect(removed).toBe(2);
-    expect(settings.hooks?.PostToolUse).toEqual([{ command: unrelatedLocalhostCommand }]);
-    expect(settings.hooks?.Stop).toEqual([{ command: 'echo keep-me' }]);
+    // Keepline-only block dropped; unrelated block preserved.
+    expect(settings.hooks?.PostToolUse).toEqual([unrelatedBlock]);
+    // Mixed block keeps the non-Keepline hook only.
+    expect(settings.hooks?.Stop).toEqual([
+      { hooks: [{ type: 'command', command: 'echo keep-me' }] },
+    ]);
   });
 
-  test('install upgrades a legacy Keepline hook without duplicating', () => {
+  test('install upgrades a legacy Keepline hook in place without duplicating', () => {
     const settings: ClaudeSettings = {
       hooks: {
-        PostToolUse: [{ command: legacyKeeplineCommand }],
+        PostToolUse: [{ hooks: [{ type: 'command', command: legacyKeeplineCommand }] }],
       },
     };
 
     const changed = installKeeplineHookConfig(settings, markedCommand);
 
     expect(changed).toBe(true);
-    expect(settings.hooks?.PostToolUse).toEqual([{ command: markedCommand }]);
+    expect(settings.hooks?.PostToolUse).toHaveLength(1);
+    expect(settings.hooks?.PostToolUse?.[0].hooks[0].command).toBe(markedCommand);
+  });
+
+  test('generated command forwards stdin and does not rely on $CLAUDE_* env vars', () => {
+    const settings: ClaudeSettings = {};
+    installKeeplineHookConfig(settings);
+    const command = settings.hooks?.PostToolUse?.[0].hooks[0].command ?? '';
+
+    expect(command).toContain('--data-binary @-');
+    expect(command).not.toContain('$CLAUDE_EVENT_TYPE');
+    expect(command).not.toContain('$CLAUDE_SESSION_ID');
+    expect(command).not.toContain('$CLAUDE_TOOL_INPUT');
   });
 });

--- a/src/__tests__/hook.server-parse.test.ts
+++ b/src/__tests__/hook.server-parse.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression tests for GH #75: the hook server must parse Claude Code's native
+ * stdin payload (`hook_event_name`, `tool_response`, ...) — not the old
+ * `event_type` shape that depended on non-existent `$CLAUDE_*` env vars.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { parseHookEvent } from '../adapters/hook/server.js';
+
+const SESSION = 'session-abcdef01';
+
+describe('parseHookEvent (GH #75)', () => {
+  test('parses a native PostToolUse payload', () => {
+    const event = parseHookEvent({
+      hook_event_name: 'PostToolUse',
+      session_id: SESSION,
+      cwd: '/tmp/repo',
+      tool_name: 'Edit',
+      tool_input: { file_path: '/tmp/repo/a.ts' },
+      tool_response: { content: 'ok' },
+    });
+
+    expect(event).not.toBeNull();
+    expect(event?.event_type).toBe('PostToolUse');
+    expect(event?.session_id).toBe(SESSION);
+    expect((event as { tool_name: string }).tool_name).toBe('Edit');
+    // tool output is normalized from tool_response and stringified.
+    expect((event as { tool_output?: string }).tool_output).toBe('{"content":"ok"}');
+    // timestamp is stamped on receipt (Claude does not send one).
+    expect(typeof event?.timestamp).toBe('string');
+  });
+
+  test('parses a native UserPromptSubmit payload', () => {
+    const event = parseHookEvent({
+      hook_event_name: 'UserPromptSubmit',
+      session_id: SESSION,
+      cwd: '/tmp/repo',
+      prompt: 'do the thing',
+    });
+
+    expect(event?.event_type).toBe('UserPromptSubmit');
+    expect((event as { prompt: string }).prompt).toBe('do the thing');
+  });
+
+  test('parses a native Stop payload', () => {
+    const event = parseHookEvent({
+      hook_event_name: 'Stop',
+      session_id: SESSION,
+      stop_reason: 'completed',
+    });
+
+    expect(event?.event_type).toBe('Stop');
+    expect((event as { reason?: string }).reason).toBe('completed');
+  });
+
+  test('rejects the legacy event_type shape (no hook_event_name)', () => {
+    expect(
+      parseHookEvent({
+        event_type: 'PostToolUse',
+        session_id: SESSION,
+        cwd: '/tmp/repo',
+        timestamp: '2026-01-01T00:00:00Z',
+        tool_name: 'Edit',
+        tool_input: {},
+      })
+    ).toBeNull();
+  });
+
+  test('rejects unknown event types, bad session ids and non-objects', () => {
+    expect(parseHookEvent({ hook_event_name: 'Bogus', session_id: SESSION })).toBeNull();
+    expect(parseHookEvent({ hook_event_name: 'Stop', session_id: "x' OR '1'='1" })).toBeNull();
+    expect(parseHookEvent(null)).toBeNull();
+    expect(parseHookEvent('not-an-object')).toBeNull();
+  });
+
+  test('rejects a tool event with no tool_name', () => {
+    expect(
+      parseHookEvent({ hook_event_name: 'PostToolUse', session_id: SESSION, tool_input: {} })
+    ).toBeNull();
+  });
+});

--- a/src/adapters/hook/installer.ts
+++ b/src/adapters/hook/installer.ts
@@ -1,15 +1,38 @@
 /**
  * Claude hooks installer
+ *
+ * Registers a Keepline hook under Claude Code's real settings shape:
+ *   hooks.<Event>[] = [{ matcher?, hooks: [{ type: "command", command }] }]
+ *
+ * The command forwards Claude's stdin hook JSON verbatim to the hook server;
+ * it does NOT rely on `$CLAUDE_*` environment variables (those do not exist —
+ * Claude Code delivers hook data on stdin only).
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { CLAUDE_SETTINGS } from '../../lib/paths.js';
 import { config } from '../../lib/config.js';
 import { logger } from '../../lib/logger.js';
-import type { ClaudeSettings, ClaudeHookConfig } from './types.js';
+import type {
+  ClaudeSettings,
+  ClaudeHookMatcher,
+  HookCommandEntry,
+  HookEventType,
+} from './types.js';
 
-const KEEPLINE_HOOK_MARKER = 'KEEPLINE_HOOK_MARKER=keepline-hook-v1';
-const HOOK_TYPES = ['PreToolUse', 'PostToolUse', 'Notification', 'Stop', 'UserPromptSubmit'] as const;
+const KEEPLINE_HOOK_MARKER = 'KEEPLINE_HOOK_MARKER=keepline-hook-v2';
+
+/** Event types Keepline registers a forwarding hook under */
+const KEEPLINE_EVENTS: HookEventType[] = ['PostToolUse', 'Stop', 'UserPromptSubmit'];
+
+/** Every event type we scan when uninstalling (covers historical registrations) */
+const ALL_HOOK_EVENTS: HookEventType[] = [
+  'PreToolUse',
+  'PostToolUse',
+  'Notification',
+  'Stop',
+  'UserPromptSubmit',
+];
 
 /** Get current Claude settings */
 function getClaudeSettings(): ClaudeSettings {
@@ -34,36 +57,55 @@ function saveClaudeSettings(settings: ClaudeSettings): void {
   writeFileSync(CLAUDE_SETTINGS, JSON.stringify(settings, null, 2));
 }
 
-/** Generate hook command */
+/**
+ * Generate the hook command.
+ *
+ * `--data-binary @-` forwards Claude's stdin JSON verbatim (no newline
+ * stripping, no urlencoding). The marker prefix is a harmless env assignment
+ * used only to identify Keepline-owned hooks in the settings file.
+ */
 function getHookCommand(): string {
   const port = config.get().hookPort;
-  return `${KEEPLINE_HOOK_MARKER} curl -s -X POST http://127.0.0.1:${port}/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
+  return `${KEEPLINE_HOOK_MARKER} curl -s -X POST http://127.0.0.1:${port}/hook -H 'Content-Type: application/json' --data-binary @- >/dev/null 2>&1 || true`;
 }
 
+/** Detect the pre-v2 command that (incorrectly) relied on `$CLAUDE_*` env vars */
 function isLegacyKeeplineHookCommand(command: string): boolean {
   return (
     command.includes('curl -s -X POST') &&
     /\bhttp:\/\/127\.0\.0\.1:\d+\/hook\b/.test(command) &&
     command.includes('"event_type":"$CLAUDE_EVENT_TYPE"') &&
-    command.includes('"session_id":"$CLAUDE_SESSION_ID"') &&
-    command.includes('"cwd":"$PWD"') &&
-    command.includes('"tool_name":"$CLAUDE_TOOL_NAME"') &&
-    command.includes('CLAUDE_TOOL_INPUT')
+    command.includes('"session_id":"$CLAUDE_SESSION_ID"')
   );
 }
 
-export function isKeeplineHook(hook: unknown): hook is ClaudeHookConfig {
-  if (
-    !hook ||
-    typeof hook !== 'object' ||
-    typeof (hook as Partial<ClaudeHookConfig>).command !== 'string'
-  ) {
-    return false;
-  }
-  const command = (hook as ClaudeHookConfig).command;
-  return command.includes(KEEPLINE_HOOK_MARKER) || isLegacyKeeplineHookCommand(command);
+/** Is this command string a Keepline-owned hook (any version)? */
+export function isKeeplineHookCommand(command: string): boolean {
+  return command.includes('KEEPLINE_HOOK_MARKER=') || isLegacyKeeplineHookCommand(command);
 }
 
+/** Is this settings hook entry a Keepline-owned command hook? */
+export function isKeeplineHook(hook: unknown): hook is HookCommandEntry {
+  if (!hook || typeof hook !== 'object') {
+    return false;
+  }
+  const command = (hook as Partial<HookCommandEntry>).command;
+  return typeof command === 'string' && isKeeplineHookCommand(command);
+}
+
+/** Find the Keepline-owned command entry among a list of matcher blocks */
+function findKeeplineEntry(blocks: ClaudeHookMatcher[]): HookCommandEntry | undefined {
+  for (const block of blocks) {
+    const entry = block.hooks?.find(isKeeplineHook);
+    if (entry) return entry;
+  }
+  return undefined;
+}
+
+/**
+ * Ensure a Keepline hook is registered under every KEEPLINE_EVENTS type.
+ * Returns true if the settings object was modified.
+ */
 export function installKeeplineHookConfig(
   settings: ClaudeSettings,
   hookCommand: string = getHookCommand()
@@ -72,50 +114,66 @@ export function installKeeplineHookConfig(
     settings.hooks = {};
   }
 
-  if (!settings.hooks.PostToolUse) {
-    settings.hooks.PostToolUse = [];
-  }
+  let changed = false;
 
-  const existingIndex = settings.hooks.PostToolUse.findIndex(isKeeplineHook);
-  const keeplineHook: ClaudeHookConfig = {
-    command: hookCommand,
-  };
+  for (const event of KEEPLINE_EVENTS) {
+    const blocks = settings.hooks[event] ?? (settings.hooks[event] = []);
+    const existing = findKeeplineEntry(blocks);
 
-  if (existingIndex >= 0) {
-    const existing = settings.hooks.PostToolUse[existingIndex];
-    if (existing.command !== hookCommand) {
-      settings.hooks.PostToolUse[existingIndex] = {
-        ...existing,
-        command: hookCommand,
-      };
-      return true;
+    if (existing) {
+      // Upgrade an older/legacy Keepline hook in place, without duplicating.
+      if (existing.command !== hookCommand || existing.type !== 'command') {
+        existing.command = hookCommand;
+        existing.type = 'command';
+        changed = true;
+      }
+    } else {
+      blocks.push({ hooks: [{ type: 'command', command: hookCommand }] });
+      changed = true;
     }
-    return false;
   }
 
-  settings.hooks.PostToolUse.push(keeplineHook);
-  return true;
+  return changed;
 }
 
+/**
+ * Remove every Keepline-owned command hook, preserving unrelated hooks and
+ * matcher blocks. Blocks that become empty (they were Keepline-only) are
+ * dropped. Returns the number of command hooks removed.
+ */
 export function uninstallKeeplineHookConfig(settings: ClaudeSettings): number {
   if (!settings.hooks) return 0;
 
   let removed = 0;
-  for (const hookType of HOOK_TYPES) {
-    const hooks = settings.hooks[hookType];
-    if (!hooks) continue;
-    const nextHooks = hooks.filter((hook) => !isKeeplineHook(hook));
-    removed += hooks.length - nextHooks.length;
-    settings.hooks[hookType] = nextHooks;
+
+  for (const event of ALL_HOOK_EVENTS) {
+    const blocks = settings.hooks[event];
+    if (!blocks) continue;
+
+    const nextBlocks: ClaudeHookMatcher[] = [];
+    for (const block of blocks) {
+      const originalHooks = block.hooks ?? [];
+      const keptHooks = originalHooks.filter((hook) => !isKeeplineHook(hook));
+      removed += originalHooks.length - keptHooks.length;
+
+      // Keep blocks that still hold unrelated hooks; drop Keepline-only blocks.
+      if (keptHooks.length > 0) {
+        nextBlocks.push({ ...block, hooks: keptHooks });
+      }
+    }
+
+    settings.hooks[event] = nextBlocks;
   }
 
   return removed;
 }
 
+/** Are Keepline hooks installed under any registered event? */
 function hasKeeplineHook(settings: ClaudeSettings): boolean {
-  return Boolean(
-    settings.hooks?.PostToolUse?.some(isKeeplineHook)
-  );
+  return KEEPLINE_EVENTS.some((event) => {
+    const blocks = settings.hooks?.[event];
+    return Boolean(blocks && findKeeplineEntry(blocks));
+  });
 }
 
 /** Check if keepline hooks are installed */

--- a/src/adapters/hook/server.ts
+++ b/src/adapters/hook/server.ts
@@ -37,46 +37,95 @@ const VALID_EVENT_TYPES: Set<HookEventType> = new Set([
 /** Track first prompts per session for context injection */
 const sessionFirstPrompts: Map<string, boolean> = new Map();
 
-/** Validate hook event payload */
-function isValidHookEvent(event: unknown): event is HookEvent {
-  if (!event || typeof event !== 'object') {
-    return false;
+/** Extract a tool's output from Claude's native payload (field name varies) */
+function extractToolOutput(e: Record<string, unknown>): string | undefined {
+  const raw = e.tool_response ?? e.tool_result ?? e.tool_output;
+  if (raw === undefined || raw === null) return undefined;
+  return typeof raw === 'string' ? raw : JSON.stringify(raw);
+}
+
+/**
+ * Parse Claude Code's native hook payload (delivered as stdin JSON) into a
+ * normalized internal event, or return null if it is not a valid/known event.
+ *
+ * Claude uses `hook_event_name` (not `event_type`) and does not send a
+ * timestamp, so one is stamped on receipt.
+ */
+export function parseHookEvent(raw: unknown): HookEvent | null {
+  if (!raw || typeof raw !== 'object') {
+    return null;
   }
 
-  const e = event as Record<string, unknown>;
+  const e = raw as Record<string, unknown>;
 
-  // Required fields
+  const eventType = e.hook_event_name;
+  if (typeof eventType !== 'string' || !VALID_EVENT_TYPES.has(eventType as HookEventType)) {
+    return null;
+  }
   if (!isValidSessionId(e.session_id)) {
-    return false;
-  }
-  if (typeof e.cwd !== 'string') {
-    return false;
-  }
-  if (typeof e.timestamp !== 'string') {
-    return false;
-  }
-  if (typeof e.event_type !== 'string' || !VALID_EVENT_TYPES.has(e.event_type as HookEventType)) {
-    return false;
+    return null;
   }
 
-  // Tool events require additional fields
-  if (e.event_type === 'PreToolUse' || e.event_type === 'PostToolUse') {
-    if (typeof e.tool_name !== 'string' || e.tool_name.length === 0) {
-      return false;
-    }
-    if (!e.tool_input || typeof e.tool_input !== 'object') {
-      return false;
-    }
-  }
+  const session_id = e.session_id;
+  const cwd = typeof e.cwd === 'string' ? e.cwd : '';
+  const timestamp = new Date().toISOString();
 
-  // UserPromptSubmit requires prompt field
-  if (e.event_type === 'UserPromptSubmit') {
-    if (typeof e.prompt !== 'string') {
-      return false;
+  switch (eventType as HookEventType) {
+    case 'PreToolUse':
+    case 'PostToolUse': {
+      if (typeof e.tool_name !== 'string' || e.tool_name.length === 0) {
+        return null;
+      }
+      const tool_input =
+        e.tool_input && typeof e.tool_input === 'object'
+          ? (e.tool_input as Record<string, unknown>)
+          : {};
+      return {
+        event_type: eventType as 'PreToolUse' | 'PostToolUse',
+        session_id,
+        cwd,
+        timestamp,
+        tool_name: e.tool_name,
+        tool_input,
+        tool_output: extractToolOutput(e),
+      };
     }
-  }
 
-  return true;
+    case 'UserPromptSubmit':
+      return {
+        event_type: 'UserPromptSubmit',
+        session_id,
+        cwd,
+        timestamp,
+        prompt: typeof e.prompt === 'string' ? e.prompt : '',
+      };
+
+    case 'Stop':
+      return {
+        event_type: 'Stop',
+        session_id,
+        cwd,
+        timestamp,
+        reason:
+          typeof e.stop_reason === 'string'
+            ? e.stop_reason
+            : typeof e.reason === 'string'
+              ? e.reason
+              : undefined,
+      };
+
+    case 'Notification':
+      return {
+        event_type: 'Notification',
+        session_id,
+        cwd,
+        timestamp,
+        message: typeof e.message === 'string' ? e.message : '',
+      };
+
+    default:
+      return null;
+  }
 }
 
 /** Handle incoming hook event */
@@ -219,14 +268,21 @@ export async function startHookServer(): Promise<void> {
   // Hook event endpoint
   server.post<{ Body: unknown }>('/hook', async (request, reply) => {
     try {
-      // Validate input before processing
-      if (!isValidHookEvent(request.body)) {
-        logger.warn('Invalid hook event received', { body: request.body });
+      // Parse Claude's native stdin payload into a normalized event.
+      const event = parseHookEvent(request.body);
+      if (!event) {
+        // Log only non-sensitive identifiers, never the raw body (which may
+        // carry prompts, tool inputs, or secrets).
+        const body = request.body as Record<string, unknown> | null;
+        logger.warn('Invalid hook event received', {
+          hook_event_name: body?.hook_event_name,
+          session_id: body?.session_id,
+        });
         reply.status(400);
         return { success: false, error: 'Invalid hook event payload' };
       }
 
-      await handleHookEvent(request.body);
+      await handleHookEvent(event);
       return { success: true };
     } catch (error) {
       logger.error('Failed to handle hook event', error);

--- a/src/adapters/hook/types.ts
+++ b/src/adapters/hook/types.ts
@@ -2,7 +2,7 @@
  * Hook module types
  */
 
-/** Hook event types from Claude Code */
+/** Hook event types from Claude Code that Keepline consumes */
 export type HookEventType =
   | 'PreToolUse'
   | 'PostToolUse'
@@ -10,7 +10,14 @@ export type HookEventType =
   | 'Stop'
   | 'UserPromptSubmit'; // User submitted a prompt
 
-/** Base hook event payload */
+/**
+ * Internal, normalized hook event payload.
+ *
+ * Claude Code delivers hook data as JSON on stdin (fields such as
+ * `hook_event_name`, `tool_response`) and does NOT set `$CLAUDE_*` env vars.
+ * The server parses that native payload into these normalized shapes; the
+ * `timestamp` is stamped on receipt because Claude does not send one.
+ */
 export interface HookEventPayload {
   session_id: string;
   cwd: string;
@@ -41,7 +48,6 @@ export interface StopHookEvent extends HookEventPayload {
 export interface UserPromptSubmitHookEvent extends HookEventPayload {
   event_type: 'UserPromptSubmit';
   prompt: string;
-  is_first_prompt?: boolean;
 }
 
 /** Union type for all hook events */
@@ -51,20 +57,24 @@ export type HookEvent =
   | StopHookEvent
   | UserPromptSubmitHookEvent;
 
-/** Claude settings hook configuration */
-export interface ClaudeHookConfig {
-  matcher?: string;
+/**
+ * A single command entry inside a Claude settings hook matcher block.
+ * This is Claude Code's real nested shape: `hooks[].hooks[]`.
+ */
+export interface HookCommandEntry {
+  type: 'command';
   command: string;
+  timeout?: number;
 }
 
-/** Claude settings structure */
+/** A matcher block: optionally filters events, and runs one or more commands */
+export interface ClaudeHookMatcher {
+  matcher?: string;
+  hooks: HookCommandEntry[];
+}
+
+/** Claude settings structure (hooks use the nested matcher-block shape) */
 export interface ClaudeSettings {
-  hooks?: {
-    PreToolUse?: ClaudeHookConfig[];
-    PostToolUse?: ClaudeHookConfig[];
-    Notification?: ClaudeHookConfig[];
-    Stop?: ClaudeHookConfig[];
-    UserPromptSubmit?: ClaudeHookConfig[];
-  };
+  hooks?: Partial<Record<HookEventType, ClaudeHookMatcher[]>>;
   [key: string]: unknown;
 }


### PR DESCRIPTION
修复 codebase-audit 发现的 Critical:实时 hook 管道从未真正工作。根因已用官方文档核实(https://code.claude.com/docs/en/hooks.md)。

## 根因(三重叠加)

1. **依赖不存在的环境变量**:安装的 curl 用 `$CLAUDE_EVENT_TYPE / $CLAUDE_SESSION_ID / $CLAUDE_TOOL_NAME / $CLAUDE_TOOL_INPUT` 拼 JSON,但 Claude Code 不设这些变量——hook 数据只经 **stdin JSON** 传入,字段名是 `hook_event_name`。变量展开为空 → 服务端校验失败 → 400 → `|| true` 吞掉。
2. **settings 形状无效**:写的是扁平 `{command}`,而 Claude Code 要求嵌套 `hooks.<Event>[{matcher?, hooks:[{type:"command", command}]}]`,所以 hook 根本不被识别。
3. **只注册 PostToolUse**:`Stop`(自动标记完成)和 `UserPromptSubmit`(跨会话记忆注入)永不触发。

## 修复

- **installer**:命令改为 `curl --data-binary @-` 原样转发 Claude 的 stdin JSON;写入正确的嵌套 matcher-block 形状;在 `PostToolUse` / `Stop` / `UserPromptSubmit` 三个事件下注册。install/uninstall/upgrade 保留无关 hook、丢弃空块。
- **server**:新增 `parseHookEvent()` 解析 native schema(`hook_event_name`、`tool_response` 等)为内部归一化事件,timestamp 在接收时生成(Claude 不下发)。
- **顺带修 P3**:非法事件日志只记录事件名 + session_id,不再打印可能含 prompt/工具输入/密钥的原始 body。

## 测试

- `hook.installer.test.ts`(重写为嵌套形状):注册三事件、幂等、与无关 hook 共存、legacy 原地升级、生成命令不含 `$CLAUDE_*` 且用 `--data-binary @-`。
- `hook.server-parse.test.ts`(新增):native PostToolUse/UserPromptSubmit/Stop 正确解析;拒绝旧 `event_type` 形状、未知事件、非法 session_id、非对象。

## 验证(本次会话实测)

- `bun x tsc --noEmit`:exit 0
- `bun test`:371 pass / 0 fail(含 8 个新 hook 用例)

## ⚠️ 未能运行时验证的两点(本环境无法跑真实 Claude Code)

1. **matcher 省略语义**:按文档,省略 `matcher` 匹配该事件全部;PostToolUse 未设 matcher。若实测发现需显式 matcher 才触发,是一行改动。
2. **工具输出字段名**:PostToolUse 输出字段取 `tool_response ?? tool_result ?? tool_output`(防御式),已尽量覆盖。

建议合并前用一次真实 Claude Code 触发验证(装 hook → 触发工具调用 → 看 hook server 日志有无合法事件)。

Closes #75
