### PR TITLE
merge: drain implx queue integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,3 +387,22 @@ bun test             # Run tests
 MIT License
 
 </div>
+
+---
+
+## The Agent Infra Stack
+
+This project is one layer of an open-source stack for running coding agents (Claude Code, Codex) as serious infrastructure. Every piece works standalone; together they close the loop:
+
+`keepline` is the **Keep** layer — the session command center on top of the stack: monitor, recover, and never lose agent work.
+
+| Layer | Project | What it does |
+|---|---|---|
+| Extend | [claude-skill-registry](https://github.com/majiayu000/claude-skill-registry) | Discover and search community Claude Code skills |
+| Extend | [spellbook](https://github.com/majiayu000/spellbook) | Cross-runtime skills for Claude Code, Codex, and multi-agent workflows |
+| Trust | [argus](https://github.com/majiayu000/argus) | Static install-time scanner for supply-chain attacks (npm / PyPI / crates.io) |
+| Trust | [vibeguard](https://github.com/majiayu000/vibeguard) | Rules, hooks, and guards against hallucinated or unverified agent changes |
+| Remember | [remem](https://github.com/majiayu000/remem) | Local-first persistent memory for Claude Code and Codex sessions |
+| Orchestrate | [harness](https://github.com/majiayu000/harness) | Rust agent orchestration platform — rules, skills, GC, observability |
+| Route | [litellm-rs](https://github.com/majiayu000/litellm-rs) | High-performance Rust AI gateway — 100+ LLM APIs via OpenAI format |
+| Keep | [keepline](https://github.com/majiayu000/keepline) **◀ you are here** | Session command center — monitor, recover, never lose agent work |

--- a/specs/GH74/product.md
+++ b/specs/GH74/product.md
@@ -1,0 +1,45 @@
+# LanceDB Observation ID Injection Hardening Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/74
+
+## Summary
+
+Keepline 的 memory observation API 必须拒绝带有 filter DSL 注入字符的 observation id。用户或本地集成只能读取或删除明确命中的单条 observation，不能通过路径参数扩大到其它 observation 或整张 LanceDB 表。
+
+## User Problem
+
+Keepline 将跨会话记忆持久化到 LanceDB。当前按 observation id 读取和删除的路径把 HTTP 参数直接拼进 LanceDB filter 字符串。认证用户或本地恶意页面一旦能触达 API，就可能用带引号和布尔表达式的 id 读取额外数据或删除全部 observation。
+
+用户需要的行为是 fail closed：非法 id 直接返回清晰的 400 错误，合法但不存在的 id 返回 404，底层向量库不应看到非法 filter。
+
+## Product Behavior
+
+1. `GET /api/memory/observations/:id` 对非法 observation id 返回 400。
+2. `DELETE /api/memory/observations/:id` 对非法 observation id 返回 400。
+3. 非法 observation id 包括空字符串、过短或过长字符串、空格、引号、SQL/filter 运算符片段、点号和其它不在允许字符集内的字符。
+4. 合法 observation id 使用与 Keepline 生成的 UUID 兼容的安全字符集。
+5. 合法但不存在的 observation id 保持现有 404 行为。
+6. 底层 vector store 被直接调用时也必须拒绝非法 observation id，不能依赖 HTTP 路由作为唯一防线。
+7. 此修复不改变 memory observation 的创建、搜索、sessionId 查询或 sessionId 批量删除行为。
+
+## Non-Goals
+
+- 不重写 LanceDB 查询层或替换向量数据库。
+- 不改变 `sessionId` 的现有校验策略。
+- 不实现 observation id 迁移或历史数据重写。
+- 不处理 P2 中的 LanceDB 维度迁移、`count()` 性能或 session 批量删除性能。
+- 不改变认证、JWT、rate limit 或 DNS-rebinding 防护。
+
+## Acceptance Criteria
+
+1. observation id 有单独的验证函数，允许 Keepline 当前生成的 UUID。
+2. `GET /api/memory/observations/:id` 在非法 id 下返回 400，且不初始化或查询 LanceDB。
+3. `DELETE /api/memory/observations/:id` 在非法 id 下返回 400，且不初始化或删除 LanceDB 数据。
+4. `LanceDBVectorStore.getById()` 在非法 id 下抛出明确错误。
+5. `LanceDBVectorStore.delete()` 在非法 id 下抛出明确错误。
+6. `getById()` 和 `delete()` 不再使用未经校验的 path 参数构造 LanceDB filter。
+7. 回归测试覆盖注入形 id，例如 `x' OR '1'='1`。
+
+## Open Questions
+
+- LanceDB 是否提供稳定的参数化 predicate API。如果没有，本次采用严格 id allowlist；后续可以在升级 LanceDB 时改为参数化查询。

--- a/specs/GH74/tasks.md
+++ b/specs/GH74/tasks.md
@@ -1,0 +1,87 @@
+# LanceDB Observation ID Injection Hardening Task Plan
+
+Issue: https://github.com/majiayu000/keepline/issues/74
+Product spec: `specs/GH74/product.md`
+Tech spec: `specs/GH74/tech.md`
+
+## Tasks
+
+### SP74-T1: Add observation id validation
+
+Owner: implementation agent
+
+Dependencies: GH74 issue evidence
+
+Done when:
+
+- `src/lib/observation-id.ts` exports `isValidObservationId()` and `assertValidObservationId()`.
+- Valid UUID observation ids pass.
+- Injection-style ids with quotes, spaces, or filter operators fail.
+- API validation exports the helper for route and test reuse.
+
+Verify:
+
+```sh
+bun test src/__tests__/validation.test.ts
+```
+
+### SP74-T2: Reject invalid ids at API boundary
+
+Owner: implementation agent
+
+Dependencies: SP74-T1
+
+Done when:
+
+- `GET /api/memory/observations/:id` returns 400 for invalid ids before vector store access.
+- `DELETE /api/memory/observations/:id` returns 400 for invalid ids before vector store access.
+- Valid but missing ids retain 404 behavior.
+
+Verify:
+
+```sh
+bun test src/__tests__/observation-id.test.ts
+```
+
+### SP74-T3: Guard vector adapter direct calls
+
+Owner: implementation agent
+
+Dependencies: SP74-T1
+
+Done when:
+
+- `LanceDBVectorStore.getById()` rejects invalid ids before initialization/query.
+- `LanceDBVectorStore.delete()` rejects invalid ids before initialization/delete.
+- Invalid ids cannot reach LanceDB filter construction through these methods.
+
+Verify:
+
+```sh
+bun test src/__tests__/observation-id.test.ts
+```
+
+### SP74-T4: Run deterministic verification and prepare PR
+
+Owner: coordinator
+
+Dependencies: SP74-T1, SP74-T2, SP74-T3
+
+Done when:
+
+- Focused tests pass.
+- Typecheck passes.
+- Full `bun test` passes or any unrelated failure is recorded with evidence.
+- Build passes.
+- PR references and closes #74 only if every acceptance criterion is satisfied.
+
+Verify:
+
+```sh
+test -f specs/GH74/product.md
+test -f specs/GH74/tech.md
+test -f specs/GH74/tasks.md
+bun run typecheck
+bun test
+bun run build
+```

--- a/specs/GH74/tech.md
+++ b/specs/GH74/tech.md
@@ -1,0 +1,91 @@
+# LanceDB Observation ID Injection Hardening Tech Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/74
+Product spec: `specs/GH74/product.md`
+
+## Current Behavior
+
+- `src/web/api/routes/memory.ts` 的 `GET /observations/:id` 和 `DELETE /observations/:id` 直接读取 `c.req.param('id')`，没有格式校验。
+- `src/infrastructure/vector/lancedb.adapter.ts` 在 `getById()` 中使用 `.where(\`id = '${id}'\`)`，在 `delete()` 中使用 `this.table.delete(\`id = '${id}'\`)`。
+- `POST /observations` 使用 `crypto.randomUUID()` 创建 id，因此正常新数据的 id 形如 UUID，能被安全 allowlist 覆盖。
+- `sessionId` 路径已有 `isValidSessionId()`，但 observation id 没有等价防线。
+
+## Design
+
+1. 新增共享 observation id 验证模块。
+
+   Suggested file: `src/lib/observation-id.ts`
+
+   Rules:
+
+   - 类型必须是 `string`。
+   - 长度 8 到 64。
+   - 只允许 `a-z`、`A-Z`、`0-9`、`-`、`_`。
+   - `crypto.randomUUID()` 生成的 UUID 必须通过。
+   - 引号、空格、点号、分号、等号等字符必须失败。
+
+2. API 路由 fail closed。
+
+   `src/web/api/routes/memory.ts` 在 `GET /observations/:id` 和 `DELETE /observations/:id` 进入 vector store 之前调用 `isValidObservationId(id)`。失败时返回：
+
+   ```json
+   { "success": false, "error": "Invalid observation ID format" }
+   ```
+
+   HTTP status 为 400。
+
+3. Vector adapter 加第二道防线。
+
+   `LanceDBVectorStore.getById()` 和 `delete()` 在任何初始化或 LanceDB 调用之前执行 `assertValidObservationId(id)`。这样即使未来新增内部调用路径，也不会把非法 id 拼入 filter。
+
+4. 保持合法 id 行为不变。
+
+   本次不改变 LanceDB 的 filter DSL 形态，因为严格 allowlist 已保证被插值的 id 不含引号、空格或运算符。若 LanceDB 版本提供参数化 API，可作为后续强化替换。
+
+## Affected Files
+
+- `src/lib/observation-id.ts`
+- `src/web/api/middleware/validation.ts`
+- `src/web/api/routes/memory.ts`
+- `src/infrastructure/vector/lancedb.adapter.ts`
+- `src/__tests__/validation.test.ts`
+- focused observation id / memory route regression tests
+- `specs/GH74/product.md`
+- `specs/GH74/tech.md`
+- `specs/GH74/tasks.md`
+
+## Verification Plan
+
+Focused:
+
+```sh
+bun test src/__tests__/validation.test.ts
+bun test src/__tests__/observation-id.test.ts
+```
+
+Repository:
+
+```sh
+bun run typecheck
+bun test
+bun run build
+```
+
+Workflow:
+
+```sh
+test -f specs/GH74/product.md
+test -f specs/GH74/tech.md
+test -f specs/GH74/tasks.md
+```
+
+`checks/check_workflow.py` is not present in this repository, so there is no repo-local SpecRail workflow checker to run for this tranche.
+
+## Risks
+
+- If historical observation ids used characters outside the allowlist, those rows would no longer be addressable by id through this endpoint. Current production creation path uses UUID, so this risk is acceptable.
+- `deleteBySessionId()` still interpolates `sessionId`, but the existing API boundary already validates `sessionId` and the sessionId issue is outside GH74 scope. A future adapter-level `assertValidSessionId()` would be a separate hardening change.
+
+## Rollback
+
+Revert the GH74 commit. The API returns to prior permissive behavior. No migration or persisted data shape is changed.

--- a/specs/GH75/product.md
+++ b/specs/GH75/product.md
@@ -1,0 +1,42 @@
+# Hook Pipeline Recovery Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/75
+
+## Summary
+
+Keepline 的 Claude Code hook 安装必须让实时监控和跨会话上下文入口实际收到 Claude Code 事件。安装后，Claude Code 的 `PreToolUse`、`PostToolUse`、`Notification`、`Stop`、`UserPromptSubmit` 事件应全部转发到本地 hook server。
+
+## User Problem
+
+用户安装 hooks 后预期看到实时会话状态、工具活动、Stop 自动完成和首次 prompt 上下文注入。如果安装器只注册 `PostToolUse`，或依赖 Claude Code 不提供的环境变量拼接 payload，功能会静默失效：
+
+1. `Stop` 不会把会话标记为 completed。
+2. `UserPromptSubmit` 不会触发上下文注入。
+3. 工具事件无法稳定携带 session、cwd、tool input 和 tool response。
+4. `|| true` 会隐藏 hook 命令失败，用户只看到实时功能退化。
+
+## Product Behavior
+
+1. `keepline hooks install` 写入 Claude Code 当前 hook schema。
+2. 同一个 Keepline command hook 注册到 `PreToolUse`、`PostToolUse`、`Notification`、`Stop`、`UserPromptSubmit`。
+3. Command hook 从 stdin 接收 Claude Code JSON，并原样 POST 到 Keepline hook server。
+4. Hook server 接受 Claude Code 官方字段：`hook_event_name`、`session_id`、`cwd`、`tool_name`、`tool_input`、`tool_response`、`prompt`、`message`。
+5. Hook server 继续兼容旧 Keepline payload：`event_type`、`timestamp`、`tool_output`。
+6. 无效 payload 必须返回 400，不得被当作有效事件降级处理。
+
+## Non-Goals
+
+- 不在本 issue 引入 hook shared secret 或 Host/Origin 校验；安全加固由 GH79 覆盖。
+- 不改变 compression queue 或 memory extractor 的内部事件 contract。
+- 不要求 hook server 在 `keepline web` 默认启动；daemon/web 启动边界由其他 issue 覆盖。
+- 不移除旧 hook ownership detection；旧安装需要可升级。
+
+## Acceptance Criteria
+
+1. 安装器不再依赖 `$CLAUDE_EVENT_TYPE`、`$CLAUDE_SESSION_ID`、`$CLAUDE_TOOL_NAME`、`$CLAUDE_TOOL_INPUT`。
+2. 安装器注册全部五类已消费事件，而不只是 `PostToolUse`。
+3. `PostToolUse` 官方 `tool_response` 能被转为内部 `tool_output` 并进入现有 tool event/压缩路径。
+4. `UserPromptSubmit` 官方 payload 能通过 validation 并触发现有 prompt handling。
+5. 旧 Keepline payload 仍可被 hook server 接受。
+6. 回归测试覆盖安装结构、legacy 升级、官方 payload normalization 和 malformed payload 拒绝。
+7. 验证命令通过：focused hook tests、`bun run typecheck`、`bun test`、`bun run build`。

--- a/specs/GH75/tasks.md
+++ b/specs/GH75/tasks.md
@@ -1,0 +1,23 @@
+# Hook Pipeline Recovery Tasks
+
+Issue: https://github.com/majiayu000/keepline/issues/75
+
+## Tasks
+
+- [x] Verify current Claude Code hook contract from official docs.
+- [x] Add GH75 product and tech specs.
+- [x] Update hook settings types for current matcher-group schema.
+- [x] Replace env-var payload synthesis with stdin forwarding.
+- [x] Register Keepline hook command for all consumed event types.
+- [x] Preserve and upgrade legacy Keepline hook ownership detection.
+- [x] Normalize official Claude Code payloads at the hook server boundary.
+- [x] Keep legacy `event_type` payload compatibility.
+- [x] Add focused installer and server tests.
+- [x] Run focused hook tests.
+- [x] Run `bun run typecheck`.
+- [x] Run `bun test`.
+- [x] Run `bun run build`.
+
+## Completion Mode
+
+Final implementation PR should use `Fixes #75` only after all acceptance criteria pass. Partial follow-up slices should use `Refs #75`.

--- a/specs/GH75/tech.md
+++ b/specs/GH75/tech.md
@@ -1,0 +1,91 @@
+# Hook Pipeline Recovery Tech Spec
+
+Product spec: specs/GH75/product.md
+
+Issue: https://github.com/majiayu000/keepline/issues/75
+
+## External Contract
+
+Claude Code command hooks receive the event JSON on stdin. Common fields include `session_id`, `transcript_path`, `cwd`, and `hook_event_name`. Tool events add `tool_name` and `tool_input`; `PostToolUse` adds `tool_response`; `UserPromptSubmit` adds `prompt`; `Stop` adds stop-specific fields.
+
+The hook settings schema is event keyed and contains matcher groups with nested hook handlers:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "..."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Implementation Plan
+
+### Installer
+
+Update `src/adapters/hook/installer.ts`:
+
+- Generate one command that forwards stdin:
+
+  ```bash
+  KEEPLINE_HOOK_MARKER=keepline-hook-v1 curl -fsS -X POST http://127.0.0.1:<port>/hook -H "Content-Type: application/json" --data-binary @- > /dev/null 2>&1 || true
+  ```
+
+- Register Keepline hook handlers for:
+  - `PreToolUse`
+  - `PostToolUse`
+  - `Notification`
+  - `Stop`
+  - `UserPromptSubmit`
+- Use `matcher: "*"` only for tool events.
+- Preserve unrelated hook handlers and remove/upgrade only Keepline-owned legacy hooks.
+- Treat fully installed five-event config as installed; partial `PostToolUse` only should be repaired by reinstall.
+
+### Server Boundary
+
+Update `src/adapters/hook/server.ts`:
+
+- Add a pure `normalizeHookEvent(raw, now)` boundary function.
+- Accept both official `hook_event_name` and legacy `event_type`.
+- Fill missing `timestamp` at receive time for official payloads.
+- Convert official `tool_response` to internal string `tool_output` with `JSON.stringify`.
+- Keep existing internal handlers unchanged after normalization.
+- Reject malformed payloads with 400.
+
+### Types
+
+Update `src/adapters/hook/types.ts`:
+
+- Model current hook settings as matcher groups with nested command handlers.
+- Keep legacy direct command entries in the union for ownership detection and uninstall.
+- Keep internal `HookEvent` normalized around `event_type` and `timestamp`.
+
+## Tests
+
+- `src/__tests__/hook.installer.test.ts`
+  - unrelated localhost hooks are preserved.
+  - foreign legacy-shaped hooks are not claimed.
+  - install writes all five events in current schema.
+  - uninstall removes only Keepline-owned handlers.
+  - legacy Keepline command is upgraded without duplication.
+  - reinstall of the full config is a no-op.
+
+- `src/__tests__/hook.server.test.ts`
+  - official `PostToolUse` stdin payload normalizes successfully.
+  - legacy `event_type` payload remains accepted.
+  - official `UserPromptSubmit` without command-synthesized timestamp is valid.
+  - malformed tool payload is rejected.
+
+## Risk Notes
+
+- The command keeps `|| true` to avoid blocking Claude Code when Keepline is not running. This preserves existing non-blocking behavior but means users need status/health tooling to discover delivery failures.
+- GH79 should add Host/Origin/auth checks; this issue only restores event delivery.

--- a/specs/GH76/product.md
+++ b/specs/GH76/product.md
@@ -1,0 +1,35 @@
+# Truncated JSONL Tail Recovery Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/76
+
+## Summary
+
+Keepline must keep recoverable sessions visible when a Claude Code or Codex JSONL transcript ends with a truncated final line. A crash or interrupted write can leave the last JSONL record incomplete; the parser should preserve all complete records before that tail instead of rejecting the whole file.
+
+## User Problem
+
+The product promise is session recovery after terminal crashes. Crash-time JSONL files are exactly where a truncated final line is most likely. If one bad final line causes the whole file to be cached as a parse failure, the session disappears from the dashboard and recovery candidates.
+
+## Product Behavior
+
+1. Claude Code session JSONL files with complete prior lines and a malformed final line still produce a parsed session summary.
+2. Codex rollout JSONL files with complete prior lines and a malformed final line still produce a parsed session summary.
+3. Malformed non-final lines remain hard parse errors.
+4. Scanner failure caches are not populated for tolerated truncated-tail files, so repeated scans keep the session visible.
+5. Empty/blank trailing lines remain ignored.
+
+## Non-Goals
+
+- Do not silently tolerate corruption in the middle of a transcript.
+- Do not attempt partial JSON repair or schema inference.
+- Do not change scanner mtime cache semantics except through avoiding false parse failures.
+- Do not broaden accepted file names or session IDs.
+
+## Acceptance Criteria
+
+1. Claude parser skips a malformed final JSONL line and returns data from earlier valid entries.
+2. Codex parser skips a malformed final JSONL line and returns data from earlier valid entries.
+3. Claude parser still throws `ParseError` for malformed non-final JSONL lines.
+4. Codex parser still throws `ParseError` for malformed non-final JSONL lines.
+5. Tests prove truncated-tail sessions are visible through parser/scanner paths.
+6. Verification commands pass: focused parser/scanner tests, `bun run typecheck`, `bun test`, `bun run build`.

--- a/specs/GH76/tasks.md
+++ b/specs/GH76/tasks.md
@@ -1,0 +1,20 @@
+# Truncated JSONL Tail Recovery Tasks
+
+Issue: https://github.com/majiayu000/keepline/issues/76
+
+## Tasks
+
+- [x] Confirm root cause in Claude and Codex JSONL parser loops.
+- [x] Add GH76 product and tech specs.
+- [x] Update Claude parser to tolerate malformed final line only.
+- [x] Update Codex parser to tolerate malformed final line only.
+- [x] Add parser tests for truncated final line and corrupted middle line.
+- [x] Add scanner/cache tests proving truncated sessions remain visible.
+- [x] Run focused parser/scanner tests.
+- [x] Run `bun run typecheck`.
+- [x] Run `bun test`.
+- [x] Run `bun run build`.
+
+## Completion Mode
+
+Final implementation PR should use `Fixes #76` only after all acceptance criteria pass. Partial follow-up slices should use `Refs #76`.

--- a/specs/GH76/tech.md
+++ b/specs/GH76/tech.md
@@ -1,0 +1,44 @@
+# Truncated JSONL Tail Recovery Tech Spec
+
+Product spec: specs/GH76/product.md
+
+Issue: https://github.com/majiayu000/keepline/issues/76
+
+## Current Root Cause
+
+`src/adapters/claude/parser/jsonl.ts` and `src/adapters/codex/parser.ts` parse each JSONL line as soon as it is read. Any `JSON.parse` failure throws `ParseError`. Scanner callers catch that error, cache the file as failed for the current mtime, and return no session data for that file.
+
+This is correct for middle-of-file corruption, but wrong for a final partial line caused by a process crash or interrupted write.
+
+## Design
+
+Use one-line lookahead in both streaming parsers:
+
+1. Keep the current line pending.
+2. When the next line arrives, parse the previous pending line as definitely non-final.
+3. After the stream ends, parse the last pending line with `allowTruncatedTail: true`.
+4. If the last pending line fails JSON parse, return `null` for that line only and finalize the accumulator from earlier complete records.
+5. If any non-final line fails JSON parse, throw `ParseError` with the original file path and line number.
+
+This keeps memory constant and preserves the streaming parser shape.
+
+## Implementation Notes
+
+- Claude parser:
+  - Extend `parseLine` to accept `allowTruncatedTail`.
+  - Add a local `processLine` helper inside `parseSessionFile`.
+  - Reuse existing accumulator/finalizer unchanged.
+
+- Codex parser:
+  - Add a small `parseCodexLine` helper with the same last-line tolerance.
+  - Apply the same pending-line flow in `parseCodexSessionFile`.
+
+- Tests:
+  - Adjust invalid JSONL tests so non-final corruption is still asserted.
+  - Add final-line truncation tests for both parsers.
+  - Add scanner-level coverage that truncated tails do not become cached failures.
+
+## Risk Notes
+
+- Tolerating any malformed final line can hide a real final-record corruption. This is deliberate because final-record corruption is indistinguishable from crash truncation and should not hide an otherwise recoverable session.
+- The parser does not log tolerated tail truncation. Avoid noisy logs for files actively being written.

--- a/specs/GH77/product.md
+++ b/specs/GH77/product.md
@@ -1,0 +1,32 @@
+# Completed Session Sync Preservation Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/77
+
+## Summary
+
+When a user marks a session completed, later sync cycles must preserve that explicit completed state. File rescans can refresh metadata, but they must not turn a user-completed session back into `lost`, `idle`, `waiting`, or `running`.
+
+## User Problem
+
+Users mark sessions completed to remove them from active recovery/attention workflows. If the next JSONL sync recomputes status from process state and overwrites `completed`, the dashboard shows completed work as lost or idle again.
+
+## Product Behavior
+
+1. A persisted `completed` session remains `completed` during later syncs.
+2. `completedAt` is not overwritten by scanner metadata.
+3. Sync may still refresh non-authoritative metadata such as title, message counts, tool info, and usage.
+4. Non-completed sessions keep existing behavior: no process still becomes `lost`; live process can become `running`, `waiting`, or `idle`.
+
+## Non-Goals
+
+- Do not infer completed from tools or transcript text.
+- Do not change the explicit `completeSession` API behavior.
+- Do not change retention cleanup semantics.
+
+## Acceptance Criteria
+
+1. Existing completed session plus no process plus scanned JSONL remains completed after sync.
+2. `completedAt` remains the original explicit completion timestamp.
+3. Existing non-completed session can still become lost when no process exists.
+4. Focused sync regression test covers the completed preservation path.
+5. Verification commands pass: focused sync test, `bun run typecheck`, `bun test`, `bun run build`.

--- a/specs/GH77/tasks.md
+++ b/specs/GH77/tasks.md
@@ -1,0 +1,18 @@
+# Completed Session Sync Preservation Tasks
+
+Issue: https://github.com/majiayu000/keepline/issues/77
+
+## Tasks
+
+- [x] Confirm root cause in existing-session sync branch.
+- [x] Add GH77 product and tech specs.
+- [x] Preserve existing `completed` status during sync.
+- [x] Add subprocess-backed sync regression test.
+- [x] Run focused sync test.
+- [x] Run `bun run typecheck`.
+- [x] Run `bun test`.
+- [x] Run `bun run build`.
+
+## Completion Mode
+
+Final implementation PR should use `Fixes #77` only after all acceptance criteria pass. Partial follow-up slices should use `Refs #77`.

--- a/specs/GH77/tech.md
+++ b/specs/GH77/tech.md
@@ -1,0 +1,35 @@
+# Completed Session Sync Preservation Tech Spec
+
+Product spec: specs/GH77/product.md
+
+Issue: https://github.com/majiayu000/keepline/issues/77
+
+## Current Root Cause
+
+`src/services/session.service.ts` computes `detectSessionStatus(process || null, agentSession.lastActiveAt)` for every scanned session. In the existing-session branch, that detected status is passed directly into `repository.upsert`. `detectSessionStatus` never returns `completed`, so a user-completed session is overwritten on the next scan.
+
+The later dead-process loop already excludes completed sessions via `findActiveLightweight()`, but the primary scanned-session update path does not.
+
+## Implementation Plan
+
+- In the existing-session branch, compute:
+
+  ```ts
+  const nextStatus = existing.status === 'completed' ? 'completed' : detectedStatus;
+  ```
+
+- Use `nextStatus` for `wasLost` and `repository.upsert`.
+- Do not pass `completedAt` during sync; repository `COALESCE` keeps the original value.
+- Keep metadata refresh behavior unchanged.
+
+## Tests
+
+Add a subprocess-backed sync test that:
+
+1. Uses temporary `HOME` and `KEEPLINE_HOME`.
+2. Writes a real Claude project JSONL file inside `.claude/projects`.
+3. Inserts a matching DB session with `status: 'completed'`, `completedAt`, and a stale pid.
+4. Runs `sessionService.syncSessions({ fullSync: true })`.
+5. Asserts status remains `completed`, `completedAt` is unchanged, and `lost` count remains `0`.
+
+This tests the real scanner, process matcher, service, and repository path without weakening production code.

--- a/specs/GH78/product.md
+++ b/specs/GH78/product.md
@@ -1,0 +1,36 @@
+# High-Cost Notification Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/78
+
+## Summary
+
+Keepline's high-cost notification must fire when a session crosses the user's configured cost threshold. The session list and realtime dashboard paths currently use the basic session payload, so that payload must preserve persisted usage data required by notifications.
+
+## User Problem
+
+Users can enable "High Cost Warning" and set a dollar threshold, but the notification never fires because the list and WebSocket payloads omit `usageStats`. A session can exceed the configured threshold while the dashboard keeps seeing `session.usageStats === undefined`.
+
+## Product Behavior
+
+1. Basic session responses include persisted `usageStats` when the database has token or cost data.
+2. Basic session responses continue to omit heavy transcript/detail fields such as `initialPrompt`, `lastMessage`, tool input, and current file.
+3. WebSocket session updates consider usage changes as meaningful changes so cost-only updates are broadcast.
+4. The client session version signature considers usage changes so notification checks run when cost changes.
+5. High-cost notifications fire once when a session cost crosses from below the configured threshold to at or above that threshold.
+6. Missing usage data remains missing; Keepline must not infer or fabricate costs.
+
+## Non-Goals
+
+- Do not fetch full session details only to power high-cost notifications.
+- Do not change pricing extraction or cost calculation.
+- Do not add a new notification settings UI.
+- Do not emit repeated high-cost notifications while the session remains above the same threshold.
+
+## Acceptance Criteria
+
+1. `GET /api/sessions?fields=basic` returns `usageStats` for sessions with persisted usage data.
+2. Basic serialization still excludes heavy session detail fields.
+3. Realtime dashboard updates broadcast when persisted usage cost or token totals change.
+4. Client session versioning changes when usage cost or token totals change.
+5. A regression test with a mocked high-cost session proves the high-cost notification event is produced when the cost crosses the threshold.
+6. Verification passes: focused tests, `bun run typecheck`, `bun test`, and `bun run build`.

--- a/specs/GH78/tasks.md
+++ b/specs/GH78/tasks.md
@@ -1,0 +1,96 @@
+# High-Cost Notification Task Plan
+
+Issue: https://github.com/majiayu000/keepline/issues/78
+
+## Tasks
+
+### SP78-T1: Add SpecRail artifacts
+
+Done when:
+
+- `specs/GH78/product.md` exists.
+- `specs/GH78/tech.md` exists.
+- `specs/GH78/tasks.md` exists.
+
+Verify:
+
+```sh
+test -f specs/GH78/product.md
+test -f specs/GH78/tech.md
+test -f specs/GH78/tasks.md
+```
+
+### SP78-T2: Preserve usage data in lightweight backend sessions
+
+Writable files:
+
+- `src/domain/session/entity.ts`
+- `src/infrastructure/database/repositories/session.repository.ts`
+- `src/web/api/session-response.ts`
+
+Done when:
+
+- Lightweight repository rows include persisted usage columns.
+- `SessionListItem` can carry `usageStats`.
+- `serializeBasicSession()` emits `usageStats` when available and still omits heavy fields.
+
+Verify:
+
+```sh
+bun test src/__tests__/session-response.test.ts src/__tests__/sessions.route-basic.test.ts
+```
+
+### SP78-T3: Make realtime and client versioning cost-aware
+
+Writable files:
+
+- `src/web/api/server.ts`
+- `src/web/client/src/hooks/useSessions.ts`
+
+Done when:
+
+- Realtime broadcast state changes when usage cost or token totals change.
+- Client session version signature changes when usage cost or token totals change.
+
+Verify:
+
+```sh
+bun run typecheck
+```
+
+### SP78-T4: Add high-cost notification regression
+
+Writable files:
+
+- `src/web/client/src/hooks/useNotifications.ts`
+- `src/__tests__/use-notifications.test.ts`
+
+Done when:
+
+- A mocked previous/new session pair crossing the threshold produces one high-cost notification event.
+- A session already above the threshold does not produce another crossing event.
+
+Verify:
+
+```sh
+bun test src/__tests__/use-notifications.test.ts
+```
+
+### SP78-T5: Full local verification and PR
+
+Done when:
+
+- Focused tests pass.
+- Typecheck passes.
+- Full test suite passes.
+- Build passes.
+- PR links and closes #78.
+
+Verify:
+
+```sh
+bun test src/__tests__/session-response.test.ts src/__tests__/sessions.route-basic.test.ts src/__tests__/use-notifications.test.ts
+bun run typecheck
+bun test
+bun run build
+```

--- a/specs/GH78/tech.md
+++ b/specs/GH78/tech.md
@@ -1,0 +1,60 @@
+# High-Cost Notification Tech Spec
+
+Product spec: `specs/GH78/product.md`
+
+Issue: https://github.com/majiayu000/keepline/issues/78
+
+## Context
+
+- `src/web/client/src/hooks/useNotifications.ts` only evaluates the high-cost branch when `session.usageStats` exists.
+- `src/web/client/src/hooks/useSessions.ts` fetches `api.fetchSessions('basic', ...)` for the dashboard list and notification snapshots.
+- `src/web/api/server.ts` broadcasts `serializeBasicSessions(...)` over WebSocket.
+- `src/web/api/session-response.ts` currently strips `usageStats` from the basic payload.
+- `SessionRepository.findAllLightweight()` currently avoids heavy fields but also omits persisted usage columns.
+
+## Design
+
+Keep the basic payload lightweight, but include already-persisted usage columns:
+
+```ts
+usageStats?: {
+  totalInputTokens: number
+  totalOutputTokens: number
+  totalTokens: number
+  totalCost: number
+  apiCalls: number
+}
+```
+
+The database lightweight query should select `total_input_tokens`, `total_output_tokens`, `total_tokens`, `total_cost`, and `api_calls`. Mapping should match the full session mapper: return `usageStats` only when usage exists and use zero defaults for nullable parts.
+
+`serializeBasicSession()` should include `usageStats` without adding heavy detail fields.
+
+Realtime change detection should include stable usage fields in its state signature:
+
+- `totalCost`
+- `totalTokens`
+- `apiCalls`
+
+The client session version signature should include cost and token totals so `App` re-runs `checkSessionChanges` for cost-only changes.
+
+For a focused notification regression, expose a small pure helper that derives notification events from previous and next sessions. The hook can call that helper and forward events to `notify()`.
+
+## Failure Behavior
+
+- Missing usage columns must serialize as no `usageStats`, not zero-cost guessed data.
+- Cost updates must not require full session fetches.
+- Notification derivation must not throw when a previous session lacks `usageStats`.
+
+## Verification Plan
+
+- `bun test src/__tests__/session-response.test.ts src/__tests__/sessions.route-basic.test.ts src/__tests__/use-notifications.test.ts`
+- `bun run typecheck`
+- `bun test`
+- `bun run build`
+
+## Rollback
+
+- Remove usage fields from the lightweight query and basic serializer.
+- Remove the client usage fields from the version signature and realtime state signature.
+- Remove the notification helper test.

--- a/specs/GH79/product.md
+++ b/specs/GH79/product.md
@@ -1,0 +1,35 @@
+# Hook Server Request Security Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/79
+
+## Summary
+
+The local hook HTTP server must reject browser-originated or DNS-rebound requests that do not target a loopback host. Hook events and context reads are local automation surfaces, not public browser APIs.
+
+## User Problem
+
+Keepline's main web server validates local Host and browser request metadata, but the hook server accepts every Host, Origin, and browser fetch metadata value. A malicious browser page can attempt DNS-rebinding or cross-origin requests against the local hook port to forge hook events or read context data.
+
+## Product Behavior
+
+1. The hook server only accepts requests whose `Host` header names a loopback host such as `127.0.0.1`, `localhost`, or `[::1]`.
+2. Requests with a non-loopback `Host` are rejected with 403 before route handlers run.
+3. Requests with an `Origin` header must have a loopback origin.
+4. Requests with browser Fetch Metadata must be `same-origin`, `same-site`, or `none`.
+5. CLI/Claude hook requests without `Origin` or `Sec-Fetch-Site` remain supported when their Host header is loopback.
+6. The `/context` endpoint is protected by the same request gate as `/hook`, `/health`, and `/compression/stats`.
+
+## Non-Goals
+
+- Do not introduce a shared hook token in this tranche.
+- Do not change hook event payload semantics.
+- Do not make the hook server remotely accessible.
+- Do not change the configured default hook port.
+
+## Acceptance Criteria
+
+1. A `POST /hook` request with `Host: attacker.example` receives 403.
+2. A `GET /context` request with loopback Host but cross-origin `Origin` receives 403.
+3. A `GET /health` request with loopback Host remains accepted.
+4. A loopback `POST /hook` with an invalid body reaches validation and returns 400 rather than being rejected by the security gate.
+5. Focused tests, `bun run typecheck`, `bun test`, and `bun run build` pass.

--- a/specs/GH79/tasks.md
+++ b/specs/GH79/tasks.md
@@ -1,0 +1,78 @@
+# Hook Server Request Security Task Plan
+
+Issue: https://github.com/majiayu000/keepline/issues/79
+
+## Tasks
+
+### SP79-T1: Add SpecRail artifacts
+
+Done when:
+
+- `specs/GH79/product.md` exists.
+- `specs/GH79/tech.md` exists.
+- `specs/GH79/tasks.md` exists.
+
+Verify:
+
+```sh
+test -f specs/GH79/product.md
+test -f specs/GH79/tech.md
+test -f specs/GH79/tasks.md
+```
+
+### SP79-T2: Add hook request gate
+
+Writable files:
+
+- `src/adapters/hook/server.ts`
+
+Done when:
+
+- Hook server rejects non-loopback Host headers.
+- Hook server rejects non-loopback Origins when present.
+- Hook server rejects cross-site Fetch Metadata when present.
+- Loopback local automation without browser headers still works.
+
+Verify:
+
+```sh
+bun test src/__tests__/hook.server.test.ts
+```
+
+### SP79-T3: Add regression tests
+
+Writable files:
+
+- `src/__tests__/hook.server.test.ts`
+
+Done when:
+
+- Non-loopback Host on `/hook` returns 403.
+- Cross-origin `/context` returns 403.
+- Loopback `/health` returns 200.
+- Loopback invalid hook payload returns 400.
+
+Verify:
+
+```sh
+bun test src/__tests__/hook.server.test.ts
+```
+
+### SP79-T4: Full verification and PR
+
+Done when:
+
+- Focused tests pass.
+- Typecheck passes.
+- Full tests pass.
+- Build passes.
+- PR links and closes #79.
+
+Verify:
+
+```sh
+bun test src/__tests__/hook.server.test.ts
+bun run typecheck
+bun test
+bun run build
+```

--- a/specs/GH79/tech.md
+++ b/specs/GH79/tech.md
@@ -1,0 +1,51 @@
+# Hook Server Request Security Tech Spec
+
+Product spec: `specs/GH79/product.md`
+
+Issue: https://github.com/majiayu000/keepline/issues/79
+
+## Context
+
+- `src/adapters/hook/server.ts` builds a standalone Fastify server bound to `127.0.0.1`.
+- The hook server exposes `/hook`, `/context`, `/compression/stats`, and `/health`.
+- `src/web/api/request-security.ts` already exposes request security helpers:
+  - `isLoopbackHostHeader`
+  - `isLoopbackOrigin`
+  - `isAllowedFetchMetadata`
+- Fastify request headers are plain Node headers, so the hook server needs a small adapter for header lookup.
+
+## Design
+
+Add a hook-server request gate:
+
+```ts
+function isAllowedHookServerRequest(request: FastifyRequest): boolean
+```
+
+Rules:
+
+1. `Host` must pass `isLoopbackHostHeader`.
+2. If `Origin` is present, it must pass `isLoopbackOrigin`.
+3. If `Sec-Fetch-Site` is present, it must be `same-origin`, `same-site`, or `none`.
+
+Register the gate with Fastify `onRequest` before all route handlers. Reject denied requests with 403 and a generic `Forbidden` response.
+
+Extract server construction into `createHookServer()` so tests can use Fastify `inject()` without binding a real port. `startHookServer()` should continue to call the same route registration path.
+
+## Verification Plan
+
+- Add `src/__tests__/hook.server.test.ts`:
+  - rejects non-loopback Host for `/hook`
+  - rejects cross-origin `/context`
+  - accepts loopback `/health`
+  - allows loopback `/hook` to reach payload validation and return 400
+- Run:
+  - `bun test src/__tests__/hook.server.test.ts`
+  - `bun run typecheck`
+  - `bun test`
+  - `bun run build`
+
+## Rollback
+
+- Remove the Fastify `onRequest` gate and `createHookServer()` extraction.
+- Remove the focused hook server security tests.

--- a/specs/GH80/product.md
+++ b/specs/GH80/product.md
@@ -1,0 +1,37 @@
+# Runtime Identity Contract Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/80
+
+## Summary
+
+Keepline must not silently coerce unknown agent runtimes into Claude. Runtime identity should have one registered runtime-id source, and legacy session `client` values should be mapped through explicit, checked bridges.
+
+## User Problem
+
+The codebase currently has separate runtime/client vocabularies. The highest-risk behavior is that unknown runtime IDs can fall through bridge functions and become `claude`, which hides integration mistakes and mislabels future runtimes.
+
+## Product Behavior
+
+1. Registered runtime IDs are defined once in the runtime domain.
+2. The active session runtime filter uses the registered runtime ID source instead of duplicating string literals.
+3. `cursor` is not advertised as a registered runtime until an adapter is actually registered.
+4. `clientForRuntimeId()` rejects unknown runtime IDs instead of returning Claude.
+5. `runtimeIdForClient()` rejects unknown legacy clients instead of returning Claude.
+6. Existing Claude Code and Codex behavior remains unchanged.
+
+## Non-Goals
+
+- Do not remove the persisted legacy `client` column in this tranche.
+- Do not migrate every UI and repository type from `AgentClient` to `RuntimeId`.
+- Do not add a Cursor adapter.
+- Do not change public API response shapes except to avoid silent fallback.
+
+## Acceptance Criteria
+
+1. `RuntimeId` no longer contains a registered `cursor` literal without an adapter.
+2. `SessionRuntimeId` derives from the runtime-domain registered ID type.
+3. Runtime filter parsing accepts only registered runtime IDs and reports unknown IDs as invalid.
+4. Unknown runtime IDs do not map to Claude.
+5. Unknown legacy clients do not map to Claude.
+6. Regression tests cover known mappings and unknown rejection.
+7. Focused tests, `bun run typecheck`, `bun test`, and `bun run build` pass.

--- a/specs/GH80/tasks.md
+++ b/specs/GH80/tasks.md
@@ -1,0 +1,96 @@
+# Runtime Identity Contract Task Plan
+
+Issue: https://github.com/majiayu000/keepline/issues/80
+
+## Tasks
+
+### SP80-T1: Add SpecRail artifacts
+
+Done when:
+
+- `specs/GH80/product.md` exists.
+- `specs/GH80/tech.md` exists.
+- `specs/GH80/tasks.md` exists.
+
+Verify:
+
+```sh
+test -f specs/GH80/product.md
+test -f specs/GH80/tech.md
+test -f specs/GH80/tasks.md
+```
+
+### SP80-T2: Move registered runtime IDs to runtime domain
+
+Writable files:
+
+- `src/domain/runtime/types.ts`
+
+Done when:
+
+- Registered runtime IDs are exported as a const tuple.
+- `RuntimeId` derives from registered IDs plus future extension strings.
+- The dead `cursor` registered literal is removed.
+
+Verify:
+
+```sh
+bun run typecheck
+```
+
+### SP80-T3: Make runtime-status bridges explicit
+
+Writable files:
+
+- `src/services/runtime-status.ts`
+
+Done when:
+
+- `SessionRuntimeId` derives from `RegisteredRuntimeId`.
+- `runtimeIdForClient()` does not default unknown clients to Claude.
+- `clientForRuntimeId()` does not default unknown runtime IDs to Claude.
+- `parseRuntimeFilter()` checks registered runtime IDs.
+
+Verify:
+
+```sh
+bun test src/__tests__/runtime-status.test.ts
+```
+
+### SP80-T4: Add regression tests
+
+Writable files:
+
+- `src/__tests__/runtime-status.test.ts`
+
+Done when:
+
+- Known mappings still pass.
+- Unknown runtime IDs throw instead of returning `claude`.
+- Unknown clients throw instead of returning `claude-code`.
+- Runtime filters reject unregistered IDs.
+
+Verify:
+
+```sh
+bun test src/__tests__/runtime-status.test.ts
+```
+
+### SP80-T5: Full verification and PR
+
+Done when:
+
+- Focused tests pass.
+- Typecheck passes.
+- Full tests pass.
+- Build passes.
+- PR links and closes #80.
+
+Verify:
+
+```sh
+bun test src/__tests__/runtime-status.test.ts src/__tests__/session-runtime-scan.test.ts src/__tests__/sessions.route-basic.test.ts
+bun run typecheck
+bun test
+bun run build
+```

--- a/specs/GH80/tech.md
+++ b/specs/GH80/tech.md
@@ -1,0 +1,58 @@
+# Runtime Identity Contract Tech Spec
+
+Product spec: `specs/GH80/product.md`
+
+Issue: https://github.com/majiayu000/keepline/issues/80
+
+## Context
+
+- `src/domain/runtime/types.ts` declares `RuntimeId`.
+- `src/services/runtime-status.ts` declares a separate `SessionRuntimeId` and bridges runtime IDs to legacy `AgentClient`.
+- `clientForRuntimeId()` currently uses a default branch that maps anything except `codex` to `claude`.
+- `RuntimeId` includes `cursor` even though the default registry only registers Claude Code and Codex.
+
+## Design
+
+In `src/domain/runtime/types.ts`:
+
+```ts
+export const REGISTERED_RUNTIME_IDS = ['claude-code', 'codex'] as const
+export type RegisteredRuntimeId = typeof REGISTERED_RUNTIME_IDS[number]
+export type RuntimeId = RegisteredRuntimeId | (string & {})
+```
+
+In `src/services/runtime-status.ts`:
+
+- Define `SessionRuntimeId = RegisteredRuntimeId`.
+- Re-export `SESSION_RUNTIME_IDS = REGISTERED_RUNTIME_IDS`.
+- Use compile-time checked maps:
+
+```ts
+const CLIENT_RUNTIME_IDS = {
+  claude: 'claude-code',
+  codex: 'codex',
+} satisfies Record<AgentClient, SessionRuntimeId>
+
+const RUNTIME_CLIENTS = {
+  'claude-code': 'claude',
+  codex: 'codex',
+} satisfies Record<SessionRuntimeId, AgentClient>
+```
+
+- Add a small `isSessionRuntimeId()` guard.
+- Make bridge functions throw on unknown inputs.
+- Make `parseRuntimeFilter()` check the registered runtime ID set.
+
+## Verification Plan
+
+- Add `src/__tests__/runtime-status.test.ts`.
+- Run:
+  - `bun test src/__tests__/runtime-status.test.ts src/__tests__/session-runtime-scan.test.ts src/__tests__/sessions.route-basic.test.ts`
+  - `bun run typecheck`
+  - `bun test`
+  - `bun run build`
+
+## Rollback
+
+- Restore duplicated `SessionRuntimeId` literal union and old bridge functions.
+- Remove the runtime-status regression tests.

--- a/specs/GH81/product.md
+++ b/specs/GH81/product.md
@@ -1,0 +1,39 @@
+# Retention Cleanup Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/81
+
+## Summary
+
+Keepline's configured retention policy must actually delete old persisted data while the daemon is running. A default 30-day retention setting is currently declared but never executed.
+
+## User Problem
+
+Users are told that completed session data is retained for a bounded number of days, but completed sessions and related rows remain forever. Long-running daemon installations will grow the SQLite database indefinitely.
+
+## Product Behavior
+
+1. The daemon runs retention cleanup on startup and then periodically.
+2. `retentionDays > 0` enables cleanup.
+3. `retentionDays <= 0` disables cleanup.
+4. Cleanup deletes completed sessions older than the configured retention window.
+5. Cleanup deletes `tool_usage` and `hook_events` rows associated with deleted sessions.
+6. Cleanup deletes old domain events from the event store using the same cutoff.
+7. Active, waiting, idle, lost, or recent completed sessions are preserved.
+
+## Non-Goals
+
+- Do not delete active session history only because it is old.
+- Do not add a new user-facing config key.
+- Do not change the default retention value.
+- Do not vacuum or compact the SQLite database in this tranche.
+
+## Acceptance Criteria
+
+1. Daemon startup runs one retention cleanup cycle.
+2. Daemon schedules periodic retention cleanup when `retentionDays > 0`.
+3. `retentionDays <= 0` disables cleanup.
+4. Old completed sessions are deleted.
+5. Related `tool_usage` and `hook_events` rows for deleted sessions are deleted.
+6. Old event-store rows are deleted.
+7. Regression tests insert old records and prove cleanup removes only eligible data.
+8. Focused tests, `bun run typecheck`, `bun test`, and `bun run build` pass.

--- a/specs/GH81/tasks.md
+++ b/specs/GH81/tasks.md
@@ -1,0 +1,99 @@
+# Retention Cleanup Task Plan
+
+Issue: https://github.com/majiayu000/keepline/issues/81
+
+## Tasks
+
+### SP81-T1: Add SpecRail artifacts
+
+Done when:
+
+- `specs/GH81/product.md` exists.
+- `specs/GH81/tech.md` exists.
+- `specs/GH81/tasks.md` exists.
+
+Verify:
+
+```sh
+test -f specs/GH81/product.md
+test -f specs/GH81/tech.md
+test -f specs/GH81/tasks.md
+```
+
+### SP81-T2: Make old session deletion complete
+
+Writable files:
+
+- `src/infrastructure/database/repositories/session.repository.ts`
+
+Done when:
+
+- Old completed sessions are deleted in a transaction.
+- Matching `tool_usage` rows are deleted before sessions.
+- Matching `hook_events` rows are deleted.
+- Running or recent sessions are preserved.
+
+Verify:
+
+```sh
+bun test src/__tests__/retention.service.test.ts src/__tests__/session-repository.test.ts
+```
+
+### SP81-T3: Add retention service and scheduler wiring
+
+Writable files:
+
+- `src/services/retention.service.ts`
+- `src/services/daemon.scheduler.ts`
+
+Done when:
+
+- Cleanup can be called directly for tests.
+- Scheduler runs cleanup once on startup.
+- Scheduler schedules recurring cleanup when `retentionDays > 0`.
+- Scheduler clears the retention interval on stop.
+
+Verify:
+
+```sh
+bun run typecheck
+```
+
+### SP81-T4: Add retention regression tests
+
+Writable files:
+
+- `src/__tests__/retention.service.test.ts`
+
+Done when:
+
+- Old completed session rows are deleted.
+- Related usage and hook event rows are deleted.
+- Recent completed and old running sessions remain.
+- Old event-store rows are deleted.
+- `retentionDays <= 0` does not delete data.
+
+Verify:
+
+```sh
+bun test src/__tests__/retention.service.test.ts
+```
+
+### SP81-T5: Full verification and PR
+
+Done when:
+
+- Focused tests pass.
+- Typecheck passes.
+- Full tests pass.
+- Build passes.
+- PR links and closes #81.
+
+Verify:
+
+```sh
+bun test src/__tests__/retention.service.test.ts src/__tests__/session-repository.test.ts
+bun run typecheck
+bun test
+bun run build
+```

--- a/specs/GH81/tech.md
+++ b/specs/GH81/tech.md
@@ -1,0 +1,70 @@
+# Retention Cleanup Tech Spec
+
+Product spec: `specs/GH81/product.md`
+
+Issue: https://github.com/majiayu000/keepline/issues/81
+
+## Context
+
+- `config.retentionDays` defaults to 30 and validates as non-negative.
+- `sessionRepository.deleteOldSessions(retentionDays)` exists but is not called.
+- `eventStore.deleteOlderThan(date)` exists but is not called.
+- `tool_usage` has a foreign key to `sessions(session_id)`, so old session deletion must remove child usage rows first.
+- `hook_events` has `session_id` but no foreign key; it should still be cleaned for deleted sessions.
+
+## Design
+
+Add `src/services/retention.service.ts`:
+
+```ts
+interface RetentionCleanupResult {
+  disabled: boolean
+  retentionDays: number
+  cutoff?: Date
+  sessionsDeleted: number
+  eventsDeleted: number
+}
+```
+
+`runRetentionCleanup(retentionDays = config.get().retentionDays, now = new Date())`:
+
+1. If `retentionDays <= 0`, return a disabled result without touching storage.
+2. Compute `cutoff = now - retentionDays`.
+3. Call `sessionRepository.deleteOldSessions(retentionDays, now)`.
+4. Call `eventStore.deleteOlderThan(cutoff)`.
+5. Log the cleanup result.
+
+Update `sessionRepository.deleteOldSessions()` to run in one transaction:
+
+1. Count completed sessions whose `last_active_at` is older than cutoff.
+2. Delete `tool_usage` rows for those session IDs.
+3. Delete `hook_events` rows for those session IDs.
+4. Delete the session rows.
+5. Return the deleted session count.
+
+Update `daemon.scheduler.ts`:
+
+- Add a daily retention interval.
+- Run one cleanup cycle after the initial scan.
+- Schedule recurring cleanup only when startup config has `retentionDays > 0`.
+- Clear the interval on scheduler stop.
+
+## Verification Plan
+
+- Add `src/__tests__/retention.service.test.ts`:
+  - old completed sessions and related usage/hook rows are removed
+  - recent completed sessions and old non-completed sessions are preserved
+  - old event-store rows are removed
+  - `retentionDays <= 0` is a no-op
+- Run:
+  - `bun test src/__tests__/retention.service.test.ts src/__tests__/session-repository.test.ts`
+  - `bun run typecheck`
+  - `bun test`
+  - `bun run build`
+
+## Rollback
+
+- Remove the scheduler retention interval.
+- Remove `retention.service.ts`.
+- Restore `deleteOldSessions()` to only delete sessions.
+- Remove retention tests.

--- a/specs/GH82/product.md
+++ b/specs/GH82/product.md
@@ -1,0 +1,87 @@
+# P2 Audit Rollup Triage And Hardening Product Spec
+
+Issue: https://github.com/majiayu000/keepline/issues/82
+
+## Summary
+
+GH82 is a P2 technical-debt rollup from codebase audit findings. It mixes
+immediate correctness bugs, security-adjacent persistence risks, stale findings,
+items already covered by open P1 PRs, and larger architecture cleanups.
+
+This tranche converts the rollup into SpecRail-owned work and fixes the
+high-confidence items that can be changed independently of the current P0/P1 PR
+queue. It does not close GH82 until every checklist item is either fixed,
+verified stale, or split into accepted follow-up issues.
+
+## User Problem
+
+Users trust Keepline for cost visibility, session recovery, and live status. A
+few silent or stale behaviors erode that trust:
+
+1. Codex sessions can display zero cost even when token usage exists in the
+   session stream.
+2. Non-Anthropic model pricing can be omitted or silently priced as Claude.
+3. The daemon can run with stale pricing or keep running after fatal process
+   errors.
+4. Concurrent SQLite writers can fail with avoidable `SQLITE_BUSY` errors.
+5. API pagination with invalid numbers can return misleading empty results.
+6. PID reuse can make an old session look attached to a new process.
+7. Session fields that should clear can remain stale forever.
+
+## Product Behavior
+
+1. Codex token and cost data should be parsed from supported Codex JSONL usage
+   events and persisted into `usageStats` when present.
+2. Pricing should use LiteLLM entries for all providers when token costs are
+   available, while preserving known Claude defaults.
+3. Unknown model pricing should be visible in logs instead of silently looking
+   precise.
+4. The daemon should initialize pricing before sync cycles and exit on
+   uncaught exceptions or unhandled rejections so a supervisor can restart it.
+5. SQLite should wait briefly for concurrent writers instead of failing
+   immediately.
+6. Session list pagination should reject invalid `limit` or `offset` values
+   with a 400 response.
+7. PID continuity should only preserve a PID match when process start time is
+   compatible with the previous session.
+8. Explicit nullable session fields should be clearable when an updater sends
+   the field with `undefined` or `null`.
+9. Test database reset should remove the optional `events` table as well as the
+   core migrated tables.
+
+## Non-Goals
+
+- Do not duplicate the open GH74 LanceDB predicate hardening PR.
+- Do not duplicate the open GH75 hook pipeline PR.
+- Do not duplicate the open GH78-GH81 P1 fixes.
+- Do not refactor frontend runtime validation, status displays, env config, or
+  adapter layer boundaries in this tranche.
+- Do not remove public EventStore exports in a hardening tranche.
+- Do not close GH82 from this partial tranche.
+
+## Acceptance Criteria
+
+1. `specs/GH82/product.md`, `tech.md`, and `tasks.md` exist.
+2. Codex parser tests prove supported `event_msg` usage entries produce
+   non-zero `usageStats`.
+3. Pricing tests prove OpenAI/LiteLLM-style non-Anthropic entries are retained
+   and unknown model fallback is logged.
+4. Daemon startup initializes pricing and fatal process errors exit instead of
+   continuing silently.
+5. SQLite connection setup applies a non-zero busy timeout.
+6. Session route tests prove invalid `limit` and `offset` return HTTP 400.
+7. Process matcher tests prove reused PIDs with incompatible start times are not
+   treated as continuity.
+8. Repository tests prove nullable activity fields can be explicitly cleared.
+9. Reset database tests prove the optional `events` table is dropped.
+10. Verification passes: focused tests, `bun run typecheck`, `bun test`, and
+    `bun run build`.
+
+## Related Work
+
+- PR #84 covers GH74 LanceDB predicate hardening.
+- PR #87 covers GH75 hook pipeline restoration.
+- PR #90 covers GH78 usage data in basic session payloads.
+- PR #91 covers GH79 hook server request guards.
+- PR #92 covers GH80 runtime identity contract cleanup.
+- PR #93 covers GH81 retention cleanup scheduling.

--- a/specs/GH82/tasks.md
+++ b/specs/GH82/tasks.md
@@ -1,0 +1,132 @@
+# P2 Audit Rollup Triage And Hardening Task Plan
+
+Issue: https://github.com/majiayu000/keepline/issues/82
+
+Product spec: `specs/GH82/product.md`
+Tech spec: `specs/GH82/tech.md`
+
+## Tasks
+
+### SP82-T1: Add SpecRail packet and scope map
+
+Done when:
+
+- `specs/GH82/product.md` exists.
+- `specs/GH82/tech.md` exists.
+- `specs/GH82/tasks.md` exists.
+- Scope explicitly avoids duplicating open P0/P1 PRs.
+
+Verify:
+
+```sh
+test -f specs/GH82/product.md
+test -f specs/GH82/tech.md
+test -f specs/GH82/tasks.md
+```
+
+### SP82-T2: Parse Codex usage events
+
+Done when:
+
+- Codex parser accumulates supported `event_msg` usage records.
+- Missing or malformed usage records are ignored without breaking session parse.
+- Parsed Codex sessions include non-zero `usageStats` when usage telemetry is
+  present.
+
+Verify:
+
+```sh
+bun test src/__tests__/codex.parser.test.ts
+```
+
+### SP82-T3: Remove silent/stale pricing behavior
+
+Done when:
+
+- LiteLLM pricing import retains non-Anthropic model entries with token costs.
+- Unknown-model fallback emits a warning once per model.
+- Usage extraction no longer caches per-model pricing forever.
+
+Verify:
+
+```sh
+bun test src/__tests__/usage.pricing.test.ts src/__tests__/usage.extractor.test.ts
+```
+
+### SP82-T4: Harden daemon and SQLite startup
+
+Done when:
+
+- Daemon scheduler initializes pricing before scans.
+- Fatal daemon errors log, emit, stop, and exit with code 1.
+- SQLite sets a non-zero busy timeout.
+
+Verify:
+
+```sh
+bun run typecheck
+```
+
+### SP82-T5: Validate session API pagination
+
+Done when:
+
+- Invalid `limit` and `offset` return HTTP 400.
+- Valid pagination behavior remains unchanged.
+
+Verify:
+
+```sh
+bun test src/__tests__/sessions.route-basic.test.ts
+```
+
+### SP82-T6: Prevent PID reuse continuity matches
+
+Done when:
+
+- Existing PID continuity still works for compatible process start times.
+- Reused PID with an incompatible start time falls back to matching logic and
+  does not attach to stale session history.
+
+Verify:
+
+```sh
+bun test src/__tests__/session.process-matcher.test.ts
+```
+
+### SP82-T7: Clear stale nullable session fields
+
+Done when:
+
+- Upsert preserves nullable fields when omitted.
+- Upsert clears nullable fields when the key is present with `undefined` or
+  `null`.
+
+Verify:
+
+```sh
+bun test src/__tests__/session-repository.test.ts
+```
+
+### SP82-T8: Reset optional events table
+
+Done when:
+
+- `resetDatabase()` drops `events`.
+- A test proves rows inserted through EventStore do not survive reset.
+
+Verify:
+
+```sh
+bun test src/__tests__/reset-database.test.ts
+```
+
+### SP82-T9: Full verification and PR gate
+
+Done when:
+
+- Focused tests pass.
+- `bun run typecheck` passes.
+- `bun test` passes.
+- `bun run build` passes.
+- PR uses `Refs #82`, not `Closes #82`.

--- a/specs/GH82/tech.md
+++ b/specs/GH82/tech.md
@@ -1,0 +1,148 @@
+# P2 Audit Rollup Triage And Hardening Tech Spec
+
+Product spec: `specs/GH82/product.md`
+
+Issue: https://github.com/majiayu000/keepline/issues/82
+
+## Implementation Scope
+
+This tranche changes only files needed for non-overlapping hardening:
+
+- `src/adapters/codex/parser.ts`
+- `src/services/usage.pricing.ts`
+- `src/services/usage.extractor.ts`
+- `src/services/daemon.scheduler.ts`
+- `src/infrastructure/database/sqlite.ts`
+- `src/infrastructure/database/repositories/session.repository.ts`
+- `src/db/migrations.ts`
+- `src/web/api/routes/sessions.ts`
+- `src/services/session.process-matcher.ts`
+- focused tests for those modules
+
+LanceDB predicate handling, hook server installation semantics, retention
+scheduling, runtime identity vocabulary, and basic usage serialization are
+covered by existing open PRs and should not be duplicated here.
+
+## Codex Usage Parsing
+
+Codex JSONL may include usage telemetry in `event_msg` payloads. The parser
+must tolerate multiple telemetry shapes because historical Codex event payloads
+are not a stable public API.
+
+Supported shapes:
+
+```ts
+{
+  type: 'event_msg',
+  timestamp: string,
+  payload: {
+    model?: string,
+    usage?: {
+      input_tokens?: number,
+      output_tokens?: number,
+      cache_creation_input_tokens?: number,
+      cache_read_input_tokens?: number
+    }
+  }
+}
+```
+
+```ts
+{
+  type: 'event_msg',
+  payload: {
+    msg?: {
+      model?: string,
+      usage?: {
+        input_tokens?: number,
+        output_tokens?: number
+      }
+    }
+  }
+}
+```
+
+The parser should also accept camelCase token fields for compatibility with
+normalized Codex event emitters. Usage with missing numeric input or output
+tokens is ignored.
+
+Use the existing usage accumulator helpers so cost logic stays shared with
+Claude usage aggregation.
+
+## Pricing
+
+`fetchLiteLLMPricing()` should retain every LiteLLM model entry with both
+`input_cost_per_token` and `output_cost_per_token`, regardless of provider. It
+should keep provider-prefixed keys such as `openai/gpt-4o-mini` and exact keys
+as LiteLLM publishes them.
+
+Unknown-model fallback remains available for continuity, but `getModelPricing`
+must emit a warning the first time a model falls back so silent mispricing does
+not pass as precise output.
+
+The usage extractor should not keep an independent forever cache of per-token
+pricing. Recomputing the per-token values from the current pricing config is
+cheap and prevents stale cost models after pricing refresh.
+
+## Daemon Fatal Errors
+
+`startScheduler()` should call `initPricing()` after database migrations and
+before initial sync. Failure to fetch remote pricing still falls back to default
+pricing inside the pricing module.
+
+`runDaemon()` should still log and emit errors for `uncaughtException` and
+`unhandledRejection`, then stop the scheduler and exit with code 1. Continuing
+after these fatal errors is unsafe because the daemon may be partially broken
+while status still appears running.
+
+## SQLite
+
+After opening the database, set:
+
+```sql
+PRAGMA busy_timeout = 5000
+```
+
+Keep WAL and foreign keys enabled.
+
+## Sessions API Pagination
+
+Parse `limit` and `offset` through a small validator:
+
+- default `limit`: 50
+- max `limit`: 100
+- default `offset`: 0
+- invalid, non-integer, negative, or zero-limit values return HTTP 400
+
+## PID Continuity
+
+PID continuity remains preferred only when the directory/client group matches
+and the process start time is compatible with the stored session timeline.
+
+A process is compatible when its start time is not materially after the stored
+session's last active timestamp. A small clock-skew tolerance is allowed.
+Incompatible PID reuse falls back to the normal assignment algorithm instead of
+being accepted as continuity.
+
+## Nullable Session Fields
+
+Repository upsert already uses presence checks for `pid` and `tty`. Apply the
+same pattern to nullable activity fields that can become stale:
+
+- `lastTool`
+- `lastToolInput`
+- `currentFile`
+- `lastMessage`
+- `completedAt`
+- `agentId`
+- `parentSessionId`
+- `usageStats`
+- `toolCalls`
+
+When a field is omitted, preserve the old value. When a field key is present
+with `undefined` or `null`, write NULL.
+
+## Reset Database
+
+`resetDatabase()` must drop `events` before re-running migrations so tests and
+local resets do not retain optional EventStore rows.

--- a/src/__tests__/attention.prioritizer.test.ts
+++ b/src/__tests__/attention.prioritizer.test.ts
@@ -259,6 +259,7 @@ describe('buildAttentionOverview', () => {
 
     expect(overview.items[0].intent).toMatchObject({
       task: 'Investigate: Denoise probe 第一次启动失败了，我先看 stderr',
+      taskSource: 'last_message',
       currentState: 'Denoise probe 第一次启动失败了，我先看 stderr。通常这种是脚本路径或 OpenVINO Async API 细节。',
       nextAction: 'Recover this session and continue around topaz_dragon_cleanup_20260629T035947Z/cleanup_standard.png.',
       whyAttention: 'Session is lost and may be recoverable',
@@ -289,6 +290,7 @@ describe('buildAttentionOverview', () => {
     expect(overview.items[0].intent.task).toBe(
       'Continue: 结论是：gh21 应该学习产品行为和交互契约，不是照搬原型 UI'
     );
+    expect(overview.items[0].intent.taskSource).toBe('last_message');
   });
 
   test('does not use low-information responses as derived tasks', () => {
@@ -303,6 +305,7 @@ describe('buildAttentionOverview', () => {
     ], { now: NOW });
 
     expect(overview.items[0].intent.task).toBeUndefined();
+    expect(overview.items[0].intent.taskSource).toBe('none');
     expect(overview.items[0].intent.currentState).toBe('继续正常。');
     expect(overview.items[0].intent.noiseFlags).toEqual([
       'instructions_heavy',
@@ -322,6 +325,7 @@ describe('buildAttentionOverview', () => {
     ], { now: NOW });
 
     expect(overview.items[0].intent.task).toBeUndefined();
+    expect(overview.items[0].intent.taskSource).toBe('none');
     expect(overview.items[0].intent.currentState).toBe('你好，我在。 Memory citations: none');
   });
 
@@ -361,5 +365,6 @@ describe('buildAttentionOverview', () => {
       status: 'fresh',
       generatedAt: '2026-06-29T12:00:00.000Z',
     });
+    expect(overview.items[1].intent.taskSource).toBe('digest');
   });
 });

--- a/src/__tests__/claude.scanner.test.ts
+++ b/src/__tests__/claude.scanner.test.ts
@@ -15,7 +15,8 @@ function writeSessionFile(
   homeDir: string,
   projectDirName: string,
   filename: string,
-  lines: Array<Record<string, unknown> | string>
+  lines: Array<Record<string, unknown> | string>,
+  options: { trailingNewline?: boolean } = {}
 ): string {
   const projectDir = join(homeDir, '.claude', 'projects', projectDirName);
   mkdirSync(projectDir, { recursive: true });
@@ -23,7 +24,7 @@ function writeSessionFile(
   const contents = lines
     .map((line) => (typeof line === 'string' ? line : JSON.stringify(line)))
     .join('\n');
-  writeFileSync(filePath, `${contents}\n`);
+  writeFileSync(filePath, options.trailingNewline === false ? contents : `${contents}\n`);
   return filePath;
 }
 
@@ -94,6 +95,18 @@ describe('Claude Scanner', () => {
         message: { role: 'user', content: 'This file is broken' },
       },
       '{"type":"assistant", invalid json',
+      {
+        type: 'assistant',
+        uuid: 'assistant-after-bad-line',
+        sessionId: 'broken-session',
+        cwd: '/tmp/broken-project',
+        timestamp: '2026-04-13T11:00:01.000Z',
+        message: {
+          role: 'assistant',
+          model: 'claude-3-5-sonnet-20241022',
+          content: [{ type: 'text', text: 'Line after corruption' }],
+        },
+      },
     ]);
 
     const result = runScannerScript(homeDir, `
@@ -124,6 +137,18 @@ describe('Claude Scanner', () => {
         message: { role: 'user', content: 'Broken on first scan' },
       },
       '{"type":"assistant", invalid json',
+      {
+        type: 'assistant',
+        uuid: 'assistant-after-bad-line',
+        sessionId: 'repair-session',
+        cwd: '/tmp/repair-project',
+        timestamp: '2026-04-13T11:10:01.000Z',
+        message: {
+          role: 'assistant',
+          model: 'claude-3-5-sonnet-20241022',
+          content: [{ type: 'text', text: 'Line after corruption' }],
+        },
+      },
     ]);
 
     const result = runScannerScript(homeDir, `
@@ -229,6 +254,43 @@ describe('Claude Scanner', () => {
       hasToolCalls: true,
       toolCalls: ['Read'],
       toolCount: 1,
+    });
+  });
+
+  test('does not cache a final-line truncation as a Claude parse failure', () => {
+    const homeDir = createTempHome();
+
+    writeSessionFile(homeDir, '-tmp-truncated-project', 'truncated-session.jsonl', [
+      {
+        type: 'user',
+        uuid: 'user-1',
+        sessionId: 'truncated-session',
+        cwd: '/tmp/truncated-project',
+        timestamp: '2026-04-13T11:30:00.000Z',
+        userType: 'external',
+        message: { role: 'user', content: 'Visible despite truncated tail' },
+      },
+      '{"type":"assistant","message":{"content":',
+    ], { trailingNewline: false });
+
+    const result = runScannerScriptDetailed(homeDir, `
+      const { clearSessionCache, getAllSessionsWithFailures } = await import('./src/adapters/claude/scanner.ts');
+      clearSessionCache();
+      const first = await getAllSessionsWithFailures();
+      const second = await getAllSessionsWithFailures();
+      console.log(JSON.stringify({
+        firstSessions: first.sessions.map((session) => session.sessionId),
+        firstFailures: first.failures.map((failure) => failure.filePath),
+        secondSessions: second.sessions.map((session) => session.sessionId),
+        secondFailures: second.failures.map((failure) => failure.filePath),
+      }));
+    `).data;
+
+    expect(result).toEqual({
+      firstSessions: ['truncated-session'],
+      firstFailures: [],
+      secondSessions: ['truncated-session'],
+      secondFailures: [],
     });
   });
 
@@ -354,6 +416,18 @@ describe('Claude Scanner', () => {
         message: { role: 'user', content: 'broken file should be persisted' },
       },
       '{"type":"assistant", invalid json',
+      {
+        type: 'assistant',
+        uuid: 'assistant-after-bad-line',
+        sessionId: 'persist-broken',
+        cwd: '/tmp/persist-broken',
+        timestamp: '2026-04-13T12:00:01.000Z',
+        message: {
+          role: 'assistant',
+          model: 'claude-3-5-sonnet-20241022',
+          content: [{ type: 'text', text: 'Line after corruption' }],
+        },
+      },
     ]);
 
     const firstRun = runScannerScriptDetailed(homeDir, `
@@ -388,6 +462,18 @@ describe('Claude Scanner', () => {
         message: { role: 'user', content: 'broken file should still report errors' },
       },
       '{"type":"assistant", invalid json',
+      {
+        type: 'assistant',
+        uuid: 'assistant-after-bad-line',
+        sessionId: 'persist-error',
+        cwd: '/tmp/persist-runtime-error',
+        timestamp: '2026-04-13T12:05:01.000Z',
+        message: {
+          role: 'assistant',
+          model: 'claude-3-5-sonnet-20241022',
+          content: [{ type: 'text', text: 'Line after corruption' }],
+        },
+      },
     ]);
 
     const firstRun = runScannerScript(homeDir, `
@@ -428,6 +514,18 @@ describe('Claude Scanner', () => {
           message: { role: 'user', content: 'broken file' },
         },
         '{"type":"assistant", invalid json',
+        {
+          type: 'assistant',
+          uuid: `assistant-after-bad-line-${i}`,
+          sessionId: `broken-${i}`,
+          cwd: '/tmp/many-broken',
+          timestamp: '2026-04-13T12:10:01.000Z',
+          message: {
+            role: 'assistant',
+            model: 'claude-3-5-sonnet-20241022',
+            content: [{ type: 'text', text: 'Line after corruption' }],
+          },
+        },
       ]);
     }
 

--- a/src/__tests__/codex.parser.test.ts
+++ b/src/__tests__/codex.parser.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { ParseError } from '../lib/errors.js';
 import {
   parseCodexSessionFile,
   scopeCodexSessionId,
@@ -10,14 +11,17 @@ import {
 
 const tempDirs: string[] = [];
 
-function createCodexJsonlFile(lines: Array<Record<string, unknown> | string>): string {
+function createCodexJsonlFile(
+  lines: Array<Record<string, unknown> | string>,
+  options: { trailingNewline?: boolean } = {}
+): string {
   const dir = mkdtempSync(join(tmpdir(), 'keepline-jsonl-'));
   tempDirs.push(dir);
   const filePath = join(dir, 'rollout-019ed4a3-2186-7e51-9aa1-ca1e376549b8.jsonl');
   const contents = lines
     .map((line) => (typeof line === 'string' ? line : JSON.stringify(line)))
     .join('\n');
-  writeFileSync(filePath, `${contents}\n`);
+  writeFileSync(filePath, options.trailingNewline === false ? contents : `${contents}\n`);
   return filePath;
 }
 
@@ -30,7 +34,8 @@ function createTempHome(): string {
 function writeCodexSessionFile(
   homeDir: string,
   rawSessionId: string,
-  lines: Array<Record<string, unknown> | string>
+  lines: Array<Record<string, unknown> | string>,
+  options: { trailingNewline?: boolean } = {}
 ): string {
   const sessionDir = join(homeDir, '.codex', 'sessions', '2026', '06', '23');
   mkdirSync(sessionDir, { recursive: true });
@@ -38,7 +43,7 @@ function writeCodexSessionFile(
   const contents = lines
     .map((line) => (typeof line === 'string' ? line : JSON.stringify(line)))
     .join('\n');
-  writeFileSync(filePath, `${contents}\n`);
+  writeFileSync(filePath, options.trailingNewline === false ? contents : `${contents}\n`);
   return filePath;
 }
 
@@ -143,6 +148,60 @@ describe('Codex JSONL parser', () => {
       },
     ]);
   });
+
+  test('skips a truncated final JSONL line while preserving parsed session data', async () => {
+    const filePath = createCodexJsonlFile([
+      {
+        type: 'session_meta',
+        timestamp: '2026-06-17T01:00:00.000Z',
+        payload: {
+          id: '019ed4a3-2186-7e51-9aa1-ca1e376549b8',
+          cwd: '/tmp/codex-project',
+        },
+      },
+      {
+        type: 'response_item',
+        timestamp: '2026-06-17T01:00:03.000Z',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'Recover Codex tail' }],
+        },
+      },
+      '{"type":"response_item","payload":{"type":"message"',
+    ], { trailingNewline: false });
+
+    const parsed = await parseCodexSessionFile(filePath);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed!.rawSessionId).toBe('019ed4a3-2186-7e51-9aa1-ca1e376549b8');
+    expect(parsed!.firstMessage).toBe('Recover Codex tail');
+  });
+
+  test('throws ParseError for non-final invalid JSONL', async () => {
+    const filePath = createCodexJsonlFile([
+      {
+        type: 'session_meta',
+        timestamp: '2026-06-17T01:00:00.000Z',
+        payload: {
+          id: '019ed4a3-2186-7e51-9aa1-ca1e376549b8',
+          cwd: '/tmp/codex-project',
+        },
+      },
+      '{"type":"response_item", invalid json',
+      {
+        type: 'response_item',
+        timestamp: '2026-06-17T01:00:03.000Z',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'This should not mask corruption' }],
+        },
+      },
+    ]);
+
+    await expect(parseCodexSessionFile(filePath)).rejects.toBeInstanceOf(ParseError);
+  });
 });
 
 describe('Codex scanner', () => {
@@ -160,6 +219,15 @@ describe('Codex scanner', () => {
         },
       },
       '{"type":"response_item", invalid json',
+      {
+        type: 'response_item',
+        timestamp: '2026-06-23T01:00:02.000Z',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'Line after corruption' }],
+        },
+      },
     ]);
     writeCodexSessionFile(homeDir, healthyId, [
       {
@@ -199,6 +267,51 @@ describe('Codex scanner', () => {
       firstFailures: [brokenPath],
       secondSessions: [healthyId],
       secondFailures: [brokenPath],
+    });
+  });
+
+  test('does not cache a final-line truncation as a Codex parse failure', () => {
+    const homeDir = createTempHome();
+    const truncatedId = '019ed4a3-2186-7e51-9aa1-ca1e376549b8';
+    writeCodexSessionFile(homeDir, truncatedId, [
+      {
+        type: 'session_meta',
+        timestamp: '2026-06-23T01:00:00.000Z',
+        payload: {
+          id: truncatedId,
+          cwd: '/tmp/truncated-codex',
+        },
+      },
+      {
+        type: 'response_item',
+        timestamp: '2026-06-23T01:00:01.000Z',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'Visible despite truncation' }],
+        },
+      },
+      '{"type":"response_item","payload":{"type":"message"',
+    ], { trailingNewline: false });
+
+    const result = runCodexScannerScript(homeDir, `
+      const { clearCodexSessionCache, getAllCodexSessionsWithFailures } = await import('./src/adapters/codex/scanner.ts');
+      clearCodexSessionCache();
+      const first = await getAllCodexSessionsWithFailures();
+      const second = await getAllCodexSessionsWithFailures();
+      console.log(JSON.stringify({
+        firstSessions: first.sessions.map((session) => session.rawSessionId),
+        firstFailures: first.failures.map((failure) => failure.filePath),
+        secondSessions: second.sessions.map((session) => session.rawSessionId),
+        secondFailures: second.failures.map((failure) => failure.filePath),
+      }));
+    `);
+
+    expect(result).toEqual({
+      firstSessions: [truncatedId],
+      firstFailures: [],
+      secondSessions: [truncatedId],
+      secondFailures: [],
     });
   });
 });

