### PR TITLE
fix: close GH82 deterministic hardening gaps

### DIFF
--- a/specs/GH82/product.md
+++ b/specs/GH82/product.md
@@ -27,6 +27,12 @@ few silent or stale behaviors erode that trust:
 5. API pagination with invalid numbers can return misleading empty results.
 6. PID reuse can make an old session look attached to a new process.
 7. Session fields that should clear can remain stale forever.
+8. Runtime `KEEPLINE_HOME` overrides can route config and database files to
+   different homes when modules captured paths before the override.
+9. A host with no active Claude or Codex CLI process can make session list
+   routes fail while scanning processes.
+10. Newer TypeScript versions can make the documented typecheck command fail
+   before application code is checked.
 
 ## Product Behavior
 
@@ -48,6 +54,12 @@ few silent or stale behaviors erode that trust:
    the field with `undefined` or `null`.
 9. Test database reset should remove the optional `events` table as well as the
    core migrated tables.
+10. Database connections should resolve the current `KEEPLINE_HOME` when the
+    connection is opened, not from an import-time snapshot.
+11. Process scanning should return an empty process list when no supported
+    agent process exists.
+12. The documented typecheck command should remain deterministic under the
+    TypeScript version range installed by Bun.
 
 ## Non-Goals
 
@@ -74,7 +86,11 @@ few silent or stale behaviors erode that trust:
    treated as continuity.
 8. Repository tests prove nullable activity fields can be explicitly cleared.
 9. Reset database tests prove the optional `events` table is dropped.
-10. Verification passes: focused tests, `bun run typecheck`, `bun test`, and
+10. Reset database tests prove runtime `KEEPLINE_HOME` changes are honored when
+    opening a database connection.
+11. Process parser tests prove ps output without supported agent rows produces
+    an empty process list.
+12. Verification passes: focused tests, `bun run typecheck`, `bun test`, and
     `bun run build`.
 
 ## Related Work

--- a/specs/GH82/tasks.md
+++ b/specs/GH82/tasks.md
@@ -130,3 +130,19 @@ Done when:
 - `bun test` passes.
 - `bun run build` passes.
 - PR uses `Refs #82`, not `Closes #82`.
+
+### SP82-T10: Close remaining deterministic hardening gaps
+
+Done when:
+
+- SQLite opens the database through the runtime `getKeeplineDb()` getter.
+- Process scanning treats no supported Claude/Codex process as an empty result.
+- TypeScript deprecation handling keeps `bun run typecheck` working under the
+  installed TypeScript range.
+
+Verify:
+
+```sh
+bun test src/__tests__/reset-database.test.ts src/__tests__/process-parser.test.ts src/__tests__/sessions.route-basic.test.ts
+bun run typecheck
+```

--- a/specs/GH82/tech.md
+++ b/specs/GH82/tech.md
@@ -17,6 +17,9 @@ This tranche changes only files needed for non-overlapping hardening:
 - `src/db/migrations.ts`
 - `src/web/api/routes/sessions.ts`
 - `src/services/session.process-matcher.ts`
+- `src/adapters/process/scanner.ts`
+- `tsconfig.json`
+- `src/web/client/tsconfig.json`
 - focused tests for those modules
 
 LanceDB predicate handling, hook server installation semantics, retention
@@ -105,6 +108,11 @@ PRAGMA busy_timeout = 5000
 
 Keep WAL and foreign keys enabled.
 
+Database connection setup must call `getKeeplineDb()` when opening the SQLite
+connection. Do not use the import-time `KEEPLINE_DB` snapshot in this layer,
+because CLI startup and subprocess tests can set `KEEPLINE_HOME` after modules
+have already been imported.
+
 ## Sessions API Pagination
 
 Parse `limit` and `offset` through a small validator:
@@ -146,3 +154,16 @@ with `undefined` or `null`, write NULL.
 
 `resetDatabase()` must drop `events` before re-running migrations so tests and
 local resets do not retain optional EventStore rows.
+
+## Empty Process Scan
+
+`scanAgentProcesses()` should not depend on a `grep` pipeline that exits with
+status 1 when no rows match. Run `ps` once and let `parseAgentPsOutput()` filter
+supported agent rows. An empty supported-agent set is valid data and should
+return `[]`.
+
+## Typecheck Compatibility
+
+Keep `baseUrl` path mapping, but configure TypeScript's supported
+`ignoreDeprecations` value so the documented `bun run typecheck` command works
+with the TypeScript version range installed by Bun.