--- a/src/__tests__/codex.parser.test.ts
+++ b/src/__tests__/codex.parser.test.ts
@@ -143,6 +143,43 @@ describe('Codex JSONL parser', () => {
       },
     ]);
   });
+
+  test('accumulates token usage from Codex event messages', async () => {
+    const filePath = createCodexJsonlFile([
+      {
+        type: 'session_meta',
+        timestamp: '2026-06-17T01:00:00.000Z',
+        payload: {
+          id: '019ed4a3-2186-7e51-9aa1-ca1e376549b8',
+          cwd: '/tmp/codex-project',
+        },
+      },
+      {
+        type: 'event_msg',
+        timestamp: '2026-06-17T01:00:05.000Z',
+        payload: {
+          msg: {
+            model: 'gpt-4o-mini',
+            usage: {
+              input_tokens: 1000,
+              output_tokens: 250,
+              cache_read_input_tokens: 100,
+            },
+          },
+        },
+      },
+    ]);
+
+    const parsed = await parseCodexSessionFile(filePath);
+
+    expect(parsed?.usageStats).toMatchObject({
+      totalInputTokens: 1100,
+      totalOutputTokens: 250,
+      totalTokens: 1350,
+      apiCalls: 1,
+    });
+    expect(parsed?.usageStats?.totalCost).toBeGreaterThan(0);
+  });
 });
 
 describe('Codex scanner', () => {

--- a/src/__tests__/codex.scanner.test.ts
+++ b/src/__tests__/codex.scanner.test.ts
@@ -65,7 +65,20 @@ describe('Codex session scanner', () => {
     const sessionsDir = join(tempDir, 'sessions');
     mkdirSync(sessionsDir);
     const invalidFile = join(sessionsDir, 'rollout-12345678-1234-1234-1234-123456789abc.jsonl');
-    writeFileSync(invalidFile, '{not-json}\n');
+    writeFileSync(
+      invalidFile,
+      [
+        '{not-json}',
+        JSON.stringify({
+          type: 'session_meta',
+          timestamp: '2026-06-23T01:00:00.000Z',
+          payload: {
+            id: '12345678-1234-1234-1234-123456789abc',
+            cwd: '/tmp/broken-codex',
+          },
+        }),
+      ].join('\n') + '\n'
+    );
 
     const sessions = await getAllCodexSessions({ sessionsDir });
 

--- a/src/__tests__/hook.installer.test.ts
+++ b/src/__tests__/hook.installer.test.ts
@@ -10,6 +10,7 @@ const markedCommand = 'KEEPLINE_HOOK_MARKER=keepline-hook-v1 curl -s -X POST htt
 const unrelatedLocalhostCommand = 'curl -s http://127.0.0.1:7777/other-hook';
 const legacyKeeplineCommand = `curl -s -X POST http://127.0.0.1:7890/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
 const foreignLegacyShapeCommand = `curl -s -X POST https://collector.example/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
+const expectedHandler = { type: 'command', command: markedCommand };
 
 describe('hook installer ownership detection', () => {
   test('does not claim unrelated localhost hooks', () => {
@@ -31,8 +32,20 @@ describe('hook installer ownership detection', () => {
 
     expect(changed).toBe(true);
     expect(settings.hooks?.PostToolUse).toHaveLength(2);
-    expect(settings.hooks?.PostToolUse?.[0].command).toBe(unrelatedLocalhostCommand);
-    expect(settings.hooks?.PostToolUse?.[1].command).toBe(markedCommand);
+    expect(settings.hooks?.PostToolUse?.[0]).toEqual({ command: unrelatedLocalhostCommand });
+    expect(settings.hooks?.PostToolUse?.[1]).toEqual({
+      matcher: '*',
+      hooks: [expectedHandler],
+    });
+    expect(settings.hooks?.PreToolUse).toEqual([
+      {
+        matcher: '*',
+        hooks: [expectedHandler],
+      },
+    ]);
+    expect(settings.hooks?.Notification).toEqual([{ hooks: [expectedHandler] }]);
+    expect(settings.hooks?.Stop).toEqual([{ hooks: [expectedHandler] }]);
+    expect(settings.hooks?.UserPromptSubmit).toEqual([{ hooks: [expectedHandler] }]);
   });
 
   test('uninstall removes only Keepline-owned hooks', () => {
@@ -56,6 +69,32 @@ describe('hook installer ownership detection', () => {
     expect(settings.hooks?.Stop).toEqual([{ command: 'echo keep-me' }]);
   });
 
+  test('uninstall removes Keepline handlers from mixed matcher groups', () => {
+    const settings: ClaudeSettings = {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: '*',
+            hooks: [
+              { type: 'command', command: markedCommand },
+              { type: 'command', command: 'echo keep-me' },
+            ],
+          },
+        ],
+      },
+    };
+
+    const removed = uninstallKeeplineHookConfig(settings);
+
+    expect(removed).toBe(1);
+    expect(settings.hooks?.PostToolUse).toEqual([
+      {
+        matcher: '*',
+        hooks: [{ type: 'command', command: 'echo keep-me' }],
+      },
+    ]);
+  });
+
   test('install upgrades a legacy Keepline hook without duplicating', () => {
     const settings: ClaudeSettings = {
       hooks: {
@@ -66,6 +105,27 @@ describe('hook installer ownership detection', () => {
     const changed = installKeeplineHookConfig(settings, markedCommand);
 
     expect(changed).toBe(true);
-    expect(settings.hooks?.PostToolUse).toEqual([{ command: markedCommand }]);
+    expect(settings.hooks?.PostToolUse).toEqual([
+      {
+        matcher: '*',
+        hooks: [expectedHandler],
+      },
+    ]);
+    expect(settings.hooks?.PreToolUse).toEqual([
+      {
+        matcher: '*',
+        hooks: [expectedHandler],
+      },
+    ]);
+    expect(settings.hooks?.Notification).toEqual([{ hooks: [expectedHandler] }]);
+    expect(settings.hooks?.Stop).toEqual([{ hooks: [expectedHandler] }]);
+    expect(settings.hooks?.UserPromptSubmit).toEqual([{ hooks: [expectedHandler] }]);
+  });
+
+  test('reinstalling an existing full Keepline config is a no-op', () => {
+    const settings: ClaudeSettings = {};
+
+    expect(installKeeplineHookConfig(settings, markedCommand)).toBe(true);
+    expect(installKeeplineHookConfig(settings, markedCommand)).toBe(false);
   });
 });

--- a/src/__tests__/hook.installer.test.ts
+++ b/src/__tests__/hook.installer.test.ts
@@ -4,47 +4,79 @@ import {
   isKeeplineHook,
   uninstallKeeplineHookConfig,
 } from '../adapters/hook/installer.js';
-import type { ClaudeSettings } from '../adapters/hook/types.js';
+import type { ClaudeSettings, ClaudeHookMatcher } from '../adapters/hook/types.js';
 
-const markedCommand = 'KEEPLINE_HOOK_MARKER=keepline-hook-v1 curl -s -X POST http://127.0.0.1:7890/hook';
-const unrelatedLocalhostCommand = 'curl -s http://127.0.0.1:7777/other-hook';
+const markedCommand =
+  "KEEPLINE_HOOK_MARKER=keepline-hook-v2 curl -s -X POST http://127.0.0.1:7890/hook -H 'Content-Type: application/json' --data-binary @- >/dev/null 2>&1 || true";
+const unrelatedBlock: ClaudeHookMatcher = {
+  hooks: [{ type: 'command', command: 'curl -s http://127.0.0.1:7777/other-hook' }],
+};
 const legacyKeeplineCommand = `curl -s -X POST http://127.0.0.1:7890/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
-const foreignLegacyShapeCommand = `curl -s -X POST https://collector.example/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
 
 describe('hook installer ownership detection', () => {
   test('does not claim unrelated localhost hooks', () => {
-    expect(isKeeplineHook({ command: unrelatedLocalhostCommand })).toBe(false);
+    expect(
+      isKeeplineHook({ type: 'command', command: 'curl -s http://127.0.0.1:7777/other-hook' })
+    ).toBe(false);
   });
 
   test('does not claim non-local legacy-shaped hooks', () => {
-    expect(isKeeplineHook({ command: foreignLegacyShapeCommand })).toBe(false);
+    const foreign = legacyKeeplineCommand.replace('127.0.0.1:7890', 'collector.example');
+    expect(isKeeplineHook({ type: 'command', command: foreign })).toBe(false);
   });
 
-  test('install coexists with unrelated localhost hooks', () => {
+  test('registers under PostToolUse, Stop and UserPromptSubmit using the nested shape', () => {
+    const settings: ClaudeSettings = {};
+
+    const changed = installKeeplineHookConfig(settings, markedCommand);
+
+    expect(changed).toBe(true);
+    for (const event of ['PostToolUse', 'Stop', 'UserPromptSubmit'] as const) {
+      const blocks = settings.hooks?.[event];
+      expect(blocks).toHaveLength(1);
+      const entry = blocks?.[0].hooks[0];
+      expect(entry?.type).toBe('command');
+      expect(entry?.command).toBe(markedCommand);
+    }
+  });
+
+  test('install is idempotent (no duplicate registration)', () => {
+    const settings: ClaudeSettings = {};
+    installKeeplineHookConfig(settings, markedCommand);
+
+    const changedAgain = installKeeplineHookConfig(settings, markedCommand);
+
+    expect(changedAgain).toBe(false);
+    expect(settings.hooks?.PostToolUse).toHaveLength(1);
+  });
+
+  test('install coexists with unrelated hooks in the same event', () => {
     const settings: ClaudeSettings = {
-      hooks: {
-        PostToolUse: [{ command: unrelatedLocalhostCommand }],
-      },
+      hooks: { PostToolUse: [unrelatedBlock] },
     };
 
     const changed = installKeeplineHookConfig(settings, markedCommand);
 
     expect(changed).toBe(true);
     expect(settings.hooks?.PostToolUse).toHaveLength(2);
-    expect(settings.hooks?.PostToolUse?.[0].command).toBe(unrelatedLocalhostCommand);
-    expect(settings.hooks?.PostToolUse?.[1].command).toBe(markedCommand);
+    expect(settings.hooks?.PostToolUse?.[0]).toEqual(unrelatedBlock);
+    expect(settings.hooks?.PostToolUse?.[1].hooks[0].command).toBe(markedCommand);
   });
 
-  test('uninstall removes only Keepline-owned hooks', () => {
+  test('uninstall removes only Keepline-owned hooks and drops empty blocks', () => {
     const settings: ClaudeSettings = {
       hooks: {
         PostToolUse: [
-          { command: unrelatedLocalhostCommand },
-          { command: markedCommand },
+          unrelatedBlock,
+          { hooks: [{ type: 'command', command: markedCommand }] },
         ],
         Stop: [
-          { command: legacyKeeplineCommand },
-          { command: 'echo keep-me' },
+          {
+            hooks: [
+              { type: 'command', command: legacyKeeplineCommand },
+              { type: 'command', command: 'echo keep-me' },
+            ],
+          },
         ],
       },
     };
@@ -52,20 +84,36 @@ describe('hook installer ownership detection', () => {
     const removed = uninstallKeeplineHookConfig(settings);
 
     expect(removed).toBe(2);
-    expect(settings.hooks?.PostToolUse).toEqual([{ command: unrelatedLocalhostCommand }]);
-    expect(settings.hooks?.Stop).toEqual([{ command: 'echo keep-me' }]);
+    // Keepline-only block dropped; unrelated block preserved.
+    expect(settings.hooks?.PostToolUse).toEqual([unrelatedBlock]);
+    // Mixed block keeps the non-Keepline hook only.
+    expect(settings.hooks?.Stop).toEqual([
+      { hooks: [{ type: 'command', command: 'echo keep-me' }] },
+    ]);
   });
 
-  test('install upgrades a legacy Keepline hook without duplicating', () => {
+  test('install upgrades a legacy Keepline hook in place without duplicating', () => {
     const settings: ClaudeSettings = {
       hooks: {
-        PostToolUse: [{ command: legacyKeeplineCommand }],
+        PostToolUse: [{ hooks: [{ type: 'command', command: legacyKeeplineCommand }] }],
       },
     };
 
     const changed = installKeeplineHookConfig(settings, markedCommand);
 
     expect(changed).toBe(true);
-    expect(settings.hooks?.PostToolUse).toEqual([{ command: markedCommand }]);
+    expect(settings.hooks?.PostToolUse).toHaveLength(1);
+    expect(settings.hooks?.PostToolUse?.[0].hooks[0].command).toBe(markedCommand);
+  });
+
+  test('generated command forwards stdin and does not rely on $CLAUDE_* env vars', () => {
+    const settings: ClaudeSettings = {};
+    installKeeplineHookConfig(settings);
+    const command = settings.hooks?.PostToolUse?.[0].hooks[0].command ?? '';
+
+    expect(command).toContain('--data-binary @-');
+    expect(command).not.toContain('$CLAUDE_EVENT_TYPE');
+    expect(command).not.toContain('$CLAUDE_SESSION_ID');
+    expect(command).not.toContain('$CLAUDE_TOOL_INPUT');
   });
 });

--- a/src/__tests__/hook.server-parse.test.ts
+++ b/src/__tests__/hook.server-parse.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression tests for GH #75: the hook server must parse Claude Code's native
+ * stdin payload (`hook_event_name`, `tool_response`, ...) — not the old
+ * `event_type` shape that depended on non-existent `$CLAUDE_*` env vars.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { parseHookEvent } from '../adapters/hook/server.js';
+
+const SESSION = 'session-abcdef01';
+
+describe('parseHookEvent (GH #75)', () => {
+  test('parses a native PostToolUse payload', () => {
+    const event = parseHookEvent({
+      hook_event_name: 'PostToolUse',
+      session_id: SESSION,
+      cwd: '/tmp/repo',
+      tool_name: 'Edit',
+      tool_input: { file_path: '/tmp/repo/a.ts' },
+      tool_response: { content: 'ok' },
+    });
+
+    expect(event).not.toBeNull();
+    expect(event?.event_type).toBe('PostToolUse');
+    expect(event?.session_id).toBe(SESSION);
+    expect((event as { tool_name: string }).tool_name).toBe('Edit');
+    // tool output is normalized from tool_response and stringified.
+    expect((event as { tool_output?: string }).tool_output).toBe('{"content":"ok"}');
+    // timestamp is stamped on receipt (Claude does not send one).
+    expect(typeof event?.timestamp).toBe('string');
+  });
+
+  test('parses a native UserPromptSubmit payload', () => {
+    const event = parseHookEvent({
+      hook_event_name: 'UserPromptSubmit',
+      session_id: SESSION,
+      cwd: '/tmp/repo',
+      prompt: 'do the thing',
+    });
+
+    expect(event?.event_type).toBe('UserPromptSubmit');
+    expect((event as { prompt: string }).prompt).toBe('do the thing');
+  });
+
+  test('parses a native Stop payload', () => {
+    const event = parseHookEvent({
+      hook_event_name: 'Stop',
+      session_id: SESSION,
+      stop_reason: 'completed',
+    });
+
+    expect(event?.event_type).toBe('Stop');
+    expect((event as { reason?: string }).reason).toBe('completed');
+  });
+
+  test('rejects the legacy event_type shape (no hook_event_name)', () => {
+    expect(
+      parseHookEvent({
+        event_type: 'PostToolUse',
+        session_id: SESSION,
+        cwd: '/tmp/repo',
+        timestamp: '2026-01-01T00:00:00Z',
+        tool_name: 'Edit',
+        tool_input: {},
+      })
+    ).toBeNull();
+  });
+
+  test('rejects unknown event types, bad session ids and non-objects', () => {
+    expect(parseHookEvent({ hook_event_name: 'Bogus', session_id: SESSION })).toBeNull();
+    expect(parseHookEvent({ hook_event_name: 'Stop', session_id: "x' OR '1'='1" })).toBeNull();
+    expect(parseHookEvent(null)).toBeNull();
+    expect(parseHookEvent('not-an-object')).toBeNull();
+  });
+
+  test('rejects a tool event with no tool_name', () => {
+    expect(
+      parseHookEvent({ hook_event_name: 'PostToolUse', session_id: SESSION, tool_input: {} })
+    ).toBeNull();
+  });
+});

--- a/src/__tests__/hook.server.test.ts
+++ b/src/__tests__/hook.server.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { FastifyInstance } from 'fastify';
+import { createHookServer } from '../adapters/hook/server.js';
+
+describe('hook server request security', () => {
+  let server: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+      server = null;
+    }
+  });
+
+  function app(): FastifyInstance {
+    server = createHookServer();
+    return server;
+  }
+
+  test('rejects non-loopback Host headers before hook validation', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/hook',
+      headers: {
+        host: 'attacker.example',
+        'content-type': 'application/json',
+      },
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(403);
+    const body = response.json() as { success: boolean; error: string };
+    expect(body).toEqual({ success: false, error: 'Forbidden' });
+  });
+
+  test('rejects cross-origin context reads', async () => {
+    const response = await app().inject({
+      method: 'GET',
+      url: '/context?path=/tmp/project',
+      headers: {
+        host: '127.0.0.1:7890',
+        origin: 'https://attacker.example',
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  test('accepts loopback health requests', async () => {
+    const response = await app().inject({
+      method: 'GET',
+      url: '/health',
+      headers: {
+        host: 'localhost:7890',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ status: 'ok' });
+  });
+
+  test('allows loopback hook requests to reach payload validation', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/hook',
+      headers: {
+        host: '127.0.0.1:7890',
+        'content-type': 'application/json',
+      },
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json() as { success: boolean; error: string };
+    expect(body).toEqual({
+      success: false,
+      error: 'Invalid hook event payload',
+    });
+  });
+
+  test('rejects cross-site browser fetch metadata', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/hook',
+      headers: {
+        host: '127.0.0.1:7890',
+        'sec-fetch-site': 'cross-site',
+        'content-type': 'application/json',
+      },
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+});

--- a/src/__tests__/hook.server.test.ts
+++ b/src/__tests__/hook.server.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test';
+import { isValidHookEvent, normalizeHookEvent } from '../adapters/hook/server.js';
+
+const fixedNow = new Date('2026-07-02T15:30:00.000Z');
+
+describe('hook server payload normalization', () => {
+  test('accepts current Claude Code PostToolUse stdin payloads', () => {
+    const event = normalizeHookEvent(
+      {
+        session_id: 'session-1234',
+        transcript_path: '/tmp/transcript.jsonl',
+        cwd: '/tmp/project',
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Write',
+        tool_input: {
+          file_path: '/tmp/project/file.txt',
+          content: 'hello',
+        },
+        tool_response: {
+          filePath: '/tmp/project/file.txt',
+          success: true,
+        },
+      },
+      fixedNow
+    );
+
+    expect(event).toEqual({
+      event_type: 'PostToolUse',
+      session_id: 'session-1234',
+      transcript_path: '/tmp/transcript.jsonl',
+      cwd: '/tmp/project',
+      timestamp: '2026-07-02T15:30:00.000Z',
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '/tmp/project/file.txt',
+        content: 'hello',
+      },
+      tool_output: '{"filePath":"/tmp/project/file.txt","success":true}',
+    });
+  });
+
+  test('accepts legacy Keepline event_type payloads', () => {
+    const event = normalizeHookEvent({
+      event_type: 'PreToolUse',
+      session_id: 'session-1234',
+      cwd: '/tmp/project',
+      timestamp: '2026-07-02T15:31:00.000Z',
+      tool_name: 'Bash',
+      tool_input: {
+        command: 'bun test',
+      },
+    });
+
+    expect(event).toEqual({
+      event_type: 'PreToolUse',
+      session_id: 'session-1234',
+      cwd: '/tmp/project',
+      timestamp: '2026-07-02T15:31:00.000Z',
+      transcript_path: undefined,
+      tool_name: 'Bash',
+      tool_input: {
+        command: 'bun test',
+      },
+      tool_output: undefined,
+    });
+  });
+
+  test('accepts UserPromptSubmit without a synthetic timestamp from the command', () => {
+    expect(
+      isValidHookEvent({
+        session_id: 'session-1234',
+        cwd: '/tmp/project',
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'Summarize this repo',
+      })
+    ).toBe(true);
+  });
+
+  test('rejects malformed tool payloads', () => {
+    expect(
+      normalizeHookEvent({
+        session_id: 'session-1234',
+        cwd: '/tmp/project',
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Write',
+      })
+    ).toBeNull();
+  });
+});

--- a/src/__tests__/jsonl.parser.test.ts
+++ b/src/__tests__/jsonl.parser.test.ts
@@ -14,14 +14,17 @@ import { parseSessionFile } from '../adapters/claude/parser/jsonl.js';
 
 const tempDirs: string[] = [];
 
-function createJsonlFile(lines: Array<Record<string, unknown> | string>): string {
+function createJsonlFile(
+  lines: Array<Record<string, unknown> | string>,
+  options: { trailingNewline?: boolean } = {}
+): string {
   const dir = mkdtempSync(join(tmpdir(), 'keepline-jsonl-'));
   tempDirs.push(dir);
   const filePath = join(dir, 'session.jsonl');
   const contents = lines
     .map((line) => (typeof line === 'string' ? line : JSON.stringify(line)))
     .join('\n');
-  writeFileSync(filePath, `${contents}\n`);
+  writeFileSync(filePath, options.trailingNewline === false ? contents : `${contents}\n`);
   return filePath;
 }
 
@@ -225,7 +228,31 @@ describe('JSONL Session Parser', () => {
     expect(parsed!.lastActiveAt.toISOString()).toBe('2026-04-13T10:00:05.000Z');
   });
 
-  test('throws ParseError with file path and line number for invalid JSONL', async () => {
+  test('skips a truncated final JSONL line while preserving parsed session data', async () => {
+    const filePath = createJsonlFile([
+      {
+        type: 'user',
+        uuid: 'user-1',
+        sessionId: 'session-truncated-tail',
+        cwd: '/tmp/project',
+        timestamp: '2026-04-13T12:00:00.000Z',
+        userType: 'external',
+        message: {
+          role: 'user',
+          content: 'Recover me despite a truncated tail',
+        },
+      },
+      '{"type":"assistant","message":{"content":',
+    ], { trailingNewline: false });
+
+    const parsed = await parseSessionFile(filePath);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed!.sessionId).toBe('session-truncated-tail');
+    expect(parsed!.firstMessage).toBe('Recover me despite a truncated tail');
+  });
+
+  test('throws ParseError with file path and line number for non-final invalid JSONL', async () => {
     const filePath = createJsonlFile([
       {
         type: 'user',
@@ -240,6 +267,18 @@ describe('JSONL Session Parser', () => {
         },
       },
       '{"type":"assistant", bad json',
+      {
+        type: 'assistant',
+        uuid: 'assistant-after-bad-line',
+        sessionId: 'session-1',
+        cwd: '/tmp/project',
+        timestamp: '2026-04-13T12:00:01.000Z',
+        message: {
+          role: 'assistant',
+          model: 'claude-3-5-sonnet-20241022',
+          content: [{ type: 'text', text: 'This line must not hide the prior corruption' }],
+        },
+      },
     ]);
 
     try {

--- a/src/__tests__/observation-id.test.ts
+++ b/src/__tests__/observation-id.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { LanceDBVectorStore } from '../infrastructure/vector/lancedb.adapter.js';
+import { resetDatabase } from '../db/migrations.js';
+import { closeDatabase } from '../infrastructure/database/sqlite.js';
+import { setupUser } from '../services/auth.service.js';
+import memory from '../web/api/routes/memory.js';
+
+const INJECTION_ID = "x' OR '1'='1";
+const MISSING_VALID_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('observation id hardening', () => {
+  const tempDirs: string[] = [];
+
+  beforeEach(() => {
+    resetDatabase();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function vectorStoreWithTempPath(): LanceDBVectorStore {
+    const path = mkdtempSync(join(tmpdir(), 'keepline-gh74-lancedb-'));
+    tempDirs.push(path);
+    return new LanceDBVectorStore({ path });
+  }
+
+  test('memory GET route rejects injection-shaped observation IDs before vector access', async () => {
+    const { token } = await setupUser('alice', 'password123');
+
+    const response = await memory.fetch(new Request(
+      `http://localhost/observations/${encodeURIComponent(INJECTION_ID)}`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(400);
+    const body = await response.json() as { success: boolean; error: string };
+    expect(body).toEqual({
+      success: false,
+      error: 'Invalid observation ID format',
+    });
+  });
+
+  test('memory DELETE route rejects injection-shaped observation IDs before vector access', async () => {
+    const { token } = await setupUser('bob', 'password123');
+
+    const response = await memory.fetch(new Request(
+      `http://localhost/observations/${encodeURIComponent(INJECTION_ID)}`,
+      {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    ));
+
+    expect(response.status).toBe(400);
+    const body = await response.json() as { success: boolean; error: string };
+    expect(body).toEqual({
+      success: false,
+      error: 'Invalid observation ID format',
+    });
+  });
+
+  test('LanceDBVectorStore rejects unsafe getById IDs before initialization', async () => {
+    const store = vectorStoreWithTempPath();
+
+    await expect(store.getById(INJECTION_ID)).rejects.toThrow('Invalid observation ID format');
+  });
+
+  test('LanceDBVectorStore rejects unsafe delete IDs before initialization', async () => {
+    const store = vectorStoreWithTempPath();
+
+    await expect(store.delete(INJECTION_ID)).rejects.toThrow('Invalid observation ID format');
+  });
+
+  test('LanceDBVectorStore preserves not-found semantics for safe missing IDs', async () => {
+    const store = vectorStoreWithTempPath();
+
+    await expect(store.getById(MISSING_VALID_ID)).resolves.toBeNull();
+    await expect(store.delete(MISSING_VALID_ID)).resolves.toBe(false);
+  });
+});

--- a/src/__tests__/orchestrator.route.test.ts
+++ b/src/__tests__/orchestrator.route.test.ts
@@ -76,10 +76,12 @@ describe('Orchestrator Route Contract', () => {
           };
           intent: {
             task?: string;
+            taskSource: string;
             currentState?: string;
             nextAction: string;
             whyAttention: string;
             confidence: string;
+            noiseFlags: string[];
           };
           reasons: Array<{ code: string }>;
         }>;
@@ -104,6 +106,7 @@ describe('Orchestrator Route Contract', () => {
       },
       intent: {
         task: 'Track cost',
+        taskSource: 'initial_prompt',
         currentState: 'Cost is high, review before continuing',
         nextAction: 'Recover this session and continue around keepline-orchestrator/report.md.',
         whyAttention: 'Session is lost and may be recoverable; Session cost is $5.00',
@@ -111,6 +114,56 @@ describe('Orchestrator Route Contract', () => {
       },
     });
     expect(body.data.items[0].reasons.map((reason) => reason.code)).toContain('high_cost');
+  });
+
+  test('overview marks tasks derived from noisy prompt fallbacks as last-message sourced', async () => {
+    sessionRepository.upsert({
+      sessionId: 'orchestrator-last-message-derived',
+      client: 'codex',
+      directory: '/tmp/keepline-derived-intent',
+      status: 'waiting',
+      title: '# AGENTS.md instructions <INSTRUCTIONS> vibeguard-start',
+      initialPrompt: '# AGENTS.md instructions <INSTRUCTIONS> Files called AGENTS.md commonly appear in many places.',
+      lastMessage: 'Continue: 首页已经看到新定位，项目页这次正则没有命中，我会查一下 dev server 输出。',
+      lastActiveAt: recentSessionDate(),
+      toolCount: 3,
+      messageCount: 8,
+    });
+
+    const { token } = await setupUser('orchestrator-derived-intent-user', 'password123');
+    const response = await orchestrator.fetch(new Request(
+      'http://localhost/overview?limit=1',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as {
+      success: boolean;
+      data: {
+        items: Array<{
+          sessionId: string;
+          intent: {
+            task?: string;
+            taskSource: string;
+            noiseFlags: string[];
+          };
+        }>;
+      };
+    };
+
+    expect(body.success).toBe(true);
+    expect(body.data.items[0]).toMatchObject({
+      sessionId: 'orchestrator-last-message-derived',
+      intent: {
+        taskSource: 'last_message',
+        noiseFlags: expect.arrayContaining([
+          'instructions_heavy',
+          'derived_from_last_message',
+          'missing_user_goal',
+        ]),
+      },
+    });
+    expect(body.data.items[0].intent.task).toStartWith('Continue:');
   });
 
   test('server mounts the orchestrator overview route', async () => {

--- a/src/__tests__/reset-database.test.ts
+++ b/src/__tests__/reset-database.test.ts
@@ -39,4 +39,30 @@ describe('resetDatabase', () => {
     expect(queryOne<{ count: number }>('SELECT COUNT(*) as count FROM terminal_sessions')?.count).toBe(0);
     expect((queryOne<{ count: number }>('SELECT COUNT(*) as count FROM schema_migrations')?.count ?? 0)).toBeGreaterThan(0);
   });
+
+  test('sets a non-zero SQLite busy timeout', () => {
+    expect(queryOne<{ timeout: number }>('PRAGMA busy_timeout')?.timeout).toBe(5000);
+  });
+
+  test('drops optional events table during reset', () => {
+    runSql(`
+      CREATE TABLE IF NOT EXISTS events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        type TEXT NOT NULL,
+        aggregate_id TEXT,
+        payload TEXT,
+        timestamp TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    runSql(
+      'INSERT INTO events (type, aggregate_id, payload, timestamp) VALUES (?, ?, ?, ?)',
+      ['test.event', 'aggregate-1', '{}', '2026-04-13T10:00:00.000Z']
+    );
+
+    resetDatabase();
+
+    expect(queryOne<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'events'"
+    ) ?? undefined).toBeUndefined();
+  });
 });

--- a/src/__tests__/retention.service.test.ts
+++ b/src/__tests__/retention.service.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { resetDatabase } from '../db/migrations.js';
+import { closeDatabase, getDatabase } from '../infrastructure/database/sqlite.js';
+import { sessionRepository } from '../infrastructure/database/repositories/session.repository.js';
+import { eventStore } from '../infrastructure/events/store.js';
+import { runRetentionCleanup } from '../services/retention.service.js';
+
+const NOW = new Date('2026-07-02T12:00:00.000Z');
+const OLD_DATE = new Date('2026-05-01T12:00:00.000Z');
+const RECENT_DATE = new Date('2026-06-25T12:00:00.000Z');
+
+describe('retention cleanup', () => {
+  beforeEach(async () => {
+    resetDatabase();
+    await eventStore.deleteOlderThan(new Date('9999-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  function count(table: string, where: string = '1 = 1'): number {
+    const row = getDatabase()
+      .prepare(`SELECT COUNT(*) as count FROM ${table} WHERE ${where}`)
+      .get() as { count: number };
+    return row.count;
+  }
+
+  function insertSession(sessionId: string, status: 'completed' | 'running', lastActiveAt: Date) {
+    sessionRepository.upsert({
+      sessionId,
+      directory: '/tmp/project',
+      status,
+      title: sessionId,
+      initialPrompt: sessionId,
+      startedAt: lastActiveAt,
+      lastActiveAt,
+      completedAt: status === 'completed' ? lastActiveAt : undefined,
+      toolCount: 1,
+      messageCount: 1,
+    });
+  }
+
+  function insertUsageAndHookEvents(sessionId: string) {
+    const db = getDatabase();
+    db.prepare(`
+      INSERT INTO tool_usage (session_id, tool, input, output, duration, timestamp)
+      VALUES (?, 'Edit', '{}', '{}', 10, ?)
+    `).run(sessionId, OLD_DATE.toISOString());
+    db.prepare(`
+      INSERT INTO hook_events (session_id, event_type, payload, timestamp)
+      VALUES (?, 'PostToolUse', '{}', ?)
+    `).run(sessionId, OLD_DATE.toISOString());
+  }
+
+  test('deletes old completed sessions, related rows, and old events', async () => {
+    insertSession('old-completed-session', 'completed', OLD_DATE);
+    insertSession('recent-completed-session', 'completed', RECENT_DATE);
+    insertSession('old-running-session', 'running', OLD_DATE);
+    insertUsageAndHookEvents('old-completed-session');
+    insertUsageAndHookEvents('recent-completed-session');
+    insertUsageAndHookEvents('old-running-session');
+
+    await eventStore.append({
+      type: 'old:event',
+      aggregateId: 'old',
+      payload: {},
+      timestamp: OLD_DATE,
+    });
+    await eventStore.append({
+      type: 'recent:event',
+      aggregateId: 'recent',
+      payload: {},
+      timestamp: RECENT_DATE,
+    });
+
+    const result = await runRetentionCleanup(30, NOW);
+
+    expect(result).toMatchObject({
+      disabled: false,
+      retentionDays: 30,
+      sessionsDeleted: 1,
+      eventsDeleted: 1,
+    });
+    expect(sessionRepository.findBySessionId('old-completed-session')).toBeNull();
+    expect(sessionRepository.findBySessionId('recent-completed-session')).not.toBeNull();
+    expect(sessionRepository.findBySessionId('old-running-session')).not.toBeNull();
+    expect(count('tool_usage', "session_id = 'old-completed-session'")).toBe(0);
+    expect(count('hook_events', "session_id = 'old-completed-session'")).toBe(0);
+    expect(count('tool_usage', "session_id = 'recent-completed-session'")).toBe(1);
+    expect(count('hook_events', "session_id = 'old-running-session'")).toBe(1);
+    expect(await eventStore.count()).toBe(1);
+  });
+
+  test('retentionDays <= 0 disables cleanup', async () => {
+    insertSession('old-completed-session', 'completed', OLD_DATE);
+    insertUsageAndHookEvents('old-completed-session');
+    await eventStore.append({
+      type: 'old:event',
+      aggregateId: 'old',
+      payload: {},
+      timestamp: OLD_DATE,
+    });
+
+    const result = await runRetentionCleanup(0, NOW);
+
+    expect(result).toEqual({
+      disabled: true,
+      retentionDays: 0,
+      sessionsDeleted: 0,
+      eventsDeleted: 0,
+    });
+    expect(sessionRepository.findBySessionId('old-completed-session')).not.toBeNull();
+    expect(count('tool_usage', "session_id = 'old-completed-session'")).toBe(1);
+    expect(await eventStore.count()).toBe(1);
+  });
+});

--- a/src/__tests__/runtime-status.test.ts
+++ b/src/__tests__/runtime-status.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  REGISTERED_RUNTIME_IDS,
+  type RuntimeId,
+} from '../domain/runtime/index.js';
+import type { AgentClient } from '../domain/session/index.js';
+import {
+  clientForRuntimeId,
+  isSessionRuntimeId,
+  parseRuntimeFilter,
+  runtimeIdForClient,
+  SESSION_RUNTIME_IDS,
+} from '../services/runtime-status.js';
+
+describe('runtime identity status helpers', () => {
+  test('session runtime IDs come from registered runtime IDs', () => {
+    expect(SESSION_RUNTIME_IDS).toBe(REGISTERED_RUNTIME_IDS);
+    expect(SESSION_RUNTIME_IDS).toEqual(['claude-code', 'codex']);
+  });
+
+  test('maps known legacy clients to registered runtime IDs', () => {
+    expect(runtimeIdForClient('claude')).toBe('claude-code');
+    expect(runtimeIdForClient('codex')).toBe('codex');
+  });
+
+  test('maps known runtime IDs to legacy clients', () => {
+    expect(clientForRuntimeId('claude-code')).toBe('claude');
+    expect(clientForRuntimeId('codex')).toBe('codex');
+  });
+
+  test('does not silently map unknown runtime IDs to Claude', () => {
+    expect(isSessionRuntimeId('cursor')).toBe(false);
+    expect(() => clientForRuntimeId('cursor' as RuntimeId)).toThrow('Unsupported runtime id: cursor');
+  });
+
+  test('does not silently map unknown clients to Claude Code', () => {
+    expect(() => runtimeIdForClient('gemini' as AgentClient)).toThrow('Unsupported agent client: gemini');
+  });
+
+  test('runtime filter parser rejects unregistered runtime IDs', () => {
+    expect(parseRuntimeFilter('claude-code')).toEqual({ runtimeId: 'claude-code' });
+    expect(parseRuntimeFilter('codex')).toEqual({ runtimeId: 'codex' });
+    expect(parseRuntimeFilter('cursor')).toEqual({ invalid: 'cursor' });
+  });
+});

--- a/src/__tests__/session-repository.test.ts
+++ b/src/__tests__/session-repository.test.ts
@@ -124,4 +124,58 @@ describe('Session Repository Upsert', () => {
     const fetched = sessionRepository.findBySessionId('session-completed-insert');
     expect(fetched?.completedAt?.toISOString()).toBe('2026-04-13T16:00:00.000Z');
   });
+
+  test('clears nullable activity fields when explicitly provided as undefined', () => {
+    sessionRepository.upsert({
+      sessionId: 'session-clear-nullable-fields',
+      directory: '/tmp/repo',
+      status: 'completed',
+      title: 'Clear fields',
+      initialPrompt: 'Prompt',
+      lastTool: 'Read',
+      lastToolInput: JSON.stringify({ path: '/tmp/repo/file.ts' }),
+      currentFile: '/tmp/repo/file.ts',
+      lastMessage: 'Done',
+      completedAt: new Date('2026-04-13T16:00:00.000Z'),
+      lastActiveAt: new Date('2026-04-13T16:00:00.000Z'),
+      agentId: 'agent-1',
+      parentSessionId: 'parent-1',
+      usageStats: {
+        totalInputTokens: 10,
+        totalOutputTokens: 20,
+        totalTokens: 30,
+        totalCost: 0.12,
+        apiCalls: 1,
+      },
+      toolCalls: [
+        { name: 'Read', input: { path: '/tmp/repo/file.ts' }, timestamp: '2026-04-13T15:59:00.000Z' },
+      ],
+    });
+
+    sessionRepository.upsert({
+      sessionId: 'session-clear-nullable-fields',
+      title: 'Still preserves omitted title updates',
+      lastTool: undefined,
+      lastToolInput: undefined,
+      currentFile: undefined,
+      lastMessage: undefined,
+      completedAt: undefined,
+      agentId: undefined,
+      parentSessionId: undefined,
+      usageStats: undefined,
+      toolCalls: undefined,
+    });
+
+    const fetched = sessionRepository.findBySessionId('session-clear-nullable-fields');
+    expect(fetched?.title).toBe('Still preserves omitted title updates');
+    expect(fetched?.lastTool).toBeUndefined();
+    expect(fetched?.lastToolInput).toBeUndefined();
+    expect(fetched?.currentFile).toBeUndefined();
+    expect(fetched?.lastMessage).toBeUndefined();
+    expect(fetched?.completedAt).toBeUndefined();
+    expect(fetched?.agentId).toBeUndefined();
+    expect(fetched?.parentSessionId).toBeUndefined();
+    expect(fetched?.usageStats).toBeUndefined();
+    expect(fetched?.toolCalls).toBeUndefined();
+  });
 });

--- a/src/__tests__/session-response.test.ts
+++ b/src/__tests__/session-response.test.ts
@@ -3,7 +3,7 @@ import { generateTitle } from '../domain/session/entity.js';
 import { serializeBasicSession } from '../web/api/session-response.js';
 
 describe('Session Response Serialization', () => {
-  test('serializeBasicSession emits only lightweight list fields', () => {
+  test('serializeBasicSession emits lightweight list fields with usage stats', () => {
     const createdAt = new Date('2026-04-13T14:00:00.000Z');
     const updatedAt = new Date('2026-04-13T14:05:00.000Z');
     const startedAt = new Date('2026-04-13T13:55:00.000Z');
@@ -29,6 +29,13 @@ describe('Session Response Serialization', () => {
       tty: 'ttys001',
       toolCount: 7,
       messageCount: 3,
+      usageStats: {
+        totalInputTokens: 1200,
+        totalOutputTokens: 300,
+        totalTokens: 1500,
+        totalCost: 1.25,
+        apiCalls: 4,
+      },
       createdAt,
       updatedAt,
       processRunning: true,
@@ -55,6 +62,13 @@ describe('Session Response Serialization', () => {
       tty: 'ttys001',
       toolCount: 7,
       messageCount: 3,
+      usageStats: {
+        totalInputTokens: 1200,
+        totalOutputTokens: 300,
+        totalTokens: 1500,
+        totalCost: 1.25,
+        apiCalls: 4,
+      },
       processRunning: true,
       cpuUsage: 1.5,
       memoryUsage: 2.5,

--- a/src/__tests__/session.process-matcher.test.ts
+++ b/src/__tests__/session.process-matcher.test.ts
@@ -49,6 +49,27 @@ describe('matchProcessesToSessions', () => {
     expect(matches.get('session-b')?.pid).toBe(1002);
   });
 
+  test('does not preserve a reused PID when process start time is incompatible', () => {
+    const base = Date.now();
+    const sessions = [
+      sessionCandidate({
+        sessionId: 'stale-known-pid',
+        pid: 1001,
+        startedAt: new Date(base - 4 * 60 * 60 * 1000),
+        lastActiveAt: new Date(base - 3 * 60 * 60 * 1000),
+      }),
+    ];
+    const processes = [
+      processCandidate({
+        pid: 1001,
+        startTime: new Date(base),
+      }),
+    ];
+
+    const matches = matchProcessesToSessions(sessions, processes);
+    expect(matches.has('stale-known-pid')).toBe(false);
+  });
+
   test('matches same-directory sessions by closest start time', () => {
     const base = Date.now();
     const sessions = [

--- a/src/__tests__/session.service-sync.test.ts
+++ b/src/__tests__/session.service-sync.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const tempDirs: string[] = [];
+
+function createTempHome(): string {
+  const homeDir = mkdtempSync(join(tmpdir(), 'keepline-sync-home-'));
+  tempDirs.push(homeDir);
+  return homeDir;
+}
+
+function writeClaudeSessionFile(homeDir: string, sessionId: string): void {
+  const projectDir = join(homeDir, '.claude', 'projects', '-tmp-completed-sync');
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(
+    join(projectDir, `${sessionId}.jsonl`),
+    JSON.stringify({
+      type: 'user',
+      uuid: 'user-1',
+      sessionId,
+      cwd: '/tmp/completed-sync',
+      timestamp: '2026-04-13T16:05:00.000Z',
+      userType: 'external',
+      message: {
+        role: 'user',
+        content: 'Completed sync regression',
+      },
+    }) + '\n'
+  );
+}
+
+function runSyncScript(homeDir: string, script: string): Record<string, unknown> {
+  const proc = Bun.spawnSync({
+    cmd: [process.execPath, '--eval', script],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      KEEPLINE_HOME: join(homeDir, '.keepline'),
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  if (proc.exitCode !== 0) {
+    throw new Error(proc.stderr.toString() || `sync subprocess failed with code ${proc.exitCode}`);
+  }
+
+  const jsonLine = proc.stdout.toString().trim().split('\n').filter(Boolean).pop();
+  if (!jsonLine) {
+    throw new Error('sync subprocess produced no JSON output');
+  }
+  return JSON.parse(jsonLine) as Record<string, unknown>;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe('SessionService sync', () => {
+  test('preserves user-completed sessions during later file syncs', () => {
+    const homeDir = createTempHome();
+    const sessionId = 'completed-sync-1';
+    writeClaudeSessionFile(homeDir, sessionId);
+
+    const result = runSyncScript(homeDir, `
+      const { resetDatabase } = await import('./src/db/migrations.ts');
+      const { closeDatabase } = await import('./src/infrastructure/database/sqlite.ts');
+      const { sessionRepository } = await import('./src/infrastructure/database/repositories/session.repository.ts');
+      const { sessionService } = await import('./src/services/session.service.ts');
+
+      resetDatabase();
+      const completedAt = new Date('2026-04-13T16:00:00.000Z');
+      sessionRepository.upsert({
+        sessionId: ${JSON.stringify(sessionId)},
+        client: 'claude',
+        directory: '/tmp/completed-sync',
+        status: 'completed',
+        title: 'Completed task',
+        initialPrompt: 'Completed sync regression',
+        startedAt: new Date('2026-04-13T15:55:00.000Z'),
+        lastActiveAt: completedAt,
+        completedAt,
+        pid: 999999,
+        toolCount: 0,
+        messageCount: 1,
+      });
+
+      const syncResult = await sessionService.syncSessions({ fullSync: true });
+      const fetched = sessionRepository.findBySessionId(${JSON.stringify(sessionId)});
+      console.log(JSON.stringify({
+        syncResult,
+        status: fetched?.status,
+        completedAt: fetched?.completedAt?.toISOString(),
+        lastActiveAt: fetched?.lastActiveAt.toISOString(),
+        pid: fetched?.pid ?? null,
+      }));
+      closeDatabase();
+    `);
+
+    expect(result).toEqual({
+      syncResult: { discovered: 0, updated: 1, lost: 0 },
+      status: 'completed',
+      completedAt: '2026-04-13T16:00:00.000Z',
+      lastActiveAt: '2026-04-13T16:05:00.000Z',
+      pid: null,
+    });
+  });
+});

--- a/src/__tests__/sessions.route-basic.test.ts
+++ b/src/__tests__/sessions.route-basic.test.ts
@@ -347,6 +347,42 @@ describe('Basic Sessions Route Contract', () => {
     expect(body.data).toBeUndefined();
   });
 
+  test('rejects invalid limit instead of returning a misleading empty page', async () => {
+    const { token } = await setupUser('invalid-limit-route-user', 'password123');
+    const response = await sessions.fetch(new Request(
+      'http://localhost/?skipSync=true&fields=basic&limit=abc',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(400);
+
+    const body = await response.json() as {
+      success: boolean;
+      error: string;
+    };
+
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Invalid limit');
+  });
+
+  test('rejects invalid offset instead of returning a misleading page', async () => {
+    const { token } = await setupUser('invalid-offset-route-user', 'password123');
+    const response = await sessions.fetch(new Request(
+      'http://localhost/?skipSync=true&fields=basic&offset=-1',
+      { headers: { Authorization: `Bearer ${token}` } }
+    ));
+
+    expect(response.status).toBe(400);
+
+    const body = await response.json() as {
+      success: boolean;
+      error: string;
+    };
+
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Invalid offset');
+  });
+
   test('runtime filter composes with project, status, search, and pagination', async () => {
     const target = makeGitProject('keepline-runtime-target-');
     const other = makeGitProject('keepline-runtime-other-');

--- a/src/__tests__/sessions.route-basic.test.ts
+++ b/src/__tests__/sessions.route-basic.test.ts
@@ -37,7 +37,7 @@ describe('Basic Sessions Route Contract', () => {
     return { root, nested };
   }
 
-  test('fields=basic returns lightweight session payloads without usageStats', async () => {
+  test('fields=basic returns lightweight session payloads with persisted usageStats', async () => {
     sessionRepository.upsert({
       sessionId: 'session-basic-1',
       directory: '/tmp/keepline-basic-contract',
@@ -52,6 +52,13 @@ describe('Basic Sessions Route Contract', () => {
       lastActiveAt: new Date('2026-04-13T10:00:05.000Z'),
       toolCount: 4,
       messageCount: 2,
+      usageStats: {
+        totalInputTokens: 1200,
+        totalOutputTokens: 300,
+        totalTokens: 1500,
+        totalCost: 1.25,
+        apiCalls: 4,
+      },
     });
 
     const { token } = await setupUser('basic-route-user', 'password123');
@@ -84,10 +91,16 @@ describe('Basic Sessions Route Contract', () => {
       toolCount: 4,
       messageCount: 2,
       processRunning: false,
+      usageStats: {
+        totalInputTokens: 1200,
+        totalOutputTokens: 300,
+        totalTokens: 1500,
+        totalCost: 1.25,
+        apiCalls: 4,
+      },
     });
     expect(session.startedAt).toBe('2026-04-13T10:00:00.000Z');
     expect(session.lastActiveAt).toBe('2026-04-13T10:00:05.000Z');
-    expect('usageStats' in session).toBe(false);
     expect('initialPrompt' in session).toBe(false);
     expect('lastMessage' in session).toBe(false);
     expect('lastTool' in session).toBe(false);

--- a/src/__tests__/usage.extractor.test.ts
+++ b/src/__tests__/usage.extractor.test.ts
@@ -2,9 +2,14 @@
  * Tests for token usage extraction from JSONL data
  */
 
-import { describe, test, expect } from 'bun:test'
+import { afterEach, describe, test, expect } from 'bun:test'
 import { extractUsageFromEntries, aggregateUsageStats } from '../services/usage.extractor.js'
+import { resetPricingForTests } from '../services/usage.pricing.js'
 import type { ClaudeAssistantEntry } from '../adapters/claude/types.js'
+
+afterEach(() => {
+  resetPricingForTests()
+})
 
 // Helper to create a mock assistant entry with usage
 function createAssistantEntry(
@@ -137,5 +142,19 @@ describe('aggregateUsageStats', () => {
     expect(stats.totalCost).toBe(0)
     expect(stats.apiCalls).toBe(0)
     expect(stats.modelBreakdown).toEqual([])
+  })
+
+  test('uses refreshed pricing for repeated model aggregation', () => {
+    const entries = [createAssistantEntry('priced-model', 1_000_000, 1_000_000)]
+
+    resetPricingForTests({
+      'priced-model': { inputPerMillion: 1, outputPerMillion: 2 },
+    })
+    expect(aggregateUsageStats(entries).totalCost).toBe(3)
+
+    resetPricingForTests({
+      'priced-model': { inputPerMillion: 10, outputPerMillion: 20 },
+    })
+    expect(aggregateUsageStats(entries).totalCost).toBe(30)
   })
 })

--- a/src/__tests__/usage.pricing.test.ts
+++ b/src/__tests__/usage.pricing.test.ts
@@ -2,12 +2,19 @@
  * Tests for pricing module
  */
 
-import { describe, test, expect, beforeAll } from 'bun:test'
-import { getModelPricing, calculateCost, FALLBACK_PRICING, initPricing } from '../services/usage.pricing.js'
+import { beforeEach, describe, test, expect } from 'bun:test'
+import {
+  DEFAULT_PRICING,
+  FALLBACK_PRICING,
+  calculateCost,
+  getModelPricing,
+  pricingConfigFromLiteLLMData,
+  resetPricingForTests,
+} from '../services/usage.pricing.js'
+import { logger } from '../lib/logger.js'
 
-// Initialize pricing before tests (uses defaults if fetch fails)
-beforeAll(async () => {
-  await initPricing()
+beforeEach(() => {
+  resetPricingForTests(DEFAULT_PRICING)
 })
 
 describe('getModelPricing', () => {
@@ -39,6 +46,61 @@ describe('getModelPricing', () => {
   test('returns fallback pricing for completely unknown model', () => {
     const pricing = getModelPricing('unknown-model-xyz')
     expect(pricing).toEqual(FALLBACK_PRICING)
+  })
+
+  test('keeps non-Anthropic LiteLLM pricing entries', () => {
+    const pricing = pricingConfigFromLiteLLMData({
+      'openai/gpt-4o-mini': {
+        litellm_provider: 'openai',
+        input_cost_per_token: 0.00000015,
+        output_cost_per_token: 0.0000006,
+      },
+      'claude/claude-3-5-sonnet-20241022': {
+        litellm_provider: 'anthropic',
+        input_cost_per_token: 0.000003,
+        output_cost_per_token: 0.000015,
+      },
+      'openai/free-embedding': {
+        litellm_provider: 'openai',
+        input_cost_per_token: 0,
+      },
+    })
+
+    expect(pricing['openai/gpt-4o-mini']).toEqual({
+      inputPerMillion: 0.15,
+      outputPerMillion: 0.6,
+    })
+    expect(pricing['claude/claude-3-5-sonnet-20241022']).toEqual({
+      inputPerMillion: 3,
+      outputPerMillion: 15,
+    })
+    expect(pricing['openai/free-embedding']).toBeUndefined()
+  })
+
+  test('logs fallback pricing for unknown models once per model', () => {
+    const warnings: Array<{ message: string; data: unknown }> = []
+    const originalWarn = logger.warn.bind(logger)
+    logger.warn = ((message: string, data?: unknown) => {
+      warnings.push({ message, data })
+    }) as typeof logger.warn
+
+    try {
+      getModelPricing('unknown-model-abc')
+      getModelPricing('unknown-model-abc')
+      getModelPricing('unknown-model-def')
+    } finally {
+      logger.warn = originalWarn
+    }
+
+    expect(warnings).toHaveLength(2)
+    expect(warnings[0]).toEqual({
+      message: 'Using fallback pricing for unknown model',
+      data: { model: 'unknown-model-abc' },
+    })
+    expect(warnings[1]).toEqual({
+      message: 'Using fallback pricing for unknown model',
+      data: { model: 'unknown-model-def' },
+    })
   })
 })
 

--- a/src/__tests__/use-notifications.test.ts
+++ b/src/__tests__/use-notifications.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  getSessionNotificationEvents,
+  type NotificationEventSettings,
+} from '../web/client/src/hooks/notification-events.js';
+import type { Session } from '../web/client/src/types/session.js';
+
+const settings: NotificationEventSettings = {
+  onStatusChange: true,
+  onSessionLost: true,
+  onHighCost: true,
+  costThreshold: 5,
+};
+
+function makeSession(overrides: Partial<Session>): Session {
+  return {
+    id: 'row-1',
+    sessionId: 'session-1',
+    client: 'claude',
+    runtimeId: 'claude-code',
+    directory: '/tmp/project',
+    status: 'running',
+    title: 'Expensive task',
+    initialPrompt: 'Run the task',
+    lastActiveAt: '2026-04-13T10:00:05.000Z',
+    toolCount: 1,
+    messageCount: 1,
+    createdAt: '2026-04-13T10:00:00.000Z',
+    updatedAt: '2026-04-13T10:00:05.000Z',
+    ...overrides,
+  };
+}
+
+describe('notification event derivation', () => {
+  test('emits high-cost notification when session cost crosses threshold', () => {
+    const events = getSessionNotificationEvents(
+      [makeSession({ usageStats: { totalInputTokens: 100, totalOutputTokens: 50, totalTokens: 150, totalCost: 4.99, apiCalls: 1 } })],
+      [makeSession({ usageStats: { totalInputTokens: 200, totalOutputTokens: 100, totalTokens: 300, totalCost: 5.01, apiCalls: 2 } })],
+      settings
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      title: 'High Cost Warning',
+      options: {
+        tag: 'high-cost-session-1',
+      },
+    });
+    expect(events[0].options.body).toContain('$5.00');
+    expect(events[0].options.body).toContain('$5.01');
+  });
+
+  test('does not repeat high-cost notification when previous cost was already above threshold', () => {
+    const events = getSessionNotificationEvents(
+      [makeSession({ usageStats: { totalInputTokens: 200, totalOutputTokens: 100, totalTokens: 300, totalCost: 5.01, apiCalls: 2 } })],
+      [makeSession({ usageStats: { totalInputTokens: 300, totalOutputTokens: 200, totalTokens: 500, totalCost: 6, apiCalls: 3 } })],
+      settings
+    );
+
+    expect(events).toEqual([]);
+  });
+});

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, test, expect } from 'bun:test';
 import {
+  isValidObservationId,
   isValidSessionId,
   validateRecoverRequest,
   validateStopRequest,
@@ -70,6 +71,42 @@ describe('isValidSessionId', () => {
       expect(isValidSessionId(null as unknown as string)).toBe(false);
       expect(isValidSessionId(undefined as unknown as string)).toBe(false);
       expect(isValidSessionId({} as unknown as string)).toBe(false);
+    });
+  });
+});
+
+describe('isValidObservationId', () => {
+  describe('valid observation IDs', () => {
+    test('accepts UUIDs generated for observations', () => {
+      expect(isValidObservationId('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+    });
+
+    test('accepts safe alphanumeric IDs with hyphens and underscores', () => {
+      expect(isValidObservationId('obs_12345')).toBe(true);
+      expect(isValidObservationId('obs-12345_ABC')).toBe(true);
+      expect(isValidObservationId('a'.repeat(64))).toBe(true);
+    });
+  });
+
+  describe('invalid observation IDs', () => {
+    test('rejects injection-shaped filter predicates', () => {
+      expect(isValidObservationId("x' OR '1'='1")).toBe(false);
+      expect(isValidObservationId("obs12345'; DELETE FROM observations; --")).toBe(false);
+    });
+
+    test('rejects unsafe characters and invalid lengths', () => {
+      expect(isValidObservationId('abc1234')).toBe(false);
+      expect(isValidObservationId('')).toBe(false);
+      expect(isValidObservationId('a'.repeat(65))).toBe(false);
+      expect(isValidObservationId('abc.12345')).toBe(false);
+      expect(isValidObservationId('abc 12345')).toBe(false);
+    });
+
+    test('rejects non-string types', () => {
+      expect(isValidObservationId(123 as unknown as string)).toBe(false);
+      expect(isValidObservationId(null as unknown as string)).toBe(false);
+      expect(isValidObservationId(undefined as unknown as string)).toBe(false);
+      expect(isValidObservationId({} as unknown as string)).toBe(false);
     });
   });
 });

--- a/src/adapters/claude/parser/jsonl.ts
+++ b/src/adapters/claude/parser/jsonl.ts
@@ -62,12 +62,20 @@ interface AssistantBlockSummary {
 }
 
 /** Parse a single JSONL line */
-function parseLine(line: string, lineNumber: number, filePath: string): ClaudeEntryWithAgent | null {
+function parseLine(
+  line: string,
+  lineNumber: number,
+  filePath: string,
+  allowTruncatedTail = false
+): ClaudeEntryWithAgent | null {
   if (!line.trim()) return null;
 
   try {
     return JSON.parse(line) as ClaudeEntryWithAgent;
   } catch {
+    if (allowTruncatedTail) {
+      return null;
+    }
     throw new ParseError(filePath, lineNumber);
   }
 }
@@ -467,6 +475,7 @@ export async function parseSessionFile(
 ): Promise<ParsedSessionData | null> {
   let lineNumber = 0;
   let accumulator: SessionSummaryAccumulator | null = null;
+  let pendingLine: { line: string; lineNumber: number } | null = null;
 
   const fileStream = createReadStream(filePath);
   const rl = createInterface({
@@ -474,29 +483,41 @@ export async function parseSessionFile(
     crlfDelay: Infinity,
   });
 
-  for await (const line of rl) {
-    lineNumber++;
-    const entry = parseLine(line, lineNumber, filePath);
+  const processLine = (line: string, currentLineNumber: number, isLastLine: boolean): void => {
+    const entry = parseLine(line, currentLineNumber, filePath, isLastLine);
     if (
       !entry ||
       isFileHistorySnapshot(entry) ||
       isBootstrapOnlyEntry(entry) ||
       !entry.timestamp
     ) {
-      continue;
+      return;
     }
 
     if (!accumulator) {
       if (!entry.cwd) {
-        continue;
+        return;
       }
       accumulator = createSessionAccumulator(entry, options);
       if (!accumulator) {
-        return null;
+        return;
       }
     }
 
     accumulateSessionEntry(accumulator, entry);
+  };
+
+  for await (const line of rl) {
+    if (pendingLine) {
+      processLine(pendingLine.line, pendingLine.lineNumber, false);
+    }
+
+    lineNumber++;
+    pendingLine = { line, lineNumber };
+  }
+
+  if (pendingLine) {
+    processLine(pendingLine.line, pendingLine.lineNumber, true);
   }
 
   return accumulator ? finalizeSessionAccumulator(accumulator) : null;

--- a/src/adapters/codex/parser.ts
+++ b/src/adapters/codex/parser.ts
@@ -7,6 +7,11 @@ import { createInterface } from 'readline';
 import { ParseError } from '../../lib/errors.js';
 import type { ToolCallInfo } from '../../domain/session/index.js';
 import type { CodexJsonlEntry, CodexParsedSessionData } from './types.js';
+import {
+  addUsageToAccumulator,
+  createUsageAccumulator,
+  usageStatsFromAccumulator,
+} from '../../services/usage.extractor.js';
 
 export interface ParseCodexSessionOptions {
   includeToolCalls?: boolean;
@@ -27,6 +32,7 @@ interface CodexAccumulator {
   lastActiveAtMs: number;
   toolCalls: ToolCallInfo[];
   includeToolCalls: boolean;
+  usageAccumulator: ReturnType<typeof createUsageAccumulator>;
 }
 
 export function scopeCodexSessionId(rawSessionId: string): string {
@@ -110,6 +116,7 @@ function createAccumulator(entry: CodexJsonlEntry, includeToolCalls: boolean): C
     lastActiveAtMs: startedAtMs ?? Date.now(),
     toolCalls: [],
     includeToolCalls,
+    usageAccumulator: createUsageAccumulator(),
   };
 }
 
@@ -163,6 +170,92 @@ function accumulateResponseItem(accumulator: CodexAccumulator, entry: CodexJsonl
   }
 }
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function numberField(record: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
+function stringField(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return undefined;
+}
+
+function findUsageRecord(payload: Record<string, unknown>): {
+  source: Record<string, unknown>;
+  usage: Record<string, unknown>;
+} | undefined {
+  const directUsage = asRecord(payload.usage);
+  if (directUsage) return { source: payload, usage: directUsage };
+
+  for (const key of ['msg', 'message', 'event', 'data']) {
+    const nested = asRecord(payload[key]);
+    const nestedUsage = nested ? asRecord(nested.usage) : undefined;
+    if (nested && nestedUsage) return { source: nested, usage: nestedUsage };
+  }
+
+  return undefined;
+}
+
+function accumulateCodexUsageEvent(accumulator: CodexAccumulator, entry: CodexJsonlEntry): void {
+  const payload = entry.payload;
+  if (!payload) return;
+
+  const usageRecord = findUsageRecord(payload);
+  if (!usageRecord) return;
+
+  const inputTokens = numberField(usageRecord.usage, [
+    'input_tokens',
+    'inputTokens',
+    'prompt_tokens',
+    'promptTokens',
+  ]);
+  const outputTokens = numberField(usageRecord.usage, [
+    'output_tokens',
+    'outputTokens',
+    'completion_tokens',
+    'completionTokens',
+  ]);
+
+  if (inputTokens === undefined || outputTokens === undefined) {
+    return;
+  }
+
+  const cacheCreationTokens = numberField(usageRecord.usage, [
+    'cache_creation_input_tokens',
+    'cacheCreationInputTokens',
+    'cache_write_input_tokens',
+    'cacheWriteInputTokens',
+    'cacheWriteTokens',
+  ]) ?? 0;
+  const cacheReadTokens = numberField(usageRecord.usage, [
+    'cache_read_input_tokens',
+    'cacheReadInputTokens',
+    'cacheReadTokens',
+  ]) ?? 0;
+  const model = stringField(usageRecord.source, ['model', 'modelName', 'model_name']) ??
+    stringField(usageRecord.usage, ['model', 'modelName', 'model_name']) ??
+    'codex-unknown';
+
+  addUsageToAccumulator(accumulator.usageAccumulator, model, {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    cache_creation_input_tokens: cacheCreationTokens,
+    cache_read_input_tokens: cacheReadTokens,
+  });
+}
+
 function finalizeAccumulator(accumulator: CodexAccumulator): CodexParsedSessionData {
   return {
     client: 'codex',
@@ -179,6 +272,9 @@ function finalizeAccumulator(accumulator: CodexAccumulator): CodexParsedSessionD
     startedAt: accumulator.startedAtMs === undefined ? undefined : new Date(accumulator.startedAtMs),
     lastActiveAt: new Date(accumulator.lastActiveAtMs),
     toolCalls: accumulator.includeToolCalls ? accumulator.toolCalls : undefined,
+    usageStats: accumulator.usageAccumulator.apiCalls === 0
+      ? undefined
+      : usageStatsFromAccumulator(accumulator.usageAccumulator),
   };
 }
 
@@ -217,6 +313,9 @@ export async function parseCodexSessionFile(
     if (!accumulator) continue;
     if (entry.type === 'response_item') {
       accumulateResponseItem(accumulator, entry);
+    } else if (entry.type === 'event_msg') {
+      accumulateCodexUsageEvent(accumulator, entry);
+      updateTimestamp(accumulator, entry.timestamp);
     } else {
       updateTimestamp(accumulator, entry.timestamp);
     }

--- a/src/adapters/codex/parser.ts
+++ b/src/adapters/codex/parser.ts
@@ -79,6 +79,24 @@ function parseFunctionArguments(argumentsValue: unknown): Record<string, unknown
   return undefined;
 }
 
+function parseCodexLine(
+  line: string,
+  lineNumber: number,
+  filePath: string,
+  allowTruncatedTail = false
+): CodexJsonlEntry | null {
+  if (!line.trim()) return null;
+
+  try {
+    return JSON.parse(line) as CodexJsonlEntry;
+  } catch {
+    if (allowTruncatedTail) {
+      return null;
+    }
+    throw new ParseError(filePath, lineNumber);
+  }
+}
+
 function extractCodexCurrentFile(toolInput: Record<string, unknown> | undefined): string | undefined {
   if (!toolInput) return undefined;
 
@@ -195,31 +213,38 @@ export async function parseCodexSessionFile(
   let lineNumber = 0;
   let accumulator: CodexAccumulator | null = null;
   const includeToolCalls = options.includeToolCalls ?? true;
+  let pendingLine: { line: string; lineNumber: number } | null = null;
 
-  for await (const line of rl) {
-    lineNumber++;
-    if (!line.trim()) continue;
-
-    let entry: CodexJsonlEntry;
-    try {
-      entry = JSON.parse(line) as CodexJsonlEntry;
-    } catch {
-      throw new ParseError(filePath, lineNumber);
-    }
+  const processLine = (line: string, currentLineNumber: number, isLastLine: boolean): void => {
+    const entry = parseCodexLine(line, currentLineNumber, filePath, isLastLine);
+    if (!entry) return;
 
     if (!accumulator) {
       accumulator = createAccumulator(entry, includeToolCalls);
       if (accumulator) {
-        continue;
+        return;
       }
     }
 
-    if (!accumulator) continue;
+    if (!accumulator) return;
     if (entry.type === 'response_item') {
       accumulateResponseItem(accumulator, entry);
     } else {
       updateTimestamp(accumulator, entry.timestamp);
     }
+  };
+
+  for await (const line of rl) {
+    if (pendingLine) {
+      processLine(pendingLine.line, pendingLine.lineNumber, false);
+    }
+
+    lineNumber++;
+    pendingLine = { line, lineNumber };
+  }
+
+  if (pendingLine) {
+    processLine(pendingLine.line, pendingLine.lineNumber, true);
   }
 
   return accumulator ? finalizeAccumulator(accumulator) : null;

--- a/src/adapters/hook/installer.ts
+++ b/src/adapters/hook/installer.ts
@@ -6,7 +6,13 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { CLAUDE_SETTINGS } from '../../lib/paths.js';
 import { config } from '../../lib/config.js';
 import { logger } from '../../lib/logger.js';
-import type { ClaudeSettings, ClaudeHookConfig } from './types.js';
+import type {
+  ClaudeHookCommandHandler,
+  ClaudeHookConfig,
+  ClaudeHookMatcherGroup,
+  ClaudeSettings,
+  HookEventType,
+} from './types.js';
 
 const KEEPLINE_HOOK_MARKER = 'KEEPLINE_HOOK_MARKER=keepline-hook-v1';
 const HOOK_TYPES = ['PreToolUse', 'PostToolUse', 'Notification', 'Stop', 'UserPromptSubmit'] as const;
@@ -37,7 +43,7 @@ function saveClaudeSettings(settings: ClaudeSettings): void {
 /** Generate hook command */
 function getHookCommand(): string {
   const port = config.get().hookPort;
-  return `${KEEPLINE_HOOK_MARKER} curl -s -X POST http://127.0.0.1:${port}/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
+  return `${KEEPLINE_HOOK_MARKER} curl -fsS -X POST http://127.0.0.1:${port}/hook -H "Content-Type: application/json" --data-binary @- > /dev/null 2>&1 || true`;
 }
 
 function isLegacyKeeplineHookCommand(command: string): boolean {
@@ -52,49 +58,120 @@ function isLegacyKeeplineHookCommand(command: string): boolean {
   );
 }
 
+function isHookCommandHandler(hook: unknown): hook is ClaudeHookCommandHandler {
+  return Boolean(
+    hook &&
+    typeof hook === 'object' &&
+    typeof (hook as Partial<ClaudeHookCommandHandler>).command === 'string'
+  );
+}
+
+function isHookMatcherGroup(hook: unknown): hook is ClaudeHookMatcherGroup {
+  return Boolean(
+    hook &&
+    typeof hook === 'object' &&
+    Array.isArray((hook as Partial<ClaudeHookMatcherGroup>).hooks)
+  );
+}
+
 export function isKeeplineHook(hook: unknown): hook is ClaudeHookConfig {
-  if (
-    !hook ||
-    typeof hook !== 'object' ||
-    typeof (hook as Partial<ClaudeHookConfig>).command !== 'string'
-  ) {
-    return false;
+  if (isHookCommandHandler(hook)) {
+    return hook.command.includes(KEEPLINE_HOOK_MARKER) || isLegacyKeeplineHookCommand(hook.command);
   }
-  const command = (hook as ClaudeHookConfig).command;
-  return command.includes(KEEPLINE_HOOK_MARKER) || isLegacyKeeplineHookCommand(command);
+
+  if (isHookMatcherGroup(hook)) {
+    return hook.hooks.some(isKeeplineHook);
+  }
+
+  return false;
+}
+
+function removeKeeplineHooks(hooks: ClaudeHookConfig[]): ClaudeHookConfig[] {
+  const nextHooks: ClaudeHookConfig[] = [];
+
+  for (const hook of hooks) {
+    if (isHookCommandHandler(hook)) {
+      if (!isKeeplineHook(hook)) {
+        nextHooks.push(hook);
+      }
+      continue;
+    }
+
+    if (isHookMatcherGroup(hook)) {
+      const remainingHandlers = hook.hooks.filter((handler) => !isKeeplineHook(handler));
+      if (remainingHandlers.length > 0) {
+        nextHooks.push({
+          ...hook,
+          hooks: remainingHandlers,
+        });
+      }
+      continue;
+    }
+
+    nextHooks.push(hook);
+  }
+
+  return nextHooks;
+}
+
+function countKeeplineHooks(hooks: ClaudeHookConfig[]): number {
+  let count = 0;
+
+  for (const hook of hooks) {
+    if (isHookCommandHandler(hook)) {
+      if (isKeeplineHook(hook)) {
+        count++;
+      }
+      continue;
+    }
+
+    if (isHookMatcherGroup(hook)) {
+      count += hook.hooks.filter(isKeeplineHook).length;
+    }
+  }
+
+  return count;
+}
+
+function createKeeplineHookConfig(
+  hookType: HookEventType,
+  hookCommand: string
+): ClaudeHookMatcherGroup {
+  const config: ClaudeHookMatcherGroup = {
+    hooks: [
+      {
+        type: 'command',
+        command: hookCommand,
+      },
+    ],
+  };
+
+  if (hookType === 'PreToolUse' || hookType === 'PostToolUse') {
+    config.matcher = '*';
+  }
+
+  return config;
 }
 
 export function installKeeplineHookConfig(
   settings: ClaudeSettings,
   hookCommand: string = getHookCommand()
 ): boolean {
+  const before = JSON.stringify(settings.hooks ?? {});
+
   if (!settings.hooks) {
     settings.hooks = {};
   }
 
-  if (!settings.hooks.PostToolUse) {
-    settings.hooks.PostToolUse = [];
+  for (const hookType of HOOK_TYPES) {
+    const existingHooks = settings.hooks[hookType] ?? [];
+    settings.hooks[hookType] = [
+      ...removeKeeplineHooks(existingHooks),
+      createKeeplineHookConfig(hookType, hookCommand),
+    ];
   }
 
-  const existingIndex = settings.hooks.PostToolUse.findIndex(isKeeplineHook);
-  const keeplineHook: ClaudeHookConfig = {
-    command: hookCommand,
-  };
-
-  if (existingIndex >= 0) {
-    const existing = settings.hooks.PostToolUse[existingIndex];
-    if (existing.command !== hookCommand) {
-      settings.hooks.PostToolUse[existingIndex] = {
-        ...existing,
-        command: hookCommand,
-      };
-      return true;
-    }
-    return false;
-  }
-
-  settings.hooks.PostToolUse.push(keeplineHook);
-  return true;
+  return JSON.stringify(settings.hooks) !== before;
 }
 
 export function uninstallKeeplineHookConfig(settings: ClaudeSettings): number {
@@ -104,8 +181,8 @@ export function uninstallKeeplineHookConfig(settings: ClaudeSettings): number {
   for (const hookType of HOOK_TYPES) {
     const hooks = settings.hooks[hookType];
     if (!hooks) continue;
-    const nextHooks = hooks.filter((hook) => !isKeeplineHook(hook));
-    removed += hooks.length - nextHooks.length;
+    removed += countKeeplineHooks(hooks);
+    const nextHooks = removeKeeplineHooks(hooks);
     settings.hooks[hookType] = nextHooks;
   }
 
@@ -113,9 +190,7 @@ export function uninstallKeeplineHookConfig(settings: ClaudeSettings): number {
 }
 
 function hasKeeplineHook(settings: ClaudeSettings): boolean {
-  return Boolean(
-    settings.hooks?.PostToolUse?.some(isKeeplineHook)
-  );
+  return HOOK_TYPES.every((hookType) => settings.hooks?.[hookType]?.some(isKeeplineHook));
 }
 
 /** Check if keepline hooks are installed */

--- a/src/adapters/hook/installer.ts
+++ b/src/adapters/hook/installer.ts
@@ -1,15 +1,38 @@
 /**
  * Claude hooks installer
+ *
+ * Registers a Keepline hook under Claude Code's real settings shape:
+ *   hooks.<Event>[] = [{ matcher?, hooks: [{ type: "command", command }] }]
+ *
+ * The command forwards Claude's stdin hook JSON verbatim to the hook server;
+ * it does NOT rely on `$CLAUDE_*` environment variables (those do not exist —
+ * Claude Code delivers hook data on stdin only).
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { CLAUDE_SETTINGS } from '../../lib/paths.js';
 import { config } from '../../lib/config.js';
 import { logger } from '../../lib/logger.js';
-import type { ClaudeSettings, ClaudeHookConfig } from './types.js';
+import type {
+  ClaudeSettings,
+  ClaudeHookMatcher,
+  HookCommandEntry,
+  HookEventType,
+} from './types.js';
 
-const KEEPLINE_HOOK_MARKER = 'KEEPLINE_HOOK_MARKER=keepline-hook-v1';
-const HOOK_TYPES = ['PreToolUse', 'PostToolUse', 'Notification', 'Stop', 'UserPromptSubmit'] as const;
+const KEEPLINE_HOOK_MARKER = 'KEEPLINE_HOOK_MARKER=keepline-hook-v2';
+
+/** Event types Keepline registers a forwarding hook under */
+const KEEPLINE_EVENTS: HookEventType[] = ['PostToolUse', 'Stop', 'UserPromptSubmit'];
+
+/** Every event type we scan when uninstalling (covers historical registrations) */
+const ALL_HOOK_EVENTS: HookEventType[] = [
+  'PreToolUse',
+  'PostToolUse',
+  'Notification',
+  'Stop',
+  'UserPromptSubmit',
+];
 
 /** Get current Claude settings */
 function getClaudeSettings(): ClaudeSettings {
@@ -34,36 +57,55 @@ function saveClaudeSettings(settings: ClaudeSettings): void {
   writeFileSync(CLAUDE_SETTINGS, JSON.stringify(settings, null, 2));
 }
 
-/** Generate hook command */
+/**
+ * Generate the hook command.
+ *
+ * `--data-binary @-` forwards Claude's stdin JSON verbatim (no newline
+ * stripping, no urlencoding). The marker prefix is a harmless env assignment
+ * used only to identify Keepline-owned hooks in the settings file.
+ */
 function getHookCommand(): string {
   const port = config.get().hookPort;
-  return `${KEEPLINE_HOOK_MARKER} curl -s -X POST http://127.0.0.1:${port}/hook -H "Content-Type: application/json" -d '{"event_type":"$CLAUDE_EVENT_TYPE","session_id":"$CLAUDE_SESSION_ID","cwd":"$PWD","timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","tool_name":"$CLAUDE_TOOL_NAME","tool_input":'"\${CLAUDE_TOOL_INPUT:-{}}"'}' > /dev/null 2>&1 || true`;
+  return `${KEEPLINE_HOOK_MARKER} curl -s -X POST http://127.0.0.1:${port}/hook -H 'Content-Type: application/json' --data-binary @- >/dev/null 2>&1 || true`;
 }
 
+/** Detect the pre-v2 command that (incorrectly) relied on `$CLAUDE_*` env vars */
 function isLegacyKeeplineHookCommand(command: string): boolean {
   return (
     command.includes('curl -s -X POST') &&
     /\bhttp:\/\/127\.0\.0\.1:\d+\/hook\b/.test(command) &&
     command.includes('"event_type":"$CLAUDE_EVENT_TYPE"') &&
-    command.includes('"session_id":"$CLAUDE_SESSION_ID"') &&
-    command.includes('"cwd":"$PWD"') &&
-    command.includes('"tool_name":"$CLAUDE_TOOL_NAME"') &&
-    command.includes('CLAUDE_TOOL_INPUT')
+    command.includes('"session_id":"$CLAUDE_SESSION_ID"')
   );
 }
 
-export function isKeeplineHook(hook: unknown): hook is ClaudeHookConfig {
-  if (
-    !hook ||
-    typeof hook !== 'object' ||
-    typeof (hook as Partial<ClaudeHookConfig>).command !== 'string'
-  ) {
-    return false;
-  }
-  const command = (hook as ClaudeHookConfig).command;
-  return command.includes(KEEPLINE_HOOK_MARKER) || isLegacyKeeplineHookCommand(command);
+/** Is this command string a Keepline-owned hook (any version)? */
+export function isKeeplineHookCommand(command: string): boolean {
+  return command.includes('KEEPLINE_HOOK_MARKER=') || isLegacyKeeplineHookCommand(command);
 }
 
+/** Is this settings hook entry a Keepline-owned command hook? */
+export function isKeeplineHook(hook: unknown): hook is HookCommandEntry {
+  if (!hook || typeof hook !== 'object') {
+    return false;
+  }
+  const command = (hook as Partial<HookCommandEntry>).command;
+  return typeof command === 'string' && isKeeplineHookCommand(command);
+}
+
+/** Find the Keepline-owned command entry among a list of matcher blocks */
+function findKeeplineEntry(blocks: ClaudeHookMatcher[]): HookCommandEntry | undefined {
+  for (const block of blocks) {
+    const entry = block.hooks?.find(isKeeplineHook);
+    if (entry) return entry;
+  }
+  return undefined;
+}
+
+/**
+ * Ensure a Keepline hook is registered under every KEEPLINE_EVENTS type.
+ * Returns true if the settings object was modified.
+ */
 export function installKeeplineHookConfig(
   settings: ClaudeSettings,
   hookCommand: string = getHookCommand()
@@ -72,50 +114,66 @@ export function installKeeplineHookConfig(
     settings.hooks = {};
   }
 
-  if (!settings.hooks.PostToolUse) {
-    settings.hooks.PostToolUse = [];
-  }
+  let changed = false;
 
-  const existingIndex = settings.hooks.PostToolUse.findIndex(isKeeplineHook);
-  const keeplineHook: ClaudeHookConfig = {
-    command: hookCommand,
-  };
+  for (const event of KEEPLINE_EVENTS) {
+    const blocks = settings.hooks[event] ?? (settings.hooks[event] = []);
+    const existing = findKeeplineEntry(blocks);
 
-  if (existingIndex >= 0) {
-    const existing = settings.hooks.PostToolUse[existingIndex];
-    if (existing.command !== hookCommand) {
-      settings.hooks.PostToolUse[existingIndex] = {
-        ...existing,
-        command: hookCommand,
-      };
-      return true;
+    if (existing) {
+      // Upgrade an older/legacy Keepline hook in place, without duplicating.
+      if (existing.command !== hookCommand || existing.type !== 'command') {
+        existing.command = hookCommand;
+        existing.type = 'command';
+        changed = true;
+      }
+    } else {
+      blocks.push({ hooks: [{ type: 'command', command: hookCommand }] });
+      changed = true;
     }
-    return false;
   }
 
-  settings.hooks.PostToolUse.push(keeplineHook);
-  return true;
+  return changed;
 }
 
+/**
+ * Remove every Keepline-owned command hook, preserving unrelated hooks and
+ * matcher blocks. Blocks that become empty (they were Keepline-only) are
+ * dropped. Returns the number of command hooks removed.
+ */
 export function uninstallKeeplineHookConfig(settings: ClaudeSettings): number {
   if (!settings.hooks) return 0;
 
   let removed = 0;
-  for (const hookType of HOOK_TYPES) {
-    const hooks = settings.hooks[hookType];
-    if (!hooks) continue;
-    const nextHooks = hooks.filter((hook) => !isKeeplineHook(hook));
-    removed += hooks.length - nextHooks.length;
-    settings.hooks[hookType] = nextHooks;
+
+  for (const event of ALL_HOOK_EVENTS) {
+    const blocks = settings.hooks[event];
+    if (!blocks) continue;
+
+    const nextBlocks: ClaudeHookMatcher[] = [];
+    for (const block of blocks) {
+      const originalHooks = block.hooks ?? [];
+      const keptHooks = originalHooks.filter((hook) => !isKeeplineHook(hook));
+      removed += originalHooks.length - keptHooks.length;
+
+      // Keep blocks that still hold unrelated hooks; drop Keepline-only blocks.
+      if (keptHooks.length > 0) {
+        nextBlocks.push({ ...block, hooks: keptHooks });
+      }
+    }
+
+    settings.hooks[event] = nextBlocks;
   }
 
   return removed;
 }
 
+/** Are Keepline hooks installed under any registered event? */
 function hasKeeplineHook(settings: ClaudeSettings): boolean {
-  return Boolean(
-    settings.hooks?.PostToolUse?.some(isKeeplineHook)
-  );
+  return KEEPLINE_EVENTS.some((event) => {
+    const blocks = settings.hooks?.[event];
+    return Boolean(blocks && findKeeplineEntry(blocks));
+  });
 }
 
 /** Check if keepline hooks are installed */

--- a/src/adapters/hook/server.ts
+++ b/src/adapters/hook/server.ts
@@ -37,46 +37,108 @@ const VALID_EVENT_TYPES: Set<HookEventType> = new Set([
 /** Track first prompts per session for context injection */
 const sessionFirstPrompts: Map<string, boolean> = new Map();
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function getHookEventType(event: Record<string, unknown>): HookEventType | null {
+  const eventType = event.event_type ?? event.hook_event_name;
+  if (typeof eventType !== 'string' || !VALID_EVENT_TYPES.has(eventType as HookEventType)) {
+    return null;
+  }
+  return eventType as HookEventType;
+}
+
+function stringifyToolOutput(output: unknown): string | undefined {
+  if (output === undefined) {
+    return undefined;
+  }
+  if (typeof output === 'string') {
+    return output;
+  }
+  return JSON.stringify(output);
+}
+
+/** Normalize Claude Code stdin payloads and legacy Keepline payloads. */
+export function normalizeHookEvent(event: unknown, now: Date = new Date()): HookEvent | null {
+  if (!isRecord(event)) {
+    return null;
+  }
+
+  const eventType = getHookEventType(event);
+  if (!eventType) {
+    return null;
+  }
+
+  if (!isValidSessionId(event.session_id) || typeof event.cwd !== 'string') {
+    return null;
+  }
+
+  const base = {
+    event_type: eventType,
+    session_id: event.session_id,
+    cwd: event.cwd,
+    timestamp: typeof event.timestamp === 'string' ? event.timestamp : now.toISOString(),
+    transcript_path: typeof event.transcript_path === 'string' ? event.transcript_path : undefined,
+  };
+
+  if (eventType === 'PreToolUse' || eventType === 'PostToolUse') {
+    if (typeof event.tool_name !== 'string' || event.tool_name.length === 0) {
+      return null;
+    }
+    if (!isRecord(event.tool_input)) {
+      return null;
+    }
+
+    return {
+      ...base,
+      event_type: eventType,
+      tool_name: event.tool_name,
+      tool_input: event.tool_input,
+      tool_output: stringifyToolOutput(event.tool_output ?? event.tool_response),
+    };
+  }
+
+  if (eventType === 'Notification') {
+    if (typeof event.message !== 'string') {
+      return null;
+    }
+    return {
+      ...base,
+      event_type: 'Notification',
+      message: event.message,
+    };
+  }
+
+  if (eventType === 'Stop') {
+    return {
+      ...base,
+      event_type: 'Stop',
+      reason: typeof event.reason === 'string' ? event.reason : undefined,
+    };
+  }
+
+  if (typeof event.prompt !== 'string') {
+    return null;
+  }
+  return {
+    ...base,
+    event_type: 'UserPromptSubmit',
+    prompt: event.prompt,
+  };
+}
+
 /** Validate hook event payload */
-function isValidHookEvent(event: unknown): event is HookEvent {
-  if (!event || typeof event !== 'object') {
+export function isValidHookEvent(event: unknown): event is HookEvent {
+  if (!isRecord(event)) {
     return false;
   }
 
-  const e = event as Record<string, unknown>;
-
-  // Required fields
-  if (!isValidSessionId(e.session_id)) {
-    return false;
-  }
-  if (typeof e.cwd !== 'string') {
-    return false;
-  }
-  if (typeof e.timestamp !== 'string') {
-    return false;
-  }
-  if (typeof e.event_type !== 'string' || !VALID_EVENT_TYPES.has(e.event_type as HookEventType)) {
+  if (!isValidSessionId(event.session_id)) {
     return false;
   }
 
-  // Tool events require additional fields
-  if (e.event_type === 'PreToolUse' || e.event_type === 'PostToolUse') {
-    if (typeof e.tool_name !== 'string' || e.tool_name.length === 0) {
-      return false;
-    }
-    if (!e.tool_input || typeof e.tool_input !== 'object') {
-      return false;
-    }
-  }
-
-  // UserPromptSubmit requires prompt field
-  if (e.event_type === 'UserPromptSubmit') {
-    if (typeof e.prompt !== 'string') {
-      return false;
-    }
-  }
-
-  return true;
+  return normalizeHookEvent(event) !== null;
 }
 
 /** Handle incoming hook event */
@@ -219,14 +281,16 @@ export async function startHookServer(): Promise<void> {
   // Hook event endpoint
   server.post<{ Body: unknown }>('/hook', async (request, reply) => {
     try {
+      const event = normalizeHookEvent(request.body);
+
       // Validate input before processing
-      if (!isValidHookEvent(request.body)) {
+      if (!event) {
         logger.warn('Invalid hook event received', { body: request.body });
         reply.status(400);
         return { success: false, error: 'Invalid hook event payload' };
       }
 
-      await handleHookEvent(request.body);
+      await handleHookEvent(event);
       return { success: true };
     } catch (error) {
       logger.error('Failed to handle hook event', error);

--- a/src/adapters/hook/server.ts
+++ b/src/adapters/hook/server.ts
@@ -4,11 +4,16 @@
  * Integrates with the compression queue for async memory processing.
  */
 
-import Fastify, { FastifyInstance } from 'fastify';
+import Fastify, { FastifyInstance, FastifyRequest } from 'fastify';
 import { logger } from '../../lib/logger.js';
 import { config } from '../../lib/config.js';
 import { emit } from '../../lib/events.js';
 import { isValidSessionId } from '../../lib/session-id.js';
+import {
+  isAllowedFetchMetadata,
+  isLoopbackHostHeader,
+  isLoopbackOrigin,
+} from '../../web/api/request-security.js';
 import { updateSession } from '../../services/session.service.js';
 import {
   getCompressionQueue,
@@ -36,6 +41,30 @@ const VALID_EVENT_TYPES: Set<HookEventType> = new Set([
 
 /** Track first prompts per session for context injection */
 const sessionFirstPrompts: Map<string, boolean> = new Map();
+
+function getHeader(request: FastifyRequest, name: string): string | undefined {
+  const value = request.headers[name.toLowerCase()];
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function isAllowedHookServerRequest(request: FastifyRequest): boolean {
+  if (!isLoopbackHostHeader(getHeader(request, 'host'))) {
+    return false;
+  }
+
+  const origin = getHeader(request, 'origin');
+  if (origin && !isLoopbackOrigin(origin)) {
+    return false;
+  }
+
+  const syntheticRequest = new Request('http://127.0.0.1/', {
+    headers: {
+      'sec-fetch-site': getHeader(request, 'sec-fetch-site') ?? '',
+    },
+  });
+  return isAllowedFetchMetadata(syntheticRequest);
+}
 
 /** Validate hook event payload */
 function isValidHookEvent(event: unknown): event is HookEvent {
@@ -193,19 +222,26 @@ async function handleHookEvent(event: HookEvent): Promise<void> {
   }
 }
 
-/** Start hook server */
-export async function startHookServer(): Promise<void> {
-  if (server) {
-    logger.warn('Hook server already running');
-    return;
-  }
+export function createHookServer(): FastifyInstance {
+  const app = Fastify({ logger: false });
 
-  const port = config.get().hookPort;
+  app.addHook('onRequest', (request, reply, done) => {
+    if (isAllowedHookServerRequest(request)) {
+      done();
+      return;
+    }
 
-  server = Fastify({ logger: false });
+    logger.warn('Rejected hook server request', {
+      host: getHeader(request, 'host') ?? '<missing>',
+      origin: getHeader(request, 'origin') ?? '<missing>',
+      secFetchSite: getHeader(request, 'sec-fetch-site') ?? '<missing>',
+      path: request.url,
+    });
+    reply.status(403).send({ success: false, error: 'Forbidden' });
+  });
 
   // Health check endpoint
-  server.get('/health', async () => {
+  app.get('/health', async () => {
     const queue = getCompressionQueue();
     return {
       status: 'ok',
@@ -217,7 +253,7 @@ export async function startHookServer(): Promise<void> {
   });
 
   // Hook event endpoint
-  server.post<{ Body: unknown }>('/hook', async (request, reply) => {
+  app.post<{ Body: unknown }>('/hook', async (request, reply) => {
     try {
       // Validate input before processing
       if (!isValidHookEvent(request.body)) {
@@ -236,13 +272,13 @@ export async function startHookServer(): Promise<void> {
   });
 
   // Compression queue stats endpoint
-  server.get('/compression/stats', async () => {
+  app.get('/compression/stats', async () => {
     const queue = getCompressionQueue();
     return queue.getStats();
   });
 
   // Context injection endpoint - retrieve relevant memories for a project
-  server.get<{
+  app.get<{
     Querystring: { path?: string; prompt?: string };
   }>('/context', async (request, reply) => {
     const { path, prompt } = request.query;
@@ -276,6 +312,20 @@ export async function startHookServer(): Promise<void> {
       return { success: false, error: (error as Error).message };
     }
   });
+
+  return app;
+}
+
+/** Start hook server */
+export async function startHookServer(): Promise<void> {
+  if (server) {
+    logger.warn('Hook server already running');
+    return;
+  }
+
+  const port = config.get().hookPort;
+
+  server = createHookServer();
 
   try {
     await server.listen({ port, host: '127.0.0.1' });

--- a/src/adapters/hook/server.ts
+++ b/src/adapters/hook/server.ts
@@ -37,46 +37,95 @@ const VALID_EVENT_TYPES: Set<HookEventType> = new Set([
 /** Track first prompts per session for context injection */
 const sessionFirstPrompts: Map<string, boolean> = new Map();
 
-/** Validate hook event payload */
-function isValidHookEvent(event: unknown): event is HookEvent {
-  if (!event || typeof event !== 'object') {
-    return false;
+/** Extract a tool's output from Claude's native payload (field name varies) */
+function extractToolOutput(e: Record<string, unknown>): string | undefined {
+  const raw = e.tool_response ?? e.tool_result ?? e.tool_output;
+  if (raw === undefined || raw === null) return undefined;
+  return typeof raw === 'string' ? raw : JSON.stringify(raw);
+}
+
+/**
+ * Parse Claude Code's native hook payload (delivered as stdin JSON) into a
+ * normalized internal event, or return null if it is not a valid/known event.
+ *
+ * Claude uses `hook_event_name` (not `event_type`) and does not send a
+ * timestamp, so one is stamped on receipt.
+ */
+export function parseHookEvent(raw: unknown): HookEvent | null {
+  if (!raw || typeof raw !== 'object') {
+    return null;
   }
 
-  const e = event as Record<string, unknown>;
+  const e = raw as Record<string, unknown>;
 
-  // Required fields
+  const eventType = e.hook_event_name;
+  if (typeof eventType !== 'string' || !VALID_EVENT_TYPES.has(eventType as HookEventType)) {
+    return null;
+  }
   if (!isValidSessionId(e.session_id)) {
-    return false;
-  }
-  if (typeof e.cwd !== 'string') {
-    return false;
-  }
-  if (typeof e.timestamp !== 'string') {
-    return false;
-  }
-  if (typeof e.event_type !== 'string' || !VALID_EVENT_TYPES.has(e.event_type as HookEventType)) {
-    return false;
+    return null;
   }
 
-  // Tool events require additional fields
-  if (e.event_type === 'PreToolUse' || e.event_type === 'PostToolUse') {
-    if (typeof e.tool_name !== 'string' || e.tool_name.length === 0) {
-      return false;
-    }
-    if (!e.tool_input || typeof e.tool_input !== 'object') {
-      return false;
-    }
-  }
+  const session_id = e.session_id;
+  const cwd = typeof e.cwd === 'string' ? e.cwd : '';
+  const timestamp = new Date().toISOString();
 
-  // UserPromptSubmit requires prompt field
-  if (e.event_type === 'UserPromptSubmit') {
-    if (typeof e.prompt !== 'string') {
-      return false;
+  switch (eventType as HookEventType) {
+    case 'PreToolUse':
+    case 'PostToolUse': {
+      if (typeof e.tool_name !== 'string' || e.tool_name.length === 0) {
+        return null;
+      }
+      const tool_input =
+        e.tool_input && typeof e.tool_input === 'object'
+          ? (e.tool_input as Record<string, unknown>)
+          : {};
+      return {
+        event_type: eventType as 'PreToolUse' | 'PostToolUse',
+        session_id,
+        cwd,
+        timestamp,
+        tool_name: e.tool_name,
+        tool_input,
+        tool_output: extractToolOutput(e),
+      };
     }
-  }
 
-  return true;
+    case 'UserPromptSubmit':
+      return {
+        event_type: 'UserPromptSubmit',
+        session_id,
+        cwd,
+        timestamp,
+        prompt: typeof e.prompt === 'string' ? e.prompt : '',
+      };
+
+    case 'Stop':
+      return {
+        event_type: 'Stop',
+        session_id,
+        cwd,
+        timestamp,
+        reason:
+          typeof e.stop_reason === 'string'
+            ? e.stop_reason
+            : typeof e.reason === 'string'
+              ? e.reason
+              : undefined,
+      };
+
+    case 'Notification':
+      return {
+        event_type: 'Notification',
+        session_id,
+        cwd,
+        timestamp,
+        message: typeof e.message === 'string' ? e.message : '',
+      };
+
+    default:
+      return null;
+  }
 }
 
 /** Handle incoming hook event */
@@ -219,14 +268,21 @@ export async function startHookServer(): Promise<void> {
   // Hook event endpoint
   server.post<{ Body: unknown }>('/hook', async (request, reply) => {
     try {
-      // Validate input before processing
-      if (!isValidHookEvent(request.body)) {
-        logger.warn('Invalid hook event received', { body: request.body });
+      // Parse Claude's native stdin payload into a normalized event.
+      const event = parseHookEvent(request.body);
+      if (!event) {
+        // Log only non-sensitive identifiers, never the raw body (which may
+        // carry prompts, tool inputs, or secrets).
+        const body = request.body as Record<string, unknown> | null;
+        logger.warn('Invalid hook event received', {
+          hook_event_name: body?.hook_event_name,
+          session_id: body?.session_id,
+        });
         reply.status(400);
         return { success: false, error: 'Invalid hook event payload' };
       }
 
-      await handleHookEvent(request.body);
+      await handleHookEvent(event);
       return { success: true };
     } catch (error) {
       logger.error('Failed to handle hook event', error);

--- a/src/adapters/hook/types.ts
+++ b/src/adapters/hook/types.ts
@@ -2,7 +2,7 @@
  * Hook module types
  */
 
-/** Hook event types from Claude Code */
+/** Hook event types from Claude Code that Keepline consumes */
 export type HookEventType =
   | 'PreToolUse'
   | 'PostToolUse'
@@ -10,7 +10,14 @@ export type HookEventType =
   | 'Stop'
   | 'UserPromptSubmit'; // User submitted a prompt
 
-/** Base hook event payload */
+/**
+ * Internal, normalized hook event payload.
+ *
+ * Claude Code delivers hook data as JSON on stdin (fields such as
+ * `hook_event_name`, `tool_response`) and does NOT set `$CLAUDE_*` env vars.
+ * The server parses that native payload into these normalized shapes; the
+ * `timestamp` is stamped on receipt because Claude does not send one.
+ */
 export interface HookEventPayload {
   session_id: string;
   cwd: string;
@@ -41,7 +48,6 @@ export interface StopHookEvent extends HookEventPayload {
 export interface UserPromptSubmitHookEvent extends HookEventPayload {
   event_type: 'UserPromptSubmit';
   prompt: string;
-  is_first_prompt?: boolean;
 }
 
 /** Union type for all hook events */
@@ -51,20 +57,24 @@ export type HookEvent =
   | StopHookEvent
   | UserPromptSubmitHookEvent;
 
-/** Claude settings hook configuration */
-export interface ClaudeHookConfig {
-  matcher?: string;
+/**
+ * A single command entry inside a Claude settings hook matcher block.
+ * This is Claude Code's real nested shape: `hooks[].hooks[]`.
+ */
+export interface HookCommandEntry {
+  type: 'command';
   command: string;
+  timeout?: number;
 }
 
-/** Claude settings structure */
+/** A matcher block: optionally filters events, and runs one or more commands */
+export interface ClaudeHookMatcher {
+  matcher?: string;
+  hooks: HookCommandEntry[];
+}
+
+/** Claude settings structure (hooks use the nested matcher-block shape) */
 export interface ClaudeSettings {
-  hooks?: {
-    PreToolUse?: ClaudeHookConfig[];
-    PostToolUse?: ClaudeHookConfig[];
-    Notification?: ClaudeHookConfig[];
-    Stop?: ClaudeHookConfig[];
-    UserPromptSubmit?: ClaudeHookConfig[];
-  };
+  hooks?: Partial<Record<HookEventType, ClaudeHookMatcher[]>>;
   [key: string]: unknown;
 }

--- a/src/adapters/hook/types.ts
+++ b/src/adapters/hook/types.ts
@@ -12,9 +12,11 @@ export type HookEventType =
 
 /** Base hook event payload */
 export interface HookEventPayload {
+  event_type: HookEventType;
   session_id: string;
   cwd: string;
   timestamp: string;
+  transcript_path?: string;
 }
 
 /** Tool use hook event */
@@ -22,7 +24,7 @@ export interface ToolUseHookEvent extends HookEventPayload {
   event_type: 'PreToolUse' | 'PostToolUse';
   tool_name: string;
   tool_input: Record<string, unknown>;
-  tool_output?: string; // Only present in PostToolUse
+  tool_output?: string;
 }
 
 /** Notification hook event */
@@ -52,10 +54,21 @@ export type HookEvent =
   | UserPromptSubmitHookEvent;
 
 /** Claude settings hook configuration */
-export interface ClaudeHookConfig {
-  matcher?: string;
+export interface ClaudeHookCommandHandler {
+  type?: 'command' | string;
   command: string;
+  args?: string[];
+  timeout?: number;
+  [key: string]: unknown;
 }
+
+export interface ClaudeHookMatcherGroup {
+  matcher?: string;
+  hooks: ClaudeHookCommandHandler[];
+  [key: string]: unknown;
+}
+
+export type ClaudeHookConfig = ClaudeHookCommandHandler | ClaudeHookMatcherGroup;
 
 /** Claude settings structure */
 export interface ClaudeSettings {

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -25,6 +25,7 @@ export function resetDatabase(): void {
     DROP TABLE IF EXISTS session_memories;
     DROP TABLE IF EXISTS tool_usage;
     DROP TABLE IF EXISTS hook_events;
+    DROP TABLE IF EXISTS events;
     DROP TABLE IF EXISTS sessions;
     DROP TABLE IF EXISTS metadata;
     DROP TABLE IF EXISTS schema_migrations;

--- a/src/domain/runtime/types.ts
+++ b/src/domain/runtime/types.ts
@@ -4,7 +4,11 @@
 
 import type { SessionStatus, ToolCallInfo } from '../session/index.js';
 
-export type RuntimeId = 'claude-code' | 'codex' | 'cursor' | (string & {});
+export const REGISTERED_RUNTIME_IDS = ['claude-code', 'codex'] as const;
+
+export type RegisteredRuntimeId = typeof REGISTERED_RUNTIME_IDS[number];
+
+export type RuntimeId = RegisteredRuntimeId | (string & {});
 
 export type RuntimeKind = 'cli' | 'ide' | 'cloud' | 'unknown';
 

--- a/src/domain/session/entity.ts
+++ b/src/domain/session/entity.ts
@@ -103,6 +103,7 @@ export type SessionListItem = Pick<
   | 'tty'
   | 'toolCount'
   | 'messageCount'
+  | 'usageStats'
   | 'createdAt'
   | 'updatedAt'
 >;

--- a/src/infrastructure/database/repositories/session.repository.ts
+++ b/src/infrastructure/database/repositories/session.repository.ts
@@ -61,6 +61,11 @@ interface SessionListRow {
   tty: string | null;
   tool_count: number;
   message_count: number;
+  total_input_tokens: number | null;
+  total_output_tokens: number | null;
+  total_tokens: number | null;
+  total_cost: number | null;
+  api_calls: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -90,6 +95,23 @@ function parseToolCalls(raw: string | null): ToolCallInfo[] | undefined {
   }
 }
 
+type UsageStatsRow = Pick<
+  SessionRow,
+  'total_input_tokens' | 'total_output_tokens' | 'total_tokens' | 'total_cost' | 'api_calls'
+>;
+
+function rowToUsageStats(row: UsageStatsRow): Session['usageStats'] {
+  return row.total_tokens != null
+    ? {
+        totalInputTokens: row.total_input_tokens ?? 0,
+        totalOutputTokens: row.total_output_tokens ?? 0,
+        totalTokens: row.total_tokens ?? 0,
+        totalCost: row.total_cost ?? 0,
+        apiCalls: row.api_calls ?? 0,
+      }
+    : undefined;
+}
+
 /** Convert database row to Session entity */
 function rowToSession(row: SessionRow): Session {
   return {
@@ -114,15 +136,7 @@ function rowToSession(row: SessionRow): Session {
     agentId: row.agent_id || undefined,
     parentSessionId: row.parent_session_id || undefined,
     isSubAgent: row.is_sub_agent === 1,
-    usageStats: row.total_tokens != null
-      ? {
-          totalInputTokens: row.total_input_tokens ?? 0,
-          totalOutputTokens: row.total_output_tokens ?? 0,
-          totalTokens: row.total_tokens ?? 0,
-          totalCost: row.total_cost ?? 0,
-          apiCalls: row.api_calls ?? 0,
-        }
-      : undefined,
+    usageStats: rowToUsageStats(row),
     toolCalls: parseToolCalls(row.tool_calls),
     createdAt: new Date(row.created_at),
     updatedAt: new Date(row.updated_at),
@@ -144,6 +158,7 @@ function rowToSessionListItem(row: SessionListRow): SessionListItem {
     tty: row.tty || undefined,
     toolCount: row.tool_count,
     messageCount: row.message_count,
+    usageStats: rowToUsageStats(row),
     createdAt: new Date(row.created_at),
     updatedAt: new Date(row.updated_at),
   };
@@ -242,6 +257,11 @@ class SessionRepository implements ISessionRepository {
           tty,
           tool_count,
           message_count,
+          total_input_tokens,
+          total_output_tokens,
+          total_tokens,
+          total_cost,
+          api_calls,
           created_at,
           updated_at
         FROM sessions

--- a/src/infrastructure/database/repositories/session.repository.ts
+++ b/src/infrastructure/database/repositories/session.repository.ts
@@ -417,22 +417,41 @@ class SessionRepository implements ISessionRepository {
     });
   }
 
-  deleteOldSessions(retentionDays: number): number {
+  deleteOldSessions(retentionDays: number, now: Date = new Date()): number {
     const db = getDatabase();
-    const cutoff = new Date();
+    const cutoff = new Date(now);
     cutoff.setDate(cutoff.getDate() - retentionDays);
+    const cutoffIso = cutoff.toISOString();
 
-    const beforeCount = (db.prepare(`
-      SELECT COUNT(*) as count FROM sessions
-      WHERE status = 'completed' AND last_active_at < ?
-    `).get(cutoff.toISOString()) as { count: number }).count;
+    return transaction(() => {
+      const beforeCount = (db.prepare(`
+        SELECT COUNT(*) as count FROM sessions
+        WHERE status = 'completed' AND last_active_at < ?
+      `).get(cutoffIso) as { count: number }).count;
 
-    db.prepare(`
-      DELETE FROM sessions
-      WHERE status = 'completed' AND last_active_at < ?
-    `).run(cutoff.toISOString());
+      db.prepare(`
+        DELETE FROM tool_usage
+        WHERE session_id IN (
+          SELECT session_id FROM sessions
+          WHERE status = 'completed' AND last_active_at < ?
+        )
+      `).run(cutoffIso);
 
-    return beforeCount;
+      db.prepare(`
+        DELETE FROM hook_events
+        WHERE session_id IN (
+          SELECT session_id FROM sessions
+          WHERE status = 'completed' AND last_active_at < ?
+        )
+      `).run(cutoffIso);
+
+      db.prepare(`
+        DELETE FROM sessions
+        WHERE status = 'completed' AND last_active_at < ?
+      `).run(cutoffIso);
+
+      return beforeCount;
+    });
   }
 
   countByStatus(): Record<SessionStatus, number> {

--- a/src/infrastructure/database/repositories/session.repository.ts
+++ b/src/infrastructure/database/repositories/session.repository.ts
@@ -302,32 +302,41 @@ class SessionRepository implements ISessionRepository {
     return transaction(() => {
       const hasPid = 'pid' in data;
       const hasTty = 'tty' in data;
+      const hasLastTool = 'lastTool' in data;
+      const hasLastToolInput = 'lastToolInput' in data;
+      const hasCurrentFile = 'currentFile' in data;
+      const hasLastMessage = 'lastMessage' in data;
+      const hasCompletedAt = 'completedAt' in data;
+      const hasAgentId = 'agentId' in data;
+      const hasParentSessionId = 'parentSessionId' in data;
+      const hasUsageStats = 'usageStats' in data;
+      const hasToolCalls = 'toolCalls' in data;
       const updateResult = db.prepare(`
         UPDATE sessions SET
           status = COALESCE(?, status),
           client = COALESCE(?, client),
           title = COALESCE(?, title),
           initial_prompt = COALESCE(?, initial_prompt),
-          last_tool = COALESCE(?, last_tool),
-          last_tool_input = COALESCE(?, last_tool_input),
-          current_file = COALESCE(?, current_file),
-          last_message = COALESCE(?, last_message),
+          last_tool = CASE WHEN ? THEN ? ELSE last_tool END,
+          last_tool_input = CASE WHEN ? THEN ? ELSE last_tool_input END,
+          current_file = CASE WHEN ? THEN ? ELSE current_file END,
+          last_message = CASE WHEN ? THEN ? ELSE last_message END,
           started_at = COALESCE(?, started_at),
           last_active_at = COALESCE(?, last_active_at),
-          completed_at = COALESCE(?, completed_at),
+          completed_at = CASE WHEN ? THEN ? ELSE completed_at END,
           pid = CASE WHEN ? THEN ? ELSE pid END,
           tty = CASE WHEN ? THEN ? ELSE tty END,
           tool_count = COALESCE(?, tool_count),
           message_count = COALESCE(?, message_count),
-          agent_id = COALESCE(?, agent_id),
-          parent_session_id = COALESCE(?, parent_session_id),
+          agent_id = CASE WHEN ? THEN ? ELSE agent_id END,
+          parent_session_id = CASE WHEN ? THEN ? ELSE parent_session_id END,
           is_sub_agent = COALESCE(?, is_sub_agent),
-          total_input_tokens = COALESCE(?, total_input_tokens),
-          total_output_tokens = COALESCE(?, total_output_tokens),
-          total_tokens = COALESCE(?, total_tokens),
-          total_cost = COALESCE(?, total_cost),
-          api_calls = COALESCE(?, api_calls),
-          tool_calls = COALESCE(?, tool_calls),
+          total_input_tokens = CASE WHEN ? THEN ? ELSE total_input_tokens END,
+          total_output_tokens = CASE WHEN ? THEN ? ELSE total_output_tokens END,
+          total_tokens = CASE WHEN ? THEN ? ELSE total_tokens END,
+          total_cost = CASE WHEN ? THEN ? ELSE total_cost END,
+          api_calls = CASE WHEN ? THEN ? ELSE api_calls END,
+          tool_calls = CASE WHEN ? THEN ? ELSE tool_calls END,
           updated_at = ?
         WHERE session_id = ?
       `).run(
@@ -335,12 +344,17 @@ class SessionRepository implements ISessionRepository {
         data.client ?? null,
         data.title ?? null,
         data.initialPrompt ?? null,
+        hasLastTool ? 1 : 0,
         data.lastTool ?? null,
+        hasLastToolInput ? 1 : 0,
         data.lastToolInput ?? null,
+        hasCurrentFile ? 1 : 0,
         data.currentFile ?? null,
+        hasLastMessage ? 1 : 0,
         data.lastMessage ?? null,
         data.startedAt?.toISOString() ?? null,
         data.lastActiveAt?.toISOString() ?? null,
+        hasCompletedAt ? 1 : 0,
         data.completedAt?.toISOString() ?? null,
         hasPid ? 1 : 0,
         data.pid ?? null,
@@ -348,14 +362,22 @@ class SessionRepository implements ISessionRepository {
         data.tty ?? null,
         data.toolCount ?? null,
         data.messageCount ?? null,
+        hasAgentId ? 1 : 0,
         data.agentId ?? null,
+        hasParentSessionId ? 1 : 0,
         data.parentSessionId ?? null,
         data.isSubAgent != null ? (data.isSubAgent ? 1 : 0) : null,
+        hasUsageStats ? 1 : 0,
         data.usageStats?.totalInputTokens ?? null,
+        hasUsageStats ? 1 : 0,
         data.usageStats?.totalOutputTokens ?? null,
+        hasUsageStats ? 1 : 0,
         data.usageStats?.totalTokens ?? null,
+        hasUsageStats ? 1 : 0,
         data.usageStats?.totalCost ?? null,
+        hasUsageStats ? 1 : 0,
         data.usageStats?.apiCalls ?? null,
+        hasToolCalls ? 1 : 0,
         data.toolCalls ? JSON.stringify(data.toolCalls) : null,
         now,
         data.sessionId

--- a/src/infrastructure/database/sqlite.ts
+++ b/src/infrastructure/database/sqlite.ts
@@ -25,6 +25,7 @@ export function getDatabase(): Database {
 
     db = new Database(KEEPLINE_DB);
     db.exec('PRAGMA journal_mode = WAL');
+    db.exec('PRAGMA busy_timeout = 5000');
     db.exec('PRAGMA foreign_keys = ON');
 
     logger.debug('Database connection established');

--- a/src/infrastructure/events/store.ts
+++ b/src/infrastructure/events/store.ts
@@ -39,10 +39,18 @@ export class EventStore {
   private initialized = false;
 
   private ensureInitialized(): void {
-    if (!this.initialized) {
+    if (!this.initialized || !this.eventsTableExists()) {
       ensureEventsTable();
       this.initialized = true;
     }
+  }
+
+  private eventsTableExists(): boolean {
+    const db = getDatabase();
+    const row = db
+      .prepare("SELECT 1 as exists_flag FROM sqlite_master WHERE type = 'table' AND name = 'events'")
+      .get() as { exists_flag: number } | undefined;
+    return Boolean(row);
   }
 
   /**

--- a/src/infrastructure/vector/lancedb.adapter.ts
+++ b/src/infrastructure/vector/lancedb.adapter.ts
@@ -9,6 +9,7 @@ import * as lancedb from '@lancedb/lancedb';
 import { join } from 'path';
 import { mkdirSync, existsSync } from 'fs';
 import { logger } from '../../lib/logger.js';
+import { assertValidObservationId } from '../../lib/observation-id.js';
 import { KEEPLINE_HOME } from '../../lib/paths.js';
 import type {
   IVectorStore,
@@ -70,6 +71,17 @@ function fromRow(row: LanceDBRow): Observation {
     tokenCount: row.tokenCount,
     compressed: row.compressed,
   };
+}
+
+/** Build a LanceDB string literal only after the observation id has passed the safe allowlist. */
+function safeObservationIdLiteral(id: string): string {
+  assertValidObservationId(id);
+  return `'${id}'`;
+}
+
+/** Build a LanceDB predicate only from a safe observation id literal. */
+function observationIdPredicate(id: string): string {
+  return `id = ${safeObservationIdLiteral(id)}`;
 }
 
 /**
@@ -237,12 +249,13 @@ export class LanceDBVectorStore implements IVectorStore {
    * Get observation by ID
    */
   async getById(id: string): Promise<Observation | null> {
+    const predicate = observationIdPredicate(id);
     if (!this.initialized) await this.initialize();
     if (!this.table) return null;
 
     const results = await this.table
       .query()
-      .where(`id = '${id}'`)
+      .where(predicate)
       .limit(1)
       .toArray();
 
@@ -270,11 +283,12 @@ export class LanceDBVectorStore implements IVectorStore {
    * Delete observation by ID
    */
   async delete(id: string): Promise<boolean> {
+    const predicate = observationIdPredicate(id);
     if (!this.initialized) await this.initialize();
     if (!this.table) return false;
 
     try {
-      await this.table.delete(`id = '${id}'`);
+      await this.table.delete(predicate);
       logger.debug(`Deleted observation ${id}`);
       return true;
     } catch (error) {

--- a/src/lib/observation-id.ts
+++ b/src/lib/observation-id.ts
@@ -1,0 +1,17 @@
+/**
+ * Observation ID validation shared by memory routes and vector stores.
+ */
+
+const OBSERVATION_ID_PATTERN = /^[a-zA-Z0-9-_]{8,64}$/;
+
+/** Validate observation ID format before it is used in vector-store predicates. */
+export function isValidObservationId(id: unknown): id is string {
+  return typeof id === 'string' && OBSERVATION_ID_PATTERN.test(id);
+}
+
+/** Throw when a value cannot safely be used as an observation ID. */
+export function assertValidObservationId(id: unknown): asserts id is string {
+  if (!isValidObservationId(id)) {
+    throw new Error('Invalid observation ID format');
+  }
+}

--- a/src/services/attention.prioritizer.ts
+++ b/src/services/attention.prioritizer.ts
@@ -32,6 +32,13 @@ export interface AttentionSessionContext {
 }
 
 export type AttentionIntentConfidence = 'high' | 'medium' | 'low';
+export type AttentionIntentTaskSource =
+  | 'initial_prompt'
+  | 'digest'
+  | 'title'
+  | 'last_message'
+  | 'current_file'
+  | 'none';
 export type AttentionIntentNoiseFlag =
   | 'instructions_heavy'
   | 'missing_user_goal'
@@ -40,6 +47,7 @@ export type AttentionIntentNoiseFlag =
 
 export interface AttentionIntent {
   task?: string;
+  taskSource: AttentionIntentTaskSource;
   currentState?: string;
   nextAction: string;
   whyAttention: string;
@@ -307,17 +315,26 @@ function buildSessionIntent(
     ? `Working around ${formatPathTail(session.currentFile)}`
     : undefined;
 
-  let task = firstNonEmpty([promptTask, digestTask, titleTask]);
+  const taskCandidate = firstNonEmptyTask([
+    { task: promptTask, source: 'initial_prompt' },
+    { task: digestTask, source: 'digest' },
+    { task: titleTask, source: 'title' },
+  ]);
+
+  let task = taskCandidate?.task;
+  let taskSource: AttentionIntentTaskSource = taskCandidate?.source ?? 'none';
   let confidence: AttentionIntentConfidence = task ? 'high' : 'low';
 
   if (!task && taskMessage) {
     task = deriveTaskFromLastMessage(taskMessage);
+    taskSource = task ? 'last_message' : 'none';
     confidence = 'medium';
     noiseFlags.push('derived_from_last_message');
   }
 
   if (!task && fileTask) {
     task = fileTask;
+    taskSource = 'current_file';
     confidence = 'low';
     noiseFlags.push('derived_from_file');
   }
@@ -328,6 +345,7 @@ function buildSessionIntent(
 
   return {
     task,
+    taskSource,
     currentState: firstNonEmpty([lastMessage, digestTask, titleTask]),
     nextAction: buildNextAction(session, reasons),
     whyAttention: buildWhyAttention(reasons),
@@ -427,6 +445,14 @@ function buildWhyAttention(reasons: AttentionReason[]): string {
 
 function firstNonEmpty(values: Array<string | undefined>): string | undefined {
   return values.find((value) => value?.trim());
+}
+
+function firstNonEmptyTask(
+  values: Array<{ task: string | undefined; source: AttentionIntentTaskSource }>
+): { task: string; source: AttentionIntentTaskSource } | undefined {
+  return values.find((value): value is { task: string; source: AttentionIntentTaskSource } =>
+    Boolean(value.task?.trim())
+  );
 }
 
 function formatPathTail(path: string): string {

--- a/src/services/daemon.scheduler.ts
+++ b/src/services/daemon.scheduler.ts
@@ -10,9 +10,13 @@ import { runMigrations } from '../db/migrations.js';
 import { closeDatabase } from '../infrastructure/database/sqlite.js';
 import { emit } from '../lib/events.js';
 import { initializeMemoryService } from './memory.service.js';
+import { runRetentionCleanup } from './retention.service.js';
 
 let scanInterval: NodeJS.Timeout | null = null;
+let retentionInterval: NodeJS.Timeout | null = null;
 let isRunning = false;
+
+const RETENTION_CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 /** Run a single scan cycle */
 async function runScanCycle(): Promise<void> {
@@ -22,6 +26,16 @@ async function runScanCycle(): Promise<void> {
   } catch (error) {
     logger.error('Scan cycle failed', error);
     emit('error', { error: error as Error, context: 'scan_cycle' });
+  }
+}
+
+/** Run one retention cleanup cycle */
+async function runRetentionCleanupCycle(): Promise<void> {
+  try {
+    await runRetentionCleanup();
+  } catch (error) {
+    logger.error('Retention cleanup failed', error);
+    emit('error', { error: error as Error, context: 'retention_cleanup' });
   }
 }
 
@@ -49,8 +63,17 @@ export async function startScheduler(): Promise<void> {
   // Run initial scan
   await runScanCycle();
 
+  // Run initial retention cleanup after sessions are synced.
+  await runRetentionCleanupCycle();
+
   // Start periodic scanning
   scanInterval = setInterval(runScanCycle, cfg.scanInterval);
+
+  if (cfg.retentionDays > 0) {
+    retentionInterval = setInterval(runRetentionCleanupCycle, RETENTION_CLEANUP_INTERVAL_MS);
+  } else {
+    logger.info('Retention cleanup disabled');
+  }
 
   logger.info(`Scheduler started (scan interval: ${cfg.scanInterval}ms)`);
 }
@@ -65,6 +88,11 @@ export async function stopScheduler(): Promise<void> {
   if (scanInterval) {
     clearInterval(scanInterval);
     scanInterval = null;
+  }
+
+  if (retentionInterval) {
+    clearInterval(retentionInterval);
+    retentionInterval = null;
   }
 
   // Stop hook server

--- a/src/services/daemon.scheduler.ts
+++ b/src/services/daemon.scheduler.ts
@@ -10,6 +10,7 @@ import { runMigrations } from '../db/migrations.js';
 import { closeDatabase } from '../infrastructure/database/sqlite.js';
 import { emit } from '../lib/events.js';
 import { initializeMemoryService } from './memory.service.js';
+import { initPricing } from './usage.pricing.js';
 
 let scanInterval: NodeJS.Timeout | null = null;
 let isRunning = false;
@@ -39,6 +40,10 @@ export async function startScheduler(): Promise<void> {
 
   // Initialize database
   runMigrations();
+
+  // Initialize pricing before scan cycles. The pricing module falls back to
+  // defaults if remote LiteLLM pricing cannot be fetched.
+  await initPricing();
 
   // Initialize memory service (must be before hook server)
   initializeMemoryService();
@@ -97,15 +102,23 @@ export async function runDaemon(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 
   // Handle uncaught errors
+  const exitOnFatalError = async (error: Error, context: string): Promise<void> => {
+    try {
+      logger.error(`Fatal daemon error: ${context}`, error);
+      emit('error', { error, context });
+      await stopScheduler();
+    } finally {
+      process.exit(1);
+    }
+  };
+
   process.on('uncaughtException', (error) => {
-    logger.error('Uncaught exception', error);
-    emit('error', { error, context: 'uncaught_exception' });
+    void exitOnFatalError(error, 'uncaught_exception');
   });
 
   process.on('unhandledRejection', (reason) => {
     const error = reason instanceof Error ? reason : new Error(String(reason));
-    logger.error('Unhandled rejection', error);
-    emit('error', { error, context: 'unhandled_rejection' });
+    void exitOnFatalError(error, 'unhandled_rejection');
   });
 
   // Start scheduler

--- a/src/services/retention.service.ts
+++ b/src/services/retention.service.ts
@@ -1,0 +1,52 @@
+import { config } from '../lib/config.js';
+import { logger } from '../lib/logger.js';
+import { sessionRepository } from '../infrastructure/database/repositories/session.repository.js';
+import { eventStore } from '../infrastructure/events/store.js';
+
+export interface RetentionCleanupResult {
+  disabled: boolean;
+  retentionDays: number;
+  cutoff?: Date;
+  sessionsDeleted: number;
+  eventsDeleted: number;
+}
+
+function retentionCutoff(retentionDays: number, now: Date): Date {
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - retentionDays);
+  return cutoff;
+}
+
+export async function runRetentionCleanup(
+  retentionDays: number = config.get().retentionDays,
+  now: Date = new Date()
+): Promise<RetentionCleanupResult> {
+  if (retentionDays <= 0) {
+    logger.debug('Retention cleanup disabled', { retentionDays });
+    return {
+      disabled: true,
+      retentionDays,
+      sessionsDeleted: 0,
+      eventsDeleted: 0,
+    };
+  }
+
+  const cutoff = retentionCutoff(retentionDays, now);
+  const sessionsDeleted = sessionRepository.deleteOldSessions(retentionDays, now);
+  const eventsDeleted = await eventStore.deleteOlderThan(cutoff);
+
+  logger.info('Retention cleanup completed', {
+    retentionDays,
+    cutoff: cutoff.toISOString(),
+    sessionsDeleted,
+    eventsDeleted,
+  });
+
+  return {
+    disabled: false,
+    retentionDays,
+    cutoff,
+    sessionsDeleted,
+    eventsDeleted,
+  };
+}

--- a/src/services/runtime-status.ts
+++ b/src/services/runtime-status.ts
@@ -1,10 +1,25 @@
-import type { RuntimeId, RuntimeScanError } from '../domain/runtime/index.js';
+import {
+  REGISTERED_RUNTIME_IDS,
+  type RegisteredRuntimeId,
+  type RuntimeId,
+  type RuntimeScanError,
+} from '../domain/runtime/index.js';
 import type { AgentClient } from '../domain/session/index.js';
 
-export type SessionRuntimeId = 'claude-code' | 'codex';
+export type SessionRuntimeId = RegisteredRuntimeId;
 export type RuntimeFilter = SessionRuntimeId | 'all';
 
-export const SESSION_RUNTIME_IDS: readonly SessionRuntimeId[] = ['claude-code', 'codex'] as const;
+export const SESSION_RUNTIME_IDS: readonly SessionRuntimeId[] = REGISTERED_RUNTIME_IDS;
+
+const CLIENT_RUNTIME_IDS = {
+  claude: 'claude-code',
+  codex: 'codex',
+} satisfies Record<AgentClient, SessionRuntimeId>;
+
+const RUNTIME_CLIENTS = {
+  'claude-code': 'claude',
+  codex: 'codex',
+} satisfies Record<SessionRuntimeId, AgentClient>;
 
 export interface RuntimeScanSummary {
   runtimeId: SessionRuntimeId;
@@ -23,12 +38,23 @@ export type RuntimeScanFailure = {
 
 const latestRuntimeScan = new Map<SessionRuntimeId, RuntimeScanSummary>();
 
-export function runtimeIdForClient(client: AgentClient | undefined): SessionRuntimeId {
-  return client === 'codex' ? 'codex' : 'claude-code';
+export function isSessionRuntimeId(runtimeId: string): runtimeId is SessionRuntimeId {
+  return (SESSION_RUNTIME_IDS as readonly string[]).includes(runtimeId);
 }
 
-export function clientForRuntimeId(runtimeId: SessionRuntimeId): AgentClient {
-  return runtimeId === 'codex' ? 'codex' : 'claude';
+export function runtimeIdForClient(client: AgentClient): SessionRuntimeId {
+  const runtimeId = CLIENT_RUNTIME_IDS[client];
+  if (!runtimeId) {
+    throw new Error(`Unsupported agent client: ${String(client)}`);
+  }
+  return runtimeId;
+}
+
+export function clientForRuntimeId(runtimeId: RuntimeId): AgentClient {
+  if (!isSessionRuntimeId(runtimeId)) {
+    throw new Error(`Unsupported runtime id: ${String(runtimeId)}`);
+  }
+  return RUNTIME_CLIENTS[runtimeId];
 }
 
 export function parseRuntimeFilter(raw: string | undefined): {
@@ -37,7 +63,7 @@ export function parseRuntimeFilter(raw: string | undefined): {
 } {
   const value = raw?.trim();
   if (!value || value === 'all') return {};
-  if (value === 'claude-code' || value === 'codex') {
+  if (isSessionRuntimeId(value)) {
     return { runtimeId: value };
   }
   return { invalid: value };

--- a/src/services/session.process-matcher.ts
+++ b/src/services/session.process-matcher.ts
@@ -16,6 +16,7 @@ import type { AgentClient } from '../domain/session/index.js';
 const UNMATCHED_PROCESS_PENALTY = 30 * 24 * 60 * 60 * 1000;
 const MAX_ACTIVITY_AGE_PENALTY = 24 * 60 * 60 * 1000;
 const START_TIME_WEIGHT = 10;
+const PID_REUSE_START_TOLERANCE_MS = 60 * 1000;
 
 export interface SessionProcessCandidate {
   sessionId: string;
@@ -69,6 +70,14 @@ function compareCandidates<T extends SessionProcessCandidate>(
     return right.meta.lastActiveAtMs - left.meta.lastActiveAtMs;
   }
   return left.meta.session.sessionId.localeCompare(right.meta.session.sessionId);
+}
+
+function isPidContinuityCompatible(
+  session: SessionProcessCandidate,
+  process: ClaudeProcessInfo
+): boolean {
+  return process.startTime.getTime() <=
+    session.lastActiveAt.getTime() + PID_REUSE_START_TOLERANCE_MS;
 }
 
 function selectCandidateSessions<T extends SessionProcessCandidate>(
@@ -217,6 +226,10 @@ export function matchProcessesToSessions<T extends SessionProcessCandidate>(
         const process = processByPid.get(session.pid);
         if (!process || usedProcessPids.has(process.pid)) {
           unmatchedSessions.push(session);
+          continue;
+        }
+
+        if (!isPidContinuityCompatible(session, process)) {
           continue;
         }
 

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -203,8 +203,9 @@ export class SessionService {
         );
 
         if (existing) {
+          const nextStatus = existing.status === 'completed' ? 'completed' : status;
           // Update existing session
-          const wasLost = existing.status !== 'lost' && status === 'lost';
+          const wasLost = existing.status !== 'lost' && nextStatus === 'lost';
 
           // Update title if current one is Unknown and we have new info
           const shouldUpdateTitle =
@@ -215,7 +216,7 @@ export class SessionService {
           const updatedSession = this.repository.upsert({
             sessionId: agentSession.sessionId,
             client,
-            status,
+            status: nextStatus,
             ...(shouldUpdateTitle && {
               title: generateTitle(agentSession.firstMessage!),
               initialPrompt: agentSession.firstMessage,

--- a/src/services/usage.extractor.ts
+++ b/src/services/usage.extractor.ts
@@ -58,21 +58,12 @@ export function createUsageAccumulator(): UsageAccumulator {
   }
 }
 
-const resolvedUsageCostModels = new Map<string, UsageCostModel>()
-
 function getUsageCostModel(model: string): UsageCostModel {
-  const cached = resolvedUsageCostModels.get(model)
-  if (cached) {
-    return cached
-  }
-
   const pricing = getModelPricing(model)
-  const costModel = {
+  return {
     inputPerToken: pricing.inputPerMillion / 1_000_000,
     outputPerToken: pricing.outputPerMillion / 1_000_000,
   }
-  resolvedUsageCostModels.set(model, costModel)
-  return costModel
 }
 
 export function addUsageToAccumulator(

--- a/src/services/usage.pricing.ts
+++ b/src/services/usage.pricing.ts
@@ -15,7 +15,7 @@ let cacheTime: number = 0
 const CACHE_TTL = 24 * 60 * 60 * 1000 // 24 hours
 
 /** LiteLLM model entry structure */
-interface LiteLLMModelEntry {
+export interface LiteLLMModelEntry {
   input_cost_per_token?: number
   output_cost_per_token?: number
   litellm_provider?: string
@@ -51,6 +51,29 @@ export const DEFAULT_PRICING: PricingConfig = {
   'claude-sonnet-4-5-20250929': { inputPerMillion: 3.0, outputPerMillion: 15.0 },
 }
 
+const fallbackWarningModels = new Set<string>()
+
+/** Convert LiteLLM model price data to Keepline pricing config. */
+export function pricingConfigFromLiteLLMData(
+  data: Record<string, LiteLLMModelEntry>
+): PricingConfig {
+  const pricing: PricingConfig = {}
+
+  for (const [modelId, entry] of Object.entries(data)) {
+    if (
+      entry.input_cost_per_token !== undefined &&
+      entry.output_cost_per_token !== undefined
+    ) {
+      pricing[modelId] = {
+        inputPerMillion: entry.input_cost_per_token * 1_000_000,
+        outputPerMillion: entry.output_cost_per_token * 1_000_000,
+      }
+    }
+  }
+
+  return pricing
+}
+
 /** Fetch pricing from LiteLLM */
 async function fetchLiteLLMPricing(): Promise<PricingConfig> {
   try {
@@ -60,25 +83,7 @@ async function fetchLiteLLMPricing(): Promise<PricingConfig> {
     }
 
     const data = (await response.json()) as Record<string, LiteLLMModelEntry>
-    const pricing: PricingConfig = {}
-
-    // Extract Claude models from Anthropic provider
-    for (const [modelId, entry] of Object.entries(data)) {
-      // Only process Anthropic models
-      if (
-        entry.litellm_provider === 'anthropic' &&
-        entry.input_cost_per_token !== undefined &&
-        entry.output_cost_per_token !== undefined
-      ) {
-        // Convert per-token cost to per-million cost
-        pricing[modelId] = {
-          inputPerMillion: entry.input_cost_per_token * 1_000_000,
-          outputPerMillion: entry.output_cost_per_token * 1_000_000,
-        }
-      }
-    }
-
-    return pricing
+    return pricingConfigFromLiteLLMData(data)
   } catch (error) {
     logger.warn('Failed to fetch LiteLLM pricing, using defaults', error)
     return DEFAULT_PRICING
@@ -137,6 +142,11 @@ export function getModelPricing(model: string): ModelPricing {
     return pricing['claude/claude-3-5-sonnet-20241022'] || pricing['claude-3-5-sonnet-20241022'] || { inputPerMillion: 3.0, outputPerMillion: 15.0 }
   }
 
+  if (!fallbackWarningModels.has(model)) {
+    fallbackWarningModels.add(model)
+    logger.warn('Using fallback pricing for unknown model', { model })
+  }
+
   return FALLBACK_PRICING
 }
 
@@ -178,4 +188,11 @@ export function calculateCostWithCache(
 /** Initialize pricing (call at startup) */
 export async function initPricing(): Promise<void> {
   await getPricingConfig()
+}
+
+/** Reset pricing internals for focused tests. */
+export function resetPricingForTests(pricing?: PricingConfig): void {
+  cachedPricing = pricing ?? null
+  cacheTime = pricing ? Date.now() : 0
+  fallbackWarningModels.clear()
 }

--- a/src/web/api/middleware/validation.ts
+++ b/src/web/api/middleware/validation.ts
@@ -14,6 +14,7 @@ export const VALID_TERMINAL_APPS = ['Terminal', 'iTerm', 'Warp', 'auto'] as cons
 export type TerminalAppOption = (typeof VALID_TERMINAL_APPS)[number];
 
 export { isValidSessionId } from '../../../lib/session-id.js';
+export { isValidObservationId } from '../../../lib/observation-id.js';
 
 /** Recovery request body */
 export interface RecoverRequestBody {

--- a/src/web/api/routes/memory.ts
+++ b/src/web/api/routes/memory.ts
@@ -11,7 +11,7 @@ import { buildContext, buildMinimalContext } from '../../../domain/memory/index.
 import type { MemoryUpsertData } from '../../../domain/memory/index.js';
 import { logger } from '../../../lib/logger.js';
 import { authMiddleware } from '../middleware/auth.js';
-import { isValidSessionId } from '../middleware/validation.js';
+import { isValidObservationId, isValidSessionId } from '../middleware/validation.js';
 import type { ObservationCategory } from '../../../infrastructure/vector/types.js';
 
 const app = new Hono();
@@ -444,6 +444,10 @@ app.get('/observations', async (c) => {
 app.get('/observations/:id', async (c) => {
   const id = c.req.param('id');
 
+  if (!isValidObservationId(id)) {
+    return c.json({ success: false, error: 'Invalid observation ID format' }, 400);
+  }
+
   try {
     const vectorStore = await getVectorStoreService();
     await vectorStore.initialize();
@@ -547,6 +551,10 @@ app.post('/observations', async (c) => {
 // DELETE /api/memory/observations/:id - Delete observation by ID
 app.delete('/observations/:id', async (c) => {
   const id = c.req.param('id');
+
+  if (!isValidObservationId(id)) {
+    return c.json({ success: false, error: 'Invalid observation ID format' }, 400);
+  }
 
   try {
     const vectorStore = await getVectorStoreService();

--- a/src/web/api/routes/sessions.ts
+++ b/src/web/api/routes/sessions.ts
@@ -60,6 +60,8 @@ type SearchableSession = {
 };
 
 const VALID_STATUSES = new Set(['running', 'waiting', 'idle', 'lost', 'completed']);
+const DEFAULT_SESSION_LIMIT = 50;
+const MAX_SESSION_LIMIT = 100;
 
 function parseStatusFilters(url: string): { filters: Set<string>; invalid: string[] } {
   const params = new URL(url).searchParams;
@@ -77,6 +79,36 @@ function parseStatusFilters(url: string): { filters: Set<string>; invalid: strin
   }
 
   return { filters, invalid: [...invalid] };
+}
+
+function parseIntegerQueryParam(
+  value: string | undefined,
+  defaultValue: number
+): number | null {
+  if (value === undefined) return defaultValue;
+  if (!/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function parsePaginationParams(limitParam: string | undefined, offsetParam: string | undefined):
+  | { valid: true; limit: number; offset: number }
+  | { valid: false; error: string } {
+  const rawLimit = parseIntegerQueryParam(limitParam, DEFAULT_SESSION_LIMIT);
+  if (rawLimit === null || rawLimit < 1) {
+    return { valid: false, error: 'Invalid limit. Must be an integer between 1 and 100.' };
+  }
+
+  const offset = parseIntegerQueryParam(offsetParam, 0);
+  if (offset === null) {
+    return { valid: false, error: 'Invalid offset. Must be a non-negative integer.' };
+  }
+
+  return {
+    valid: true,
+    limit: Math.min(rawLimit, MAX_SESSION_LIMIT),
+    offset,
+  };
 }
 
 function matchesSessionQuery(session: SearchableSession, query: string): boolean {
@@ -121,8 +153,14 @@ async function backgroundSync() {
 app.get('/', async (c) => {
   try {
     // Parse pagination parameters
-    const limit = Math.min(parseInt(c.req.query('limit') || '50'), 100);
-    const offset = parseInt(c.req.query('offset') || '0');
+    const pagination = parsePaginationParams(c.req.query('limit'), c.req.query('offset'));
+    if (!pagination.valid) {
+      return c.json({
+        success: false,
+        error: pagination.error,
+      }, 400);
+    }
+    const { limit, offset } = pagination;
     const statusParseResult = parseStatusFilters(c.req.url);
     if (statusParseResult.invalid.length > 0) {
       return c.json({

--- a/src/web/api/server.ts
+++ b/src/web/api/server.ts
@@ -157,6 +157,9 @@ async function checkAndBroadcastUpdates() {
           directory: s.directory,
           lastActiveAt: s.lastActiveAt.toISOString(),
           title: s.title,
+          usageCost: s.usageStats?.totalCost ?? null,
+          usageTokens: s.usageStats?.totalTokens ?? null,
+          usageApiCalls: s.usageStats?.apiCalls ?? null,
         }))
         .sort((a, b) => a.sessionId.localeCompare(b.sessionId)),
     });

--- a/src/web/api/session-response.ts
+++ b/src/web/api/session-response.ts
@@ -21,6 +21,7 @@ export function serializeBasicSession(session: SerializableBasicSession) {
     tty: session.tty,
     toolCount: session.toolCount,
     messageCount: session.messageCount,
+    usageStats: session.usageStats,
     processRunning: session.processRunning,
     cpuUsage: session.cpuUsage,
     memoryUsage: session.memoryUsage,

--- a/src/web/client/src/components/OrchestratorPanel/OrchestratorPanel.tsx
+++ b/src/web/client/src/components/OrchestratorPanel/OrchestratorPanel.tsx
@@ -4,6 +4,7 @@ import { useOrchestratorOverview } from '@/hooks'
 import type {
   OrchestratorDigest,
   OrchestratorIntent,
+  OrchestratorIntentTaskSource,
   OrchestratorQueueItem,
   OrchestratorReason,
   OrchestratorRecommendedAction,
@@ -155,7 +156,7 @@ function QueueCard({
       <div className={styles.cardBody}>
         <div className={styles.cardHeader}>
           <div className={styles.identity}>
-            <h3 className={styles.itemTitle}>{item.intent.task || 'No clear task captured'}</h3>
+            <h3 className={styles.itemTitle}>{formatIntentTitle(item.intent)}</h3>
             <div className={styles.pathLine}>{formatIdentitySubtitle(item)}</div>
           </div>
           <div className={styles.badges}>
@@ -195,8 +196,9 @@ function QueueCard({
 }
 
 function IntentBlock({ intent }: { intent: OrchestratorIntent }) {
+  const taskSource = intent.taskSource ?? 'none'
   const rows = [
-    { label: 'Task', text: intent.task },
+    { label: formatTaskLabel(taskSource), text: intent.task },
     { label: 'Current state', text: intent.currentState },
     { label: 'Next action', text: intent.nextAction },
     { label: 'Why attention', text: intent.whyAttention },
@@ -431,6 +433,43 @@ function formatScopeText(hiddenOldLost: number, lostWindowHours?: number): strin
 
 function formatNoiseFlag(flag: string): string {
   return flag.replace(/_/g, ' ')
+}
+
+function formatIntentTitle(intent: OrchestratorIntent): string {
+  const taskSource = intent.taskSource ?? 'none'
+  if (!intent.task) return 'No original task captured'
+  switch (taskSource) {
+    case 'initial_prompt':
+      return intent.task
+    case 'digest':
+      return `Digest: ${intent.task}`
+    case 'title':
+      return `Session title: ${intent.task}`
+    case 'last_message':
+      return `Latest message: ${intent.task}`
+    case 'current_file':
+      return `Current file: ${intent.task}`
+    case 'none':
+      return `Unverified task: ${intent.task}`
+  }
+}
+
+function formatTaskLabel(source: OrchestratorIntentTaskSource | undefined): string {
+  switch (source) {
+    case 'initial_prompt':
+      return 'Original task'
+    case 'digest':
+      return 'Digest summary'
+    case 'title':
+      return 'Session title'
+    case 'last_message':
+      return 'Latest message'
+    case 'current_file':
+      return 'Current file'
+    case 'none':
+      return 'Task'
+  }
+  return 'Task'
 }
 
 function formatIdentitySubtitle(item: OrchestratorQueueItem): string {

--- a/src/web/client/src/hooks/notification-events.ts
+++ b/src/web/client/src/hooks/notification-events.ts
@@ -1,0 +1,69 @@
+import type { Session } from '../types/session'
+
+export interface NotificationEventSettings {
+  onStatusChange: boolean
+  onSessionLost: boolean
+  onHighCost: boolean
+  costThreshold: number
+}
+
+export interface SessionNotificationOptions {
+  body?: string
+  tag?: string
+}
+
+export interface SessionNotificationEvent {
+  title: string
+  options: SessionNotificationOptions
+}
+
+export function getSessionNotificationEvents(
+  prevSessions: Session[],
+  newSessions: Session[],
+  settings: NotificationEventSettings
+): SessionNotificationEvent[] {
+  const events: SessionNotificationEvent[] = []
+  const prevMap = new Map(prevSessions.map((s) => [s.sessionId, s]))
+
+  for (const session of newSessions) {
+    const prev = prevMap.get(session.sessionId)
+    if (!prev) continue
+
+    if (settings.onStatusChange && prev.status !== session.status) {
+      if (settings.onSessionLost && session.status === 'lost') {
+        events.push({
+          title: 'Session Lost',
+          options: {
+            body: `Session "${session.title || session.sessionId}" has been lost`,
+            tag: `session-lost-${session.sessionId}`,
+          },
+        })
+      } else if (session.status === 'completed' && prev.status !== 'completed') {
+        events.push({
+          title: 'Session Completed',
+          options: {
+            body: `Session "${session.title || session.sessionId}" has completed`,
+            tag: `session-completed-${session.sessionId}`,
+          },
+        })
+      }
+    }
+
+    if (settings.onHighCost && session.usageStats) {
+      const prevCost = prev.usageStats?.totalCost || 0
+      const newCost = session.usageStats.totalCost || 0
+
+      if (prevCost < settings.costThreshold && newCost >= settings.costThreshold) {
+        events.push({
+          title: 'High Cost Warning',
+          options: {
+            body: `Session "${session.title || session.sessionId}" has exceeded $${settings.costThreshold.toFixed(2)} (current: $${newCost.toFixed(2)})`,
+            tag: `high-cost-${session.sessionId}`,
+          },
+        })
+      }
+    }
+  }
+
+  return events
+}

--- a/src/web/client/src/hooks/useNotifications.ts
+++ b/src/web/client/src/hooks/useNotifications.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import type { Session } from '@/types'
+import { getSessionNotificationEvents } from './notification-events'
 
 export interface NotificationSettings {
   enabled: boolean
@@ -106,47 +107,8 @@ export function useNotifications(): UseNotificationsReturn {
       return
     }
 
-    const prevMap = new Map(prevSessions.map((s) => [s.sessionId, s]))
-
-    for (const session of newSessions) {
-      const prev = prevMap.get(session.sessionId)
-
-      // New session
-      if (!prev) {
-        continue // Don't notify for new sessions
-      }
-
-      // Status changed
-      if (settings.onStatusChange && prev.status !== session.status) {
-        // Session became lost
-        if (settings.onSessionLost && session.status === 'lost') {
-          notify('Session Lost', {
-            body: `Session "${session.title || session.sessionId}" has been lost`,
-            tag: `session-lost-${session.sessionId}`,
-          })
-        }
-        // Session completed
-        else if (session.status === 'completed' && prev.status !== 'completed') {
-          notify('Session Completed', {
-            body: `Session "${session.title || session.sessionId}" has completed`,
-            tag: `session-completed-${session.sessionId}`,
-          })
-        }
-      }
-
-      // High cost warning
-      if (settings.onHighCost && session.usageStats) {
-        const prevCost = prev.usageStats?.totalCost || 0
-        const newCost = session.usageStats.totalCost || 0
-
-        // Check if cost crossed the threshold
-        if (prevCost < settings.costThreshold && newCost >= settings.costThreshold) {
-          notify('High Cost Warning', {
-            body: `Session "${session.title || session.sessionId}" has exceeded $${settings.costThreshold.toFixed(2)} (current: $${newCost.toFixed(2)})`,
-            tag: `high-cost-${session.sessionId}`,
-          })
-        }
-      }
+    for (const event of getSessionNotificationEvents(prevSessions, newSessions, settings)) {
+      notify(event.title, event.options)
     }
   }, [settings, permission, notify])
 

--- a/src/web/client/src/hooks/useSessions.ts
+++ b/src/web/client/src/hooks/useSessions.ts
@@ -71,6 +71,9 @@ function getSessionVersionSignature(sessions: Session[]): string {
       session.completedAt || '',
       session.toolCount,
       session.messageCount,
+      session.usageStats?.totalCost ?? '',
+      session.usageStats?.totalTokens ?? '',
+      session.usageStats?.apiCalls ?? '',
       session.updatedAt,
     ].join(':'))
     .join('|')

--- a/src/web/client/src/types/orchestrator.ts
+++ b/src/web/client/src/types/orchestrator.ts
@@ -30,6 +30,13 @@ export interface OrchestratorSessionContext {
 }
 
 export type OrchestratorIntentConfidence = 'high' | 'medium' | 'low'
+export type OrchestratorIntentTaskSource =
+  | 'initial_prompt'
+  | 'digest'
+  | 'title'
+  | 'last_message'
+  | 'current_file'
+  | 'none'
 export type OrchestratorIntentNoiseFlag =
   | 'instructions_heavy'
   | 'missing_user_goal'
@@ -38,6 +45,7 @@ export type OrchestratorIntentNoiseFlag =
 
 export interface OrchestratorIntent {
   task?: string
+  taskSource: OrchestratorIntentTaskSource
   currentState?: string
   nextAction: string
   whyAttention: string


### PR DESCRIPTION
## Summary

Integration PR for the implx queue because the individually-clean PRs conflict after sequential merge. This branch includes the heads of #83, #84, #86, #87, #88, #89, #90, #91, #92, #93, #94, and #96, with conflict resolutions preserving the combined behavior.

Closes #74
Closes #75
Closes #76
Closes #77
Closes #78
Closes #79
Closes #80
Closes #81
Closes #85
Refs #82

## Conflict resolutions

- Combined GH75/#87 hook payload compatibility with #91 hook server request-security gates and #96 native hook parser coverage.
- Combined GH76 truncated Codex JSONL parser tests with GH82 Codex usage telemetry tests.
- Combined GH81 retention cleanup scheduling with GH82 pricing initialization and daemon fatal-error handling.
- Kept eventStore robust after resetDatabase drops the optional events table.

## Verification

- `bun test src/__tests__/hook.installer.test.ts src/__tests__/hook.server.test.ts src/__tests__/hook.server-parse.test.ts`: 24 pass / 0 fail
- `bun run typecheck`: pass
- `bun test`: 412 pass / 0 fail
- `bun run build`: pass
- `git diff --check`: pass
- `checks/check_workflow.py`: N/A, file is not present in this repository

## Duplicate PR note

#95 overlaps #84 and #89 but does not satisfy the #74 HTTP 400 invalid-id acceptance and conflicts with the canonical SpecRail-backed fixes. It is intentionally not included in this integration branch and should be closed as superseded after this integration merges.