--- a/src/__tests__/process-parser.test.ts
+++ b/src/__tests__/process-parser.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, test } from 'bun:test';
 import { parseAgentPsOutput, parseClaudePsOutput } from '../adapters/process/scanner.js';
 
 describe('Process Parser', () => {
+  test('returns an empty list when ps output has no supported agent rows', () => {
+    const output = [
+      '12340 0.0 0.1 ?? Mon Jan  6 10:30:40 2026 /usr/sbin/distnoted',
+      '12341 0.1 0.2 ?? Mon Jan  6 10:30:41 2026 /usr/bin/python worker.py',
+    ].join('\n');
+
+    expect(parseAgentPsOutput(output)).toEqual([]);
+    expect(parseClaudePsOutput(output)).toEqual([]);
+  });
+
   test('parses Claude ps rows and skips shell wrappers or unrelated commands', () => {
     const output = [
       '12345 1.2 0.5 ttys001 Mon Jan  6 10:30:45 2026 /usr/local/bin/claude --model sonnet --cwd /tmp/app',

--- a/src/__tests__/reset-database.test.ts
+++ b/src/__tests__/reset-database.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { queryOne, runSql, closeDatabase } from '../infrastructure/database/sqlite.js';
 import { resetDatabase, runMigrations } from '../db/migrations.js';
 import { memoryRepository } from '../infrastructure/database/index.js';
@@ -42,6 +45,31 @@ describe('resetDatabase', () => {
 
   test('sets a non-zero SQLite busy timeout', () => {
     expect(queryOne<{ timeout: number }>('PRAGMA busy_timeout')?.timeout).toBe(5000);
+  });
+
+  test('honors KEEPLINE_HOME changes made after module import', () => {
+    const previousHome = process.env.KEEPLINE_HOME;
+    const home = mkdtempSync(join(tmpdir(), 'keepline-runtime-db-home-'));
+
+    try {
+      closeDatabase();
+      process.env.KEEPLINE_HOME = home;
+
+      resetDatabase();
+
+      expect(existsSync(join(home, 'keepline.db'))).toBe(true);
+      expect((queryOne<{ count: number }>(
+        'SELECT COUNT(*) as count FROM schema_migrations'
+      )?.count ?? 0)).toBeGreaterThan(0);
+    } finally {
+      closeDatabase();
+      if (previousHome === undefined) {
+        delete process.env.KEEPLINE_HOME;
+      } else {
+        process.env.KEEPLINE_HOME = previousHome;
+      }
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   test('drops optional events table during reset', () => {

--- a/src/adapters/process/scanner.ts
+++ b/src/adapters/process/scanner.ts
@@ -249,7 +249,7 @@ export function scanAgentProcesses(): ClaudeProcessInfo[] {
     // Format: PID %CPU %MEM TTY LSTART ARGS
     // Using custom format to get lstart (which spans multiple columns)
     const output = execSync(
-      `ps -eo pid,pcpu,pmem,tty,lstart,args | grep -Ei '[c]laude|[c]odex'`,
+      'ps -eo pid,pcpu,pmem,tty,lstart,args',
       { encoding: 'utf-8', timeout: 10000 }
     );
 
@@ -283,11 +283,6 @@ export function scanAgentProcesses(): ClaudeProcessInfo[] {
     logger.debug(`Found ${processes.length} agent processes (2 syscalls)`);
     return processes;
   } catch (error) {
-    // No matching processes found (grep returns exit code 1)
-    if ((error as { status?: number }).status === 1) {
-      processCache = { processes: [], timestamp: Date.now() };
-      return [];
-    }
     throw new ProcessScanError('Failed to scan processes', {
       error: (error as Error).message,
     });

--- a/src/infrastructure/database/sqlite.ts
+++ b/src/infrastructure/database/sqlite.ts
@@ -5,7 +5,7 @@
 import { Database } from 'bun:sqlite';
 import { existsSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
-import { KEEPLINE_DB, ensureKeeplineDataHome } from '../../lib/paths.js';
+import { ensureKeeplineDataHome, getKeeplineDb } from '../../lib/paths.js';
 import { DatabaseError } from '../../lib/errors.js';
 import { logger } from '../../lib/logger.js';
 
@@ -18,12 +18,13 @@ export function getDatabase(): Database {
   try {
     ensureKeeplineDataHome();
     // Ensure directory exists
-    const dbDir = dirname(KEEPLINE_DB);
+    const dbPath = getKeeplineDb();
+    const dbDir = dirname(dbPath);
     if (!existsSync(dbDir)) {
       mkdirSync(dbDir, { recursive: true });
     }
 
-    db = new Database(KEEPLINE_DB);
+    db = new Database(dbPath);
     db.exec('PRAGMA journal_mode = WAL');
     db.exec('PRAGMA busy_timeout = 5000');
     db.exec('PRAGMA foreign_keys = ON');
@@ -32,7 +33,7 @@ export function getDatabase(): Database {
     return db;
   } catch (error) {
     throw new DatabaseError('Failed to connect to database', {
-      path: KEEPLINE_DB,
+      path: getKeeplineDb(),
       error: (error as Error).message,
     });
   }

--- a/src/web/client/tsconfig.json
+++ b/src/web/client/tsconfig.json
@@ -21,6 +21,7 @@
     "noFallthroughCasesInSwitch": true,
 
     /* Paths */
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": true,
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/web/client/src/*"]


### PR DESCRIPTION
## Summary

Refs #82.

This is a bounded GH82 follow-up tranche after PR #94. It closes several deterministic hardening gaps that remained in the rollup:

- resolve SQLite database paths through runtime `getKeeplineDb()` instead of the import-time `KEEPLINE_DB` snapshot
- make process scanning treat "no Claude/Codex process exists" as an empty result instead of relying on a failing `grep` pipeline
- keep `bun run typecheck` working with the installed TypeScript range by adding the supported `ignoreDeprecations` setting
- update the GH82 SpecRail packet and add focused regression coverage

## Verification

- `test -f specs/GH82/product.md && test -f specs/GH82/tech.md && test -f specs/GH82/tasks.md`
- `bun test src/__tests__/reset-database.test.ts src/__tests__/process-parser.test.ts src/__tests__/sessions.route-basic.test.ts`
- `bun run typecheck`
- `bun test`
- `bun run build`
- `git diff --check`

`checks/check_workflow.py` is not present in this repository, so the SpecRail workflow checker is N/A for this branch.

## Notes

This PR does not close GH82. GH82 remains a rollup until the remaining non-overlapping audit items are either verified as fixed by merged PRs or split into explicit follow-up issues.